### PR TITLE
refactor(stir): typed InvalidProofShape errors

### DIFF
--- a/stir/src/error.rs
+++ b/stir/src/error.rs
@@ -1,0 +1,331 @@
+//! Error types for STIR verification.
+
+use alloc::format;
+use alloc::string::String;
+use core::fmt::{Display, Formatter, Result as FmtResult};
+
+use thiserror::Error;
+
+use crate::config::StirConfigError;
+
+/// Which round an error refers to.
+///
+/// In a batch, a proof element carries its instance's own round index.
+/// A shared grind carries the global lockstep round.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum RoundLabel {
+    /// An intermediate folding round, indexed from 0.
+    Round(usize),
+    /// The final round, checked against the sent polynomial rather than queried again.
+    Final,
+}
+
+impl Display for RoundLabel {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Round(round) => write!(f, "round {round}"),
+            Self::Final => f.write_str("final round"),
+        }
+    }
+}
+
+/// Which of a round's two proof-of-work grinds a witness belongs to.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GrindStage {
+    /// The grind before the folding challenge `gamma`.
+    Folding,
+    /// The grind before the combination challenge `r_comb` and the query indices.
+    Query,
+}
+
+impl Display for GrindStage {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        f.write_str(match self {
+            Self::Folding => "folding",
+            Self::Query => "query",
+        })
+    }
+}
+
+/// Why a proof's shape does not match what the configuration and the public input pin.
+///
+/// `expected` is the value the verifier derived.
+/// `got` is what the proof carried.
+#[derive(Copy, Clone, Debug, Error, PartialEq, Eq)]
+pub enum ProofShapeError {
+    /// A batch takes one proof per configured instance.
+    #[error("expected {expected} proofs, got {got}")]
+    InstanceCount { expected: usize, got: usize },
+
+    /// A proof carries one round proof per configured round.
+    #[error(
+        "{}expected {expected} round proofs, got {got}",
+        instance.map_or_else(String::new, |i| format!("instance {i}: "))
+    )]
+    RoundCount {
+        /// Batch index of the offending proof, `None` outside a batch.
+        instance: Option<usize>,
+        expected: usize,
+        got: usize,
+    },
+
+    /// STIR commits the initial oracle itself, so the proof must carry that commitment.
+    #[error("missing initial oracle commitment")]
+    MissingInitialCommitment,
+
+    /// The initial oracle is bound by the caller, so the proof must carry no commitment.
+    #[error("unexpected initial oracle commitment for an externally bound oracle")]
+    UnexpectedInitialCommitment,
+
+    /// The final degree bound pins the final polynomial's coefficient count exactly.
+    #[error("final polynomial has {got} coefficients, expected {expected}")]
+    FinalPolynomialLength { expected: usize, got: usize },
+
+    /// The soundness assumption fixes each round's out-of-domain sample count.
+    #[error("{round}: {got} OOD answers, expected {expected}")]
+    OodAnswerCount {
+        round: RoundLabel,
+        expected: usize,
+        got: usize,
+    },
+
+    /// `Ans` interpolates the round's OOD and query points, bounding its degree.
+    ///
+    /// A shorter polynomial is legitimate: the prover may strip trailing zero coefficients.
+    #[error("{round}: ans polynomial has {got} coefficients, expected at most {maximum}")]
+    AnsPolynomialTooLong {
+        round: RoundLabel,
+        maximum: usize,
+        got: usize,
+    },
+
+    /// The shake polynomial is `Ans`'s quotient sum, one degree below `Ans` itself.
+    #[error("{round}: shake polynomial has {got} coefficients, expected at most {maximum}")]
+    ShakePolynomialTooLong {
+        round: RoundLabel,
+        maximum: usize,
+        got: usize,
+    },
+
+    /// A committed oracle is read through a Merkle multi-opening the proof must supply.
+    #[error("{round}: missing query openings")]
+    MissingQueryOpenings { round: RoundLabel },
+
+    /// An externally bound oracle is answered by the caller, so the proof must open nothing.
+    #[error("{round}: unexpected query openings for an externally bound oracle")]
+    UnexpectedQueryOpenings { round: RoundLabel },
+
+    /// A committed oracle is authenticated against a commitment the proof must supply.
+    #[error("{round}: missing oracle commitment")]
+    MissingCommitment { round: RoundLabel },
+
+    /// One opened row per query the round draws, a count the configuration fixes.
+    #[error("{round}: {got} opened rows, expected {expected}")]
+    QueryOpeningCount {
+        round: RoundLabel,
+        expected: usize,
+        got: usize,
+    },
+
+    /// An opened row is one fiber of the round's fold, so it holds `arity` evaluations.
+    #[error("{round}, query {query}: opened row has {got} evaluations, expected {expected}")]
+    OpenedRowArity {
+        round: RoundLabel,
+        query: usize,
+        expected: usize,
+        got: usize,
+    },
+
+    /// Instances verified in lockstep share one grind, so each must replicate its witness.
+    #[error("{round}: replicated {stage} PoW witnesses disagree across batched instances")]
+    ReplicatedWitnessMismatch {
+        round: RoundLabel,
+        stage: GrindStage,
+    },
+
+    /// The opening proof carries one STIR instance per distinct shared LDE height.
+    #[error("expected {expected} LDE-height buckets, got {got}")]
+    BucketCount { expected: usize, got: usize },
+
+    /// A bucket carries one input-opening slot per public commitment, occupied or not.
+    ///
+    /// A short list would silently drop trailing commitments from the reduced opening.
+    #[error("bucket 2^{log_height}: {got} input opening slots, expected {expected}")]
+    InputOpeningCount {
+        log_height: usize,
+        expected: usize,
+        got: usize,
+    },
+
+    /// A commitment whose matrices live at this bucket's height must be opened there.
+    #[error("bucket 2^{log_height}, commitment {commitment}: missing input opening")]
+    MissingInputOpening {
+        log_height: usize,
+        commitment: usize,
+    },
+
+    /// A commitment whose matrices live at another height must not be opened at this bucket.
+    #[error("bucket 2^{log_height}, commitment {commitment}: unexpected input opening")]
+    UnexpectedInputOpening {
+        log_height: usize,
+        commitment: usize,
+    },
+
+    /// A commitment carries one Merkle root per group of the layout its claims imply.
+    #[error("commitment {commitment}: expected {expected} Merkle roots, got {got}")]
+    CommitmentRootCount {
+        commitment: usize,
+        expected: usize,
+        got: usize,
+    },
+
+    /// A bucket that ran no `Combine` holds a single native-height class.
+    #[error("bucket 2^{log_height}: {got} native-height classes, expected {expected}")]
+    HeightClassCount {
+        log_height: usize,
+        expected: usize,
+        got: usize,
+    },
+
+    /// Every class merged by `Combine` needs its degree-correction coefficient.
+    #[error(
+        "bucket 2^{log_height}: no Combine coefficient for native height 2^{log_native_height}"
+    )]
+    MissingCombineCoefficient {
+        log_height: usize,
+        log_native_height: usize,
+    },
+
+    /// The opened-row count is the bucket's deduplicated first-round query count.
+    #[error(
+        "bucket 2^{log_height}, commitment {commitment}: {got} opened rows, expected {expected}"
+    )]
+    InputOpenedRowCount {
+        log_height: usize,
+        commitment: usize,
+        expected: usize,
+        got: usize,
+    },
+}
+
+/// Why the caller's external initial-oracle source did not answer as asked.
+///
+/// The source is a closure, so these report a caller bug rather than a malformed proof.
+#[derive(Copy, Clone, Debug, Error, PartialEq, Eq)]
+pub enum ExternalSourceError {
+    /// A batch takes one fiber source per instance.
+    #[error("expected {expected} fiber sources, got {got}")]
+    SourceCount { expected: usize, got: usize },
+
+    /// The source must answer one fiber per requested index.
+    #[error("{round}: source returned {got} fibers, expected {expected}")]
+    FiberCount {
+        round: RoundLabel,
+        expected: usize,
+        got: usize,
+    },
+
+    /// Each fiber holds the round's `arity` evaluations.
+    #[error("{round}, fiber {fiber}: source returned {got} evaluations, expected {expected}")]
+    FiberArity {
+        round: RoundLabel,
+        /// Position in the sorted, deduplicated index list handed to the source.
+        fiber: usize,
+        expected: usize,
+        got: usize,
+    },
+}
+
+/// Errors returned by [`crate::verifier::verify_stir`].
+#[derive(Debug, Error, PartialEq)]
+pub enum StirError<MmcsError, InputError = ()> {
+    /// A proof-of-work witness failed verification.
+    #[error("{round}: invalid proof-of-work witness")]
+    InvalidPowWitness { round: RoundLabel },
+
+    /// A Merkle multi-opening proof failed for a round's queries.
+    #[error("{round}: invalid MMCS opening proof")]
+    InvalidMmcsProof {
+        round: RoundLabel,
+        #[source]
+        source: MmcsError,
+    },
+
+    /// The shake polynomial identity failed at the random evaluation point.
+    #[error("{round}: shake polynomial consistency check failed")]
+    InvalidShakeConsistency { round: RoundLabel },
+
+    /// A virtual-oracle evaluation landed in the prior round's challenge set.
+    #[error("{round}, query {query}: invalid virtual-oracle query")]
+    InvalidRoundConsistency { round: RoundLabel, query: usize },
+
+    /// The final polynomial does not evaluate consistently with the last committed codeword.
+    #[error("final polynomial evaluation mismatch")]
+    FinalPolyMismatch,
+
+    /// The proof's shape disagrees with the configuration or the public input.
+    #[error(transparent)]
+    InvalidProofShape(#[from] ProofShapeError),
+
+    /// The caller's external initial-oracle source misbehaved.
+    #[error("external initial oracle: {0}")]
+    ExternalSource(#[from] ExternalSourceError),
+
+    /// A matrix in `commitment`'s batch was opened at zero points, so its width cannot be
+    /// pinned from the claimed evaluations. Every input matrix must be opened at >= 1 point.
+    #[error("commitment {commitment}, matrix {matrix}: opened at zero points")]
+    MatrixWithoutOpeningPoints { commitment: usize, matrix: usize },
+
+    /// A claimed opening point coincides with a queried fiber lane.
+    ///
+    /// The quotient `(f(z) - f(x)) / (z - x)` is undefined there.
+    #[error(
+        "commitment {commitment}, matrix {matrix}, point {point}: opening point coincides with a query point"
+    )]
+    OpeningPointMatchesQueryPoint {
+        commitment: usize,
+        matrix: usize,
+        point: usize,
+    },
+
+    /// The requested STIR parameters cannot reach `security_level` at some LDE-height bucket.
+    #[error("STIR config error: {0}")]
+    Config(#[source] StirConfigError),
+
+    /// An error propagated from the input polynomial commitment scheme.
+    #[error("input error")]
+    InputError(InputError),
+}
+
+impl<E, IE> StirError<E, IE> {
+    /// Map the `InputError` variant to a different type.
+    pub fn map_input_err<IE2>(self, f: impl FnOnce(IE) -> IE2) -> StirError<E, IE2> {
+        match self {
+            Self::InvalidPowWitness { round } => StirError::InvalidPowWitness { round },
+            Self::InvalidMmcsProof { round, source } => {
+                StirError::InvalidMmcsProof { round, source }
+            }
+            Self::InvalidShakeConsistency { round } => StirError::InvalidShakeConsistency { round },
+            Self::InvalidRoundConsistency { round, query } => {
+                StirError::InvalidRoundConsistency { round, query }
+            }
+            Self::FinalPolyMismatch => StirError::FinalPolyMismatch,
+            Self::InvalidProofShape(e) => StirError::InvalidProofShape(e),
+            Self::ExternalSource(e) => StirError::ExternalSource(e),
+            Self::MatrixWithoutOpeningPoints { commitment, matrix } => {
+                StirError::MatrixWithoutOpeningPoints { commitment, matrix }
+            }
+            Self::OpeningPointMatchesQueryPoint {
+                commitment,
+                matrix,
+                point,
+            } => StirError::OpeningPointMatchesQueryPoint {
+                commitment,
+                matrix,
+                point,
+            },
+            Self::Config(e) => StirError::Config(e),
+            Self::InputError(e) => StirError::InputError(f(e)),
+        }
+    }
+}

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -11,7 +11,8 @@
 //! - [`proof`]: Proof types ([`StirProof`], [`StirRoundProof`], [`StirQueryOpenings`]).
 //! - [`utils`]: Polynomial arithmetic primitives (shake, ans, Horner eval, synthetic division).
 //! - [`prover`]: The STIR prover ([`prover::prove_stir`]).
-//! - [`verifier`]: The STIR verifier ([`verifier::verify_stir`], [`verifier::StirError`]).
+//! - [`verifier`]: The STIR verifier ([`verifier::verify_stir`]).
+//! - [`error`]: Verification failures ([`StirError`], [`ProofShapeError`]).
 //! - [`pcs`]: [`TwoAdicStirPcs`] implementing the [`p3_commit::Pcs`] trait.
 //!
 //! # Deviations from the STIR paper (eprint 2024/390)
@@ -48,6 +49,7 @@
 extern crate alloc;
 
 pub mod config;
+pub mod error;
 pub mod pcs;
 pub mod proof;
 pub mod prover;
@@ -56,7 +58,8 @@ pub mod utils;
 pub mod verifier;
 
 pub use config::{Stage, StirConfig, StirConfigError, StirParameters, StirRoundConfig};
+pub use error::{ExternalSourceError, GrindStage, ProofShapeError, RoundLabel, StirError};
 pub use p3_security::whir::SecurityAssumption;
 pub use pcs::{DEFAULT_MAX_LOG_HEIGHT_SPREAD, StirCommitment, TwoAdicStirPcs};
 pub use proof::{StirProof, StirQueryOpenings, StirRoundProof};
-pub use verifier::{StirError, StirVerifyOutputs};
+pub use verifier::StirVerifyOutputs;

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -79,10 +79,11 @@ use spin::RwLock;
 use tracing::instrument;
 
 use crate::config::{StirConfig, StirConfigError, StirParameters};
+use crate::error::{ProofShapeError, StirError};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_multi_from_external_codewords;
 use crate::utils::combine_on_coset;
-use crate::verifier::{StirError, verify_stir_multi_with_external_initial};
+use crate::verifier::verify_stir_multi_with_external_initial;
 
 /// Batched openings of one input commitment's LDE matrices at the STIR-derived query
 /// positions for one LDE-height bucket.
@@ -1168,9 +1169,18 @@ where
             .collect();
 
         // SHAPE CHECK: one Merkle root per group of the layout the claims imply.
-        for ((commitment, _), plan) in commitments_with_opening_points.iter().zip(&plans) {
+        for (commit_idx, ((commitment, _), plan)) in commitments_with_opening_points
+            .iter()
+            .zip(&plans)
+            .enumerate()
+        {
             if commitment.len() != plan.log_lde_heights.len() {
-                return Err(StirError::InvalidProofShape);
+                return Err(ProofShapeError::CommitmentRootCount {
+                    commitment: commit_idx,
+                    expected: plan.log_lde_heights.len(),
+                    got: commitment.len(),
+                }
+                .into());
             }
         }
 
@@ -1199,7 +1209,11 @@ where
         };
 
         if proof.len() != bucket_log_heights.len() {
-            return Err(StirError::InvalidProofShape);
+            return Err(ProofShapeError::BucketCount {
+                expected: bucket_log_heights.len(),
+                got: proof.len(),
+            }
+            .into());
         }
 
         // Which of a commitment's groups (hence which of its Merkle roots) feeds each
@@ -1278,9 +1292,14 @@ where
         // transcript (above), but they'd never be MMCS-opened or included in the
         // reduced-opening accumulation, so the proof would verify against a subset of the
         // public input.
-        for (_, input_openings) in proof {
+        for (&log_height, (_, input_openings)) in bucket_log_heights.iter().zip(proof) {
             if input_openings.len() != commitments_with_opening_points.len() {
-                return Err(StirError::InvalidProofShape);
+                return Err(ProofShapeError::InputOpeningCount {
+                    log_height,
+                    expected: commitments_with_opening_points.len(),
+                    got: input_openings.len(),
+                }
+                .into());
             }
         }
 
@@ -1429,6 +1448,23 @@ where
                             fiber_point *= fiber_step;
                         }
                     }
+
+                    // Invariant: no opening point sits on a queried fiber lane.
+                    //   z == x  =>  z - x == 0
+                    //           =>  the quotient (f(z) - f(x)) / (z - x) is undefined
+                    //           =>  batch_multiplicative_inverse panics
+                    // Scanning once here keeps the branch out of the build loop above.
+                    if let Some(slot) = denom_diffs.iter().position(|d| d.is_zero()) {
+                        let (commitment, matrix, point) = locate_opening_point(
+                            commitments_with_opening_points,
+                            &bucket_points[slot % n_bp],
+                        );
+                        return Err(StirError::OpeningPointMatchesQueryPoint {
+                            commitment,
+                            matrix,
+                            point,
+                        });
+                    }
                     let inv_denoms = batch_multiplicative_inverse(&denom_diffs);
 
                     // A commitment feeds this bucket through at most one of its groups: the
@@ -1444,12 +1480,20 @@ where
 
                         let Some(opening) = per_commit_opening else {
                             if group_idx.is_some() {
-                                return Err(StirError::InvalidProofShape);
+                                return Err(ProofShapeError::MissingInputOpening {
+                                    log_height: log_h,
+                                    commitment: commit_idx,
+                                }
+                                .into());
                             }
                             continue;
                         };
                         let Some(group_idx) = group_idx else {
-                            return Err(StirError::InvalidProofShape);
+                            return Err(ProofShapeError::UnexpectedInputOpening {
+                                log_height: log_h,
+                                commitment: commit_idx,
+                            }
+                            .into());
                         };
 
                         // The commitment's matrices on this domain, in the order they were
@@ -1522,7 +1566,13 @@ where
 
                         // SHAPE CHECK: opened-row count is determined entirely by public input.
                         if opening.opened_values.len() != q_globals.len() {
-                            return Err(StirError::InvalidProofShape);
+                            return Err(ProofShapeError::InputOpenedRowCount {
+                                log_height: log_h,
+                                commitment: commit_idx,
+                                expected: q_globals.len(),
+                                got: opening.opened_values.len(),
+                            }
+                            .into());
                         }
 
                         self.input_mmcs
@@ -1580,18 +1630,26 @@ where
                     // Merge the per-class accumulators into the bucket's expected codeword
                     // fibers, mirroring the prover's `combine_on_coset`/`eval_degree_correction`
                     // pointwise, only at the queried fiber lanes.
+                    //
+                    // Both class counts come from `native_heights`, never from the proof.
+                    // Still reported rather than asserted: a verifier must not panic.
                     match combine_info {
                         None => {
-                            // SHAPE CHECK: exactly one class expected when no Combine ran.
-                            if expected_ro_by_class.len() != 1 {
-                                return Err(StirError::InvalidProofShape);
+                            // No Combine ran, so STIR folds a single class directly.
+                            let got = expected_ro_by_class.len();
+                            let mut classes = expected_ro_by_class.into_iter();
+                            match (classes.next(), classes.next()) {
+                                (Some(only), None) => Ok(only),
+                                _ => Err(ProofShapeError::HeightClassCount {
+                                    log_height: log_h,
+                                    expected: 1,
+                                    got,
+                                }
+                                .into()),
                             }
-                            Ok(expected_ro_by_class.into_iter().next().unwrap())
                         }
                         Some((r_comb, coeffs_by_height)) => {
-                            // Both sides are sized by the same deduplicated class list, so
-                            // this is an invariant rather than a check on anything the proof
-                            // controls.
+                            // Both sides are sized by the same deduplicated class list.
                             debug_assert_eq!(expected_ro_by_class.len(), coeffs_by_height.len());
 
                             // Pointwise mirror of the prover's `combine_on_coset`, evaluated
@@ -1628,9 +1686,12 @@ where
                             for (&log_native_h, ro_class) in
                                 native_heights.iter().zip(&expected_ro_by_class)
                             {
-                                let &(r_i, gap) = coeffs_by_height
-                                    .get(&log_native_h)
-                                    .ok_or(StirError::InvalidProofShape)?;
+                                let &(r_i, gap) = coeffs_by_height.get(&log_native_h).ok_or(
+                                    ProofShapeError::MissingCombineCoefficient {
+                                        log_height: log_h,
+                                        log_native_height: log_native_h,
+                                    },
+                                )?;
 
                                 // Within a query the lanes advance by the fixed base-field
                                 // ratio `fiber_step^(gap+1)`, so the numerator sweep costs one
@@ -1675,6 +1736,36 @@ where
 
         Ok(())
     }
+}
+
+/// One commitment's claims: per matrix, its domain and its `(point, values)` pairs.
+type CommitmentClaims<C, D, EF> = (C, Vec<(D, Vec<(EF, Vec<EF>)>)>);
+
+/// Locate the claim that contributed `point`, as `(commitment, matrix, point)` indices.
+///
+/// Only reached on the error path, where a linear scan costs nothing.
+fn locate_opening_point<C, D, EF: PartialEq>(
+    commitments_with_opening_points: &[CommitmentClaims<C, D, EF>],
+    point: &EF,
+) -> (usize, usize, usize) {
+    commitments_with_opening_points
+        .iter()
+        .enumerate()
+        .flat_map(|(commitment, (_, domain_claims))| {
+            domain_claims
+                .iter()
+                .enumerate()
+                .flat_map(move |(matrix, (_, point_claims))| {
+                    point_claims
+                        .iter()
+                        .enumerate()
+                        .map(move |(slot, (claimed, _))| (commitment, matrix, slot, claimed))
+                })
+        })
+        .find_map(|(commitment, matrix, slot, claimed)| {
+            (claimed == point).then_some((commitment, matrix, slot))
+        })
+        .expect("every bucket point comes from a claim")
 }
 
 /// Definition 4.11's per-class `Combine` coefficients, for classes already sorted in

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -9,9 +9,9 @@ use p3_field::{
     BasedVectorSpace, ExtensionField, Field, TwoAdicField, batch_multiplicative_inverse,
 };
 use p3_matrix::Dimensions;
-use thiserror::Error;
 
 use crate::config::{StirConfig, StirRoundConfig};
+use crate::error::{ExternalSourceError, GrindStage, ProofShapeError, RoundLabel, StirError};
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
     check_shake_consistency, eval_poly, eval_poly_at_base, fold_domain_params,
@@ -129,13 +129,47 @@ fn single_matrix_opened_values<EF>(row_evals: &[Vec<EF>]) -> Vec<Vec<&[EF]>> {
         .collect()
 }
 
+/// Reject an `Ans`/shake pair longer than the round's degree bounds allow.
+///
+/// - `Ans` interpolates `max_ans_len` points, so its degree is below that.
+/// - The shake polynomial is one degree lower.
+/// - A shorter pair is legitimate: the prover may strip trailing zeros.
+fn check_ans_and_shake_lengths<EF, MmcsError, InputError>(
+    round: RoundLabel,
+    ans_polynomial: &[EF],
+    shake_polynomial: &[EF],
+    max_ans_len: usize,
+) -> Result<(), StirError<MmcsError, InputError>> {
+    if ans_polynomial.len() > max_ans_len {
+        return Err(ProofShapeError::AnsPolynomialTooLong {
+            round,
+            maximum: max_ans_len,
+            got: ans_polynomial.len(),
+        }
+        .into());
+    }
+    let max_shake_len = max_ans_len.saturating_sub(1);
+    if shake_polynomial.len() > max_shake_len {
+        return Err(ProofShapeError::ShakePolynomialTooLong {
+            round,
+            maximum: max_shake_len,
+            got: shake_polynomial.len(),
+        }
+        .into());
+    }
+    Ok(())
+}
+
 /// Fetch an external initial oracle's queried fibers and lay them out in draw order.
 ///
 /// Queries are sampled with replacement, so `indices` may repeat; the source is asked once for
 /// the sorted unique indices and must answer in that same order.
+///
+/// `round` labels the reported errors: whichever round reads the initial oracle.
 fn external_fibers_in_draw_order<EF: Clone, MmcsError, InputError>(
     indices: &[usize],
     arity: usize,
+    round: RoundLabel,
     source: impl FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<MmcsError, InputError>>,
 ) -> Result<Vec<Vec<EF>>, StirError<MmcsError, InputError>> {
     let mut unique = indices.to_vec();
@@ -143,8 +177,22 @@ fn external_fibers_in_draw_order<EF: Clone, MmcsError, InputError>(
     unique.dedup();
 
     let fibers = source(&unique)?;
-    if fibers.len() != unique.len() || fibers.iter().any(|fiber| fiber.len() != arity) {
-        return Err(StirError::InvalidProofShape);
+    if fibers.len() != unique.len() {
+        return Err(ExternalSourceError::FiberCount {
+            round,
+            expected: unique.len(),
+            got: fibers.len(),
+        }
+        .into());
+    }
+    if let Some((fiber, evals)) = fibers.iter().enumerate().find(|(_, f)| f.len() != arity) {
+        return Err(ExternalSourceError::FiberArity {
+            round,
+            fiber,
+            expected: arity,
+            got: evals.len(),
+        }
+        .into());
     }
 
     Ok(indices
@@ -166,7 +214,7 @@ struct RoundRowsRequest<'a, EF: Field, M: Mmcs<EF>> {
     expected_num_queries: usize,
     commitment: Option<&'a M::Commitment>,
     dimensions: &'a [Dimensions],
-    error_round: usize,
+    round: RoundLabel,
 }
 
 /// Fetch a round's queried oracle rows: an external initial oracle answered by the caller's
@@ -187,21 +235,42 @@ where
 {
     if is_external {
         if req.query_openings.is_some() {
-            return Err(StirError::InvalidProofShape);
+            return Err(ProofShapeError::UnexpectedQueryOpenings { round: req.round }.into());
         }
         let source = external_fibers
             .take()
             .expect("the external source is consumed exactly once");
-        return external_fibers_in_draw_order(req.query_indices, req.arity, source);
+        return external_fibers_in_draw_order(req.query_indices, req.arity, req.round, source);
     }
 
-    let openings = req.query_openings.ok_or(StirError::InvalidProofShape)?;
-    if openings.row_evals.len() != req.expected_num_queries
-        || openings.row_evals.iter().any(|row| row.len() != req.arity)
-    {
-        return Err(StirError::InvalidProofShape);
+    let openings = req
+        .query_openings
+        .ok_or(ProofShapeError::MissingQueryOpenings { round: req.round })?;
+    if openings.row_evals.len() != req.expected_num_queries {
+        return Err(ProofShapeError::QueryOpeningCount {
+            round: req.round,
+            expected: req.expected_num_queries,
+            got: openings.row_evals.len(),
+        }
+        .into());
     }
-    let commit = req.commitment.ok_or(StirError::InvalidProofShape)?;
+    if let Some((query, row)) = openings
+        .row_evals
+        .iter()
+        .enumerate()
+        .find(|(_, row)| row.len() != req.arity)
+    {
+        return Err(ProofShapeError::OpenedRowArity {
+            round: req.round,
+            query,
+            expected: req.arity,
+            got: row.len(),
+        }
+        .into());
+    }
+    let commit = req
+        .commitment
+        .ok_or(ProofShapeError::MissingCommitment { round: req.round })?;
     let opened_values = single_matrix_opened_values(&openings.row_evals);
     mmcs.verify_multi_batch(
         commit,
@@ -211,7 +280,7 @@ where
         &openings.opening_proof,
     )
     .map_err(|source| StirError::InvalidMmcsProof {
-        round: req.error_round,
+        round: req.round,
         source,
     })?;
     Ok(openings.row_evals.clone())
@@ -233,7 +302,7 @@ fn query_fold_value<F, EF, MmcsErr, InputErr>(
     current_shift: F,
     fold_beta: EF,
     prev_ctx: Option<&VirtualRoundContext<EF>>,
-    round: usize,
+    round: RoundLabel,
     query: usize,
 ) -> Result<EF, StirError<MmcsErr, InputErr>>
 where
@@ -366,7 +435,7 @@ where
                 expected_num_queries: query_indices.len(),
                 commitment,
                 dimensions: &cur_dimensions,
-                error_round: round,
+                round: RoundLabel::Round(round),
             },
         )?;
 
@@ -392,7 +461,7 @@ where
                 current_shift,
                 self.fold_beta,
                 prev_ctx,
-                round,
+                RoundLabel::Round(round),
                 q,
             )?;
 
@@ -474,7 +543,9 @@ where
 
     // Step 1: folding PoW, folding challenge gamma, and folded-oracle commitment.
     if !challenger.check_witness(rc.folding_pow_bits, rp.folding_pow_witness) {
-        return Err(StirError::InvalidPowWitness { round });
+        return Err(StirError::InvalidPowWitness {
+            round: RoundLabel::Round(round),
+        });
     }
 
     let gamma: EF = challenger.sample_algebra_element();
@@ -485,7 +556,12 @@ where
 
     // Step 2: OOD sampling and answer observation.
     if rp.ood_answers.len() != rc.num_ood_samples {
-        return Err(StirError::InvalidProofShape);
+        return Err(ProofShapeError::OodAnswerCount {
+            round: RoundLabel::Round(round),
+            expected: rc.num_ood_samples,
+            got: rp.ood_answers.len(),
+        }
+        .into());
     }
 
     rv.ood_points = sample_ood_points(
@@ -500,7 +576,9 @@ where
     // challenge and query indices; configuration soundness gives no PoW credit to the
     // earlier OOD samples or the later shake challenge.
     if !challenger.check_witness(rc.pow_bits, rp.pow_witness) {
-        return Err(StirError::InvalidPowWitness { round });
+        return Err(StirError::InvalidPowWitness {
+            round: RoundLabel::Round(round),
+        });
     }
 
     // Step 4: combination challenge, query sampling, and fiber verification.
@@ -536,15 +614,14 @@ where
     // Step 4: ans + shake polynomial observation and consistency check.
     let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
-    // Ans interpolates |all_points| values, so its degree is `< all_points.len()`. The
-    // prover may have stripped trailing zeros, so accept any length up to that bound; reject
-    // anything larger as malformed. Shake has degree `< all_points.len() - 1`.
+    // Ans interpolates |all_points| values, bounding both polynomials' lengths.
     let max_ans_len = all_points.len();
-    if rp.ans_polynomial.len() > max_ans_len
-        || rp.shake_polynomial.len() > max_ans_len.saturating_sub(1)
-    {
-        return Err(StirError::InvalidProofShape);
-    }
+    check_ans_and_shake_lengths(
+        RoundLabel::Round(round),
+        &rp.ans_polynomial,
+        &rp.shake_polynomial,
+        max_ans_len,
+    )?;
 
     // Bind ans_poly into the transcript BEFORE rho. The shake identity is a one-point check;
     // observing both polys first means the prover commits to Ans before learning rho.
@@ -560,7 +637,9 @@ where
         &all_values,
         rho,
     ) {
-        return Err(StirError::InvalidShakeConsistency { round });
+        return Err(StirError::InvalidShakeConsistency {
+            round: RoundLabel::Round(round),
+        });
     }
 
     Ok(rv.finish(rp.ans_polynomial.clone(), &all_points))
@@ -639,7 +718,7 @@ where
                 expected_num_queries: final_indices.len(),
                 commitment,
                 dimensions: &final_dimensions,
-                error_round: num_rounds,
+                round: RoundLabel::Final,
             },
         )?;
 
@@ -663,7 +742,7 @@ where
                 current_shift,
                 self.fold_beta,
                 prev_ctx,
-                num_rounds,
+                RoundLabel::Final,
                 q,
             )?;
 
@@ -718,7 +797,9 @@ where
         config.final_folding_pow_bits,
         proof.final_folding_pow_witness,
     ) {
-        return Err(StirError::InvalidPowWitness { round: num_rounds });
+        return Err(StirError::InvalidPowWitness {
+            round: RoundLabel::Final,
+        });
     }
 
     let final_gamma: EF = challenger.sample_algebra_element();
@@ -726,13 +807,19 @@ where
 
     let expected_final_len = config.final_poly_len();
     if proof.final_polynomial.len() != expected_final_len {
-        return Err(StirError::InvalidProofShape);
+        return Err(ProofShapeError::FinalPolynomialLength {
+            expected: expected_final_len,
+            got: proof.final_polynomial.len(),
+        }
+        .into());
     }
 
     challenger.observe_algebra_slice(&proof.final_polynomial);
 
     if !challenger.check_witness(config.final_pow_bits, proof.final_pow_witness) {
-        return Err(StirError::InvalidPowWitness { round: num_rounds });
+        return Err(StirError::InvalidPowWitness {
+            round: RoundLabel::Final,
+        });
     }
 
     // Sample every final-round query index first, deferring Merkle verification to a single
@@ -757,74 +844,6 @@ where
         commitment,
         &final_indices,
     )
-}
-
-/// Errors returned by [`verify_stir`].
-#[derive(Debug, Error, PartialEq)]
-pub enum StirError<MmcsError, InputError = ()> {
-    /// A proof-of-work witness failed verification.
-    #[error("Invalid proof-of-work witness in round {round}")]
-    InvalidPowWitness { round: usize },
-
-    /// A Merkle multi-opening proof failed for a round's queries.
-    #[error("Invalid MMCS opening proof in round {round}")]
-    InvalidMmcsProof {
-        round: usize,
-        #[source]
-        source: MmcsError,
-    },
-
-    /// The shake polynomial identity failed at the random evaluation point.
-    #[error("Shake polynomial consistency check failed in round {round}")]
-    InvalidShakeConsistency { round: usize },
-
-    /// A virtual-oracle evaluation landed in the prior round's challenge set.
-    #[error("Invalid virtual-oracle query in round {round}, query {query}")]
-    InvalidRoundConsistency { round: usize, query: usize },
-
-    /// The final polynomial does not evaluate consistently with the last committed codeword.
-    #[error("Final polynomial evaluation mismatch")]
-    FinalPolyMismatch,
-
-    /// The proof has the wrong number of rounds, queries, or OOD answers.
-    #[error("Invalid proof shape")]
-    InvalidProofShape,
-
-    /// A matrix in `commitment`'s batch was opened at zero points, so its width cannot be
-    /// pinned from the claimed evaluations. Every input matrix must be opened at >= 1 point.
-    #[error("Matrix {matrix} in commitment {commitment} was opened at zero points")]
-    MatrixWithoutOpeningPoints { commitment: usize, matrix: usize },
-
-    /// The requested STIR parameters cannot reach `security_level` at some LDE-height bucket.
-    #[error("STIR config error: {0}")]
-    Config(#[source] crate::config::StirConfigError),
-
-    /// An error propagated from the input polynomial commitment scheme.
-    #[error("Input error")]
-    InputError(InputError),
-}
-
-impl<E1, IE1> StirError<E1, IE1> {
-    /// Map the `InputError` variant to a different type.
-    pub fn map_input_err<IE2>(self, f: impl FnOnce(IE1) -> IE2) -> StirError<E1, IE2> {
-        match self {
-            Self::InvalidPowWitness { round } => StirError::InvalidPowWitness { round },
-            Self::InvalidMmcsProof { round, source } => {
-                StirError::InvalidMmcsProof { round, source }
-            }
-            Self::InvalidShakeConsistency { round } => StirError::InvalidShakeConsistency { round },
-            Self::InvalidRoundConsistency { round, query } => {
-                StirError::InvalidRoundConsistency { round, query }
-            }
-            Self::FinalPolyMismatch => StirError::FinalPolyMismatch,
-            Self::InvalidProofShape => StirError::InvalidProofShape,
-            Self::MatrixWithoutOpeningPoints { commitment, matrix } => {
-                StirError::MatrixWithoutOpeningPoints { commitment, matrix }
-            }
-            Self::Config(e) => StirError::Config(e),
-            Self::InputError(e) => StirError::InputError(f(e)),
-        }
-    }
 }
 
 /// Side outputs of a successful STIR verification.
@@ -924,7 +943,12 @@ where
     let num_rounds = config.num_rounds();
 
     if proof.round_proofs.len() != num_rounds {
-        return Err(StirError::InvalidProofShape);
+        return Err(ProofShapeError::RoundCount {
+            instance: None,
+            expected: num_rounds,
+            got: proof.round_proofs.len(),
+        }
+        .into());
     }
 
     // The initial oracle is either committed by STIR — in which case its commitment enters the
@@ -935,7 +959,8 @@ where
     match (&proof.initial_commitment, initial_is_external) {
         (Some(commitment), false) => challenger.observe(commitment.clone()),
         (None, true) => {}
-        _ => return Err(StirError::InvalidProofShape),
+        (Some(_), true) => return Err(ProofShapeError::UnexpectedInitialCommitment.into()),
+        (None, false) => return Err(ProofShapeError::MissingInitialCommitment.into()),
     }
 
     // Initial domain shift is always F::GENERATOR; round_configs[0].domain_shift mirrors it
@@ -1061,10 +1086,12 @@ where
 
 /// Shared body of [`verify_stir_multi`] and [`verify_stir_multi_with_external_initial`].
 ///
-/// Mirrors `prover::prove_stir_multi_inner`'s right-aligned lockstep schedule: at
-/// each global round, every active instance's grind witness must agree (checked via
-/// `PartialEq`, else [`StirError::InvalidProofShape`]), then the shared grind is checked once
-/// at the max of the active instances' bits.
+/// Mirrors `prover::prove_stir_multi_inner`'s right-aligned lockstep schedule.
+///
+/// At each global round:
+/// - every active instance's replicated grind witness must agree,
+/// - else [`ProofShapeError::ReplicatedWitnessMismatch`],
+/// - then the shared grind is checked once, at the max of the active instances' bits.
 fn verify_stir_multi_inner<F, EF, M, Challenger, IE, Src>(
     configs: &[&StirConfig<F, EF, M, Challenger>],
     proofs: &[&StirProof<EF, M, Challenger::Witness>],
@@ -1082,22 +1109,46 @@ where
     Src: FnOnce(&[usize]) -> Result<Vec<Vec<EF>>, StirError<M::Error, IE>>,
 {
     let b = configs.len();
-    assert_eq!(proofs.len(), b, "one proof per instance");
+    if proofs.len() != b {
+        return Err(ProofShapeError::InstanceCount {
+            expected: b,
+            got: proofs.len(),
+        }
+        .into());
+    }
+
+    // Why: an empty batch is a transcript no-op on both sides.
+    //   prover:   shared grinds fall back to zero bits
+    //   verifier: check_witness(0, _) observes nothing
+    if b == 0 {
+        return Ok(Vec::new());
+    }
 
     for i in 0..b {
         if proofs[i].round_proofs.len() != configs[i].num_rounds() {
-            return Err(StirError::InvalidProofShape);
+            return Err(ProofShapeError::RoundCount {
+                instance: Some(i),
+                expected: configs[i].num_rounds(),
+                got: proofs[i].round_proofs.len(),
+            }
+            .into());
         }
     }
 
     let initial_is_external = external_fibers.is_some();
-    let mut external_fibers: Vec<Option<Src>> = external_fibers.map_or_else(
-        || (0..b).map(|_| None).collect(),
-        |v| {
-            assert_eq!(v.len(), b, "one external-fiber source per instance");
-            v.into_iter().map(Some).collect()
-        },
-    );
+    let mut external_fibers: Vec<Option<Src>> = match external_fibers {
+        None => (0..b).map(|_| None).collect(),
+        Some(sources) => {
+            if sources.len() != b {
+                return Err(ExternalSourceError::SourceCount {
+                    expected: b,
+                    got: sources.len(),
+                }
+                .into());
+            }
+            sources.into_iter().map(Some).collect()
+        }
+    };
 
     // The initial oracle is either committed by STIR — in which case its commitment enters the
     // transcript here — or external, in which case the caller has already bound it and every
@@ -1108,7 +1159,8 @@ where
         match (&proofs[i].initial_commitment, initial_is_external) {
             (Some(commitment), false) => challenger.observe(commitment.clone()),
             (None, true) => {}
-            _ => return Err(StirError::InvalidProofShape),
+            (Some(_), true) => return Err(ProofShapeError::UnexpectedInitialCommitment.into()),
+            (None, false) => return Err(ProofShapeError::MissingInitialCommitment.into()),
         }
         shifts.push(F::GENERATOR);
         log_domains.push(configs[i].log_starting_domain_size());
@@ -1140,7 +1192,11 @@ where
             .map(|&i| proofs[i].round_proofs[r - offset(i)].folding_pow_witness)
             .collect();
         if folding_witnesses.windows(2).any(|w| w[0] != w[1]) {
-            return Err(StirError::InvalidProofShape);
+            return Err(ProofShapeError::ReplicatedWitnessMismatch {
+                round: RoundLabel::Round(r),
+                stage: GrindStage::Folding,
+            }
+            .into());
         }
         let shared_folding_bits = active
             .iter()
@@ -1148,7 +1204,9 @@ where
             .max()
             .expect("`active` is non-empty for r < max_m");
         if !challenger.check_witness(shared_folding_bits, folding_witnesses[0]) {
-            return Err(StirError::InvalidPowWitness { round: r });
+            return Err(StirError::InvalidPowWitness {
+                round: RoundLabel::Round(r),
+            });
         }
 
         // Phase 1: per-instance folding challenge and commitment absorb.
@@ -1164,7 +1222,12 @@ where
             let rc = &configs[i].round_configs[local_r];
             let rp = &proofs[i].round_proofs[local_r];
             if rp.ood_answers.len() != rc.num_ood_samples {
-                return Err(StirError::InvalidProofShape);
+                return Err(ProofShapeError::OodAnswerCount {
+                    round: RoundLabel::Round(local_r),
+                    expected: rc.num_ood_samples,
+                    got: rp.ood_answers.len(),
+                }
+                .into());
             }
             rv.ood_points = sample_ood_points(
                 challenger,
@@ -1180,7 +1243,11 @@ where
             .map(|&i| proofs[i].round_proofs[r - offset(i)].pow_witness)
             .collect();
         if query_witnesses.windows(2).any(|w| w[0] != w[1]) {
-            return Err(StirError::InvalidProofShape);
+            return Err(ProofShapeError::ReplicatedWitnessMismatch {
+                round: RoundLabel::Round(r),
+                stage: GrindStage::Query,
+            }
+            .into());
         }
         let shared_pow_bits = active
             .iter()
@@ -1188,7 +1255,9 @@ where
             .max()
             .expect("`active` is non-empty for r < max_m");
         if !challenger.check_witness(shared_pow_bits, query_witnesses[0]) {
-            return Err(StirError::InvalidPowWitness { round: r });
+            return Err(StirError::InvalidPowWitness {
+                round: RoundLabel::Round(r),
+            });
         }
 
         // Phase 3: per-instance combination challenge, query sampling, and fiber
@@ -1236,11 +1305,12 @@ where
             let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
             let max_ans_len = all_points.len();
-            if rp.ans_polynomial.len() > max_ans_len
-                || rp.shake_polynomial.len() > max_ans_len.saturating_sub(1)
-            {
-                return Err(StirError::InvalidProofShape);
-            }
+            check_ans_and_shake_lengths(
+                RoundLabel::Round(local_r),
+                &rp.ans_polynomial,
+                &rp.shake_polynomial,
+                max_ans_len,
+            )?;
 
             challenger.observe_algebra_slice(&rp.ans_polynomial);
             challenger.observe_algebra_slice(&rp.shake_polynomial);
@@ -1253,7 +1323,9 @@ where
                 &all_values,
                 rho,
             ) {
-                return Err(StirError::InvalidShakeConsistency { round: local_r });
+                return Err(StirError::InvalidShakeConsistency {
+                    round: RoundLabel::Round(local_r),
+                });
             }
 
             finishes.push((i, rv.finish(rp.ans_polynomial.clone(), &all_points)));
@@ -1272,7 +1344,11 @@ where
     let final_folding_witnesses: Vec<F> =
         proofs.iter().map(|p| p.final_folding_pow_witness).collect();
     if final_folding_witnesses.windows(2).any(|w| w[0] != w[1]) {
-        return Err(StirError::InvalidProofShape);
+        return Err(ProofShapeError::ReplicatedWitnessMismatch {
+            round: RoundLabel::Final,
+            stage: GrindStage::Folding,
+        }
+        .into());
     }
     let shared_final_folding_bits = configs
         .iter()
@@ -1280,7 +1356,9 @@ where
         .max()
         .unwrap_or(0);
     if !challenger.check_witness(shared_final_folding_bits, final_folding_witnesses[0]) {
-        return Err(StirError::InvalidPowWitness { round: max_m });
+        return Err(StirError::InvalidPowWitness {
+            round: RoundLabel::Final,
+        });
     }
 
     let mut fvs: Vec<FinalRoundVerifier<F, EF>> = (0..b)
@@ -1299,18 +1377,28 @@ where
 
         let expected_final_len = configs[i].final_poly_len();
         if proofs[i].final_polynomial.len() != expected_final_len {
-            return Err(StirError::InvalidProofShape);
+            return Err(ProofShapeError::FinalPolynomialLength {
+                expected: expected_final_len,
+                got: proofs[i].final_polynomial.len(),
+            }
+            .into());
         }
         challenger.observe_algebra_slice(&proofs[i].final_polynomial);
     }
 
     let final_query_witnesses: Vec<F> = proofs.iter().map(|p| p.final_pow_witness).collect();
     if final_query_witnesses.windows(2).any(|w| w[0] != w[1]) {
-        return Err(StirError::InvalidProofShape);
+        return Err(ProofShapeError::ReplicatedWitnessMismatch {
+            round: RoundLabel::Final,
+            stage: GrindStage::Query,
+        }
+        .into());
     }
     let shared_final_pow_bits = configs.iter().map(|c| c.final_pow_bits).max().unwrap_or(0);
     if !challenger.check_witness(shared_final_pow_bits, final_query_witnesses[0]) {
-        return Err(StirError::InvalidPowWitness { round: max_m });
+        return Err(StirError::InvalidPowWitness {
+            round: RoundLabel::Final,
+        });
     }
 
     for i in 0..b {

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -4,6 +4,8 @@
 //! that the proof verifies. Tests cover BabyBear (quartic extension), KoalaBear (quartic
 //! extension), and Goldilocks (quadratic extension).
 
+use core::fmt::Debug;
+
 use p3_challenger::{
     CanObserve, CanSampleUniformBits, DuplexChallenger, FieldChallenger, GrindingChallenger,
 };
@@ -13,10 +15,13 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_stir::SecurityAssumption;
 use p3_stir::config::{StirConfig, StirParameters};
-use p3_stir::prover::prove_stir;
-use p3_stir::verifier::verify_stir;
+use p3_stir::proof::StirProof;
+use p3_stir::prover::{codeword_from_coeffs, prove_stir, prove_stir_from_external_codeword};
+use p3_stir::verifier::{verify_stir, verify_stir_with_external_initial};
+use p3_stir::{
+    ExternalSourceError, GrindStage, ProofShapeError, RoundLabel, SecurityAssumption, StirError,
+};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
@@ -24,6 +29,14 @@ use rand::{RngExt, SeedableRng};
 
 fn seeded_rng() -> SmallRng {
     SmallRng::seed_from_u64(42)
+}
+
+/// The shape error inside a `StirError`, or a panic naming what came instead.
+fn shape_of<E: Debug, IE: Debug>(err: StirError<E, IE>) -> ProofShapeError {
+    match err {
+        StirError::InvalidProofShape(shape) => shape,
+        other => panic!("expected a shape error, got {other:?}"),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -378,7 +391,13 @@ mod babybear_stir {
         let mut v_ch = challenger;
         let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_ch)
             .expect_err("tampered pow_witness must be rejected");
-        assert!(matches!(err, p3_stir::StirError::InvalidPowWitness { .. }));
+        assert!(
+            matches!(
+                err,
+                StirError::InvalidPowWitness { round } if round == RoundLabel::Round(round_with_pow)
+            ),
+            "{err:?}"
+        );
     }
 
     #[test]
@@ -402,7 +421,7 @@ mod babybear_stir {
         assert!(
             matches!(
                 err,
-                p3_stir::StirError::InvalidPowWitness { round } if round == round_with_pow
+                StirError::InvalidPowWitness { round } if round == RoundLabel::Round(round_with_pow)
             ),
             "expected InvalidPowWitness in round {round_with_pow}, got {err:?}"
         );
@@ -424,7 +443,15 @@ mod babybear_stir {
         let mut v_ch = challenger;
         let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_ch)
             .expect_err("tampered final_pow_witness must be rejected");
-        assert!(matches!(err, p3_stir::StirError::InvalidPowWitness { .. }));
+        assert!(
+            matches!(
+                err,
+                StirError::InvalidPowWitness {
+                    round: RoundLabel::Final
+                }
+            ),
+            "{err:?}"
+        );
     }
 
     #[test]
@@ -575,7 +602,10 @@ mod babybear_stir {
             .expect_err("tampered sibling hash must be rejected");
         assert!(matches!(
             err,
-            p3_stir::StirError::InvalidMmcsProof { round: 0, .. }
+            StirError::InvalidMmcsProof {
+                round: RoundLabel::Round(0),
+                ..
+            }
         ));
     }
 
@@ -605,7 +635,10 @@ mod babybear_stir {
             .expect_err("dropped sibling hash must be rejected");
         assert!(matches!(
             err,
-            p3_stir::StirError::InvalidMmcsProof { round: 0, .. }
+            StirError::InvalidMmcsProof {
+                round: RoundLabel::Round(0),
+                ..
+            }
         ));
     }
 
@@ -719,7 +752,7 @@ mod babybear_stir {
         let mut v_challenger = challenger;
         let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
             .expect_err("a missing initial commitment must be rejected");
-        assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
+        assert_eq!(shape_of(err), ProofShapeError::MissingInitialCommitment);
     }
 
     #[test]
@@ -743,6 +776,332 @@ mod babybear_stir {
         assert!(
             verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger).is_err(),
             "tampered final_query_openings.row_evals must be rejected"
+        );
+    }
+
+    /// Prove with an uncommitted initial oracle, then verify against a caller-supplied source.
+    ///
+    /// `mutate` tampers with the proof.
+    /// `fibers` rewrites the honest fibers the source would have returned.
+    ///
+    /// Lane `l` of query `j` sits at natural-order position `j + l * fold_height`.
+    fn verify_external_initial(
+        mutate: impl FnOnce(&mut StirProof<EF, MyMmcs, F>),
+        fibers: impl FnOnce(Vec<Vec<EF>>) -> Vec<Vec<EF>>,
+    ) -> Result<(), StirError<<MyMmcs as Mmcs<EF>>::Error>> {
+        let (params, dft, challenger) = make_params(1, 2);
+        let mut rng = seeded_rng();
+        let log_degree = 8;
+        let coeffs: Vec<EF> = (0..1usize << log_degree).map(|_| rng.random()).collect();
+
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let log_domain = config.log_starting_domain_size();
+        let codeword = codeword_from_coeffs(&dft, coeffs, F::GENERATOR, log_domain);
+
+        // Binding the codeword before proving is the caller's job. Observing its values
+        // stands in for the PCS layer's input commitments.
+        let mut p_challenger = challenger.clone();
+        p_challenger.observe_algebra_slice(&codeword);
+        let (mut proof, _idx) =
+            prove_stir_from_external_codeword(&config, codeword.clone(), &dft, &mut p_challenger);
+        mutate(&mut proof);
+
+        let arity0 = 1usize << config.log_starting_folding_factor;
+        let fold_height = (1usize << log_domain) / arity0;
+
+        let mut v_challenger = challenger;
+        v_challenger.observe_algebra_slice(&codeword);
+        verify_stir_with_external_initial(&config, &proof, &mut v_challenger, |js| {
+            let honest = js
+                .iter()
+                .map(|&j| (0..arity0).map(|l| codeword[j + l * fold_height]).collect())
+                .collect();
+            Ok(fibers(honest))
+        })
+        .map(|_| ())
+    }
+
+    #[test]
+    fn test_external_initial_oracle_verifies() {
+        verify_external_initial(|_| {}, |honest| honest)
+            .unwrap_or_else(|e| panic!("an honest external oracle must verify: {e:?}"));
+    }
+
+    #[test]
+    fn test_external_source_returning_too_few_fibers_rejected() {
+        let err = verify_external_initial(
+            |_| {},
+            |mut honest| {
+                honest.pop();
+                honest
+            },
+        )
+        .expect_err("a short fiber list must be rejected");
+        let StirError::ExternalSource(source) = err else {
+            panic!("expected an external-source error, got {err:?}");
+        };
+        assert_eq!(
+            source,
+            ExternalSourceError::FiberCount {
+                round: RoundLabel::Round(0),
+                expected: 19,
+                got: 18,
+            }
+        );
+    }
+
+    #[test]
+    fn test_external_source_returning_short_fiber_rejected() {
+        let err = verify_external_initial(
+            |_| {},
+            |mut honest| {
+                honest[0].pop();
+                honest
+            },
+        )
+        .expect_err("a fiber below the round's arity must be rejected");
+        let StirError::ExternalSource(source) = err else {
+            panic!("expected an external-source error, got {err:?}");
+        };
+        assert_eq!(
+            source,
+            ExternalSourceError::FiberArity {
+                round: RoundLabel::Round(0),
+                fiber: 0,
+                expected: 4,
+                got: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_external_oracle_carrying_query_openings_rejected() {
+        let err = verify_external_initial(
+            |proof| {
+                // Nothing commits to an externally bound oracle, so rows shipped against it
+                // are unauthenticated.
+                proof.round_proofs[0].query_openings = proof.final_query_openings.clone();
+                assert!(proof.round_proofs[0].query_openings.is_some());
+            },
+            |honest| honest,
+        )
+        .expect_err("openings against an external oracle must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::UnexpectedQueryOpenings {
+                round: RoundLabel::Round(0),
+            }
+        );
+    }
+
+    /// Prove a fixed instance, apply `mutate`, and return the shape error the verifier reports.
+    ///
+    /// Every mutation below breaks a length the configuration pins.
+    fn shape_error_after(mutate: impl FnOnce(&mut StirProof<EF, MyMmcs, F>)) -> ProofShapeError {
+        let (params, dft, challenger) = make_params(1, 2);
+        let mut rng = seeded_rng();
+        let log_degree = 8;
+        let poly_coeffs: Vec<EF> = (0..1usize << log_degree).map(|_| rng.random()).collect();
+
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        assert_eq!(config.num_rounds(), 3);
+        let mut p_challenger = challenger.clone();
+        let (mut proof, _idx) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
+
+        mutate(&mut proof);
+
+        let mut v_challenger = challenger;
+        let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
+            .expect_err("a shape-mutated proof must be rejected");
+        shape_of(err)
+    }
+
+    #[test]
+    fn test_dropped_round_proof_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs.pop();
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::RoundCount {
+                instance: None,
+                expected: 3,
+                got: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_extra_ood_answer_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0].ood_answers.push(EF::ONE);
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::OodAnswerCount {
+                round: RoundLabel::Round(0),
+                expected: 2,
+                got: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_dropped_ood_answer_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0].ood_answers.pop();
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::OodAnswerCount {
+                round: RoundLabel::Round(0),
+                expected: 2,
+                got: 1,
+            }
+        );
+    }
+
+    /// Mutating round 1 rather than round 0 pins that the round index is threaded through.
+    #[test]
+    fn test_extra_ood_answer_in_a_later_round_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[1].ood_answers.push(EF::ONE);
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::OodAnswerCount {
+                round: RoundLabel::Round(1),
+                expected: 2,
+                got: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_overlong_ans_polynomial_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0].ans_polynomial.resize(1024, EF::ONE);
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::AnsPolynomialTooLong {
+                round: RoundLabel::Round(0),
+                maximum: 20,
+                got: 1024,
+            }
+        );
+    }
+
+    /// Leaves `Ans` alone: the shake bound is one degree lower and checked separately.
+    #[test]
+    fn test_overlong_shake_polynomial_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0].shake_polynomial.resize(1024, EF::ONE);
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::ShakePolynomialTooLong {
+                round: RoundLabel::Round(0),
+                maximum: 19,
+                got: 1024,
+            }
+        );
+    }
+
+    #[test]
+    fn test_missing_query_openings_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0].query_openings = None;
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::MissingQueryOpenings {
+                round: RoundLabel::Round(0),
+            }
+        );
+    }
+
+    /// The final round reads its oracle through the same path, under its own label.
+    #[test]
+    fn test_missing_final_query_openings_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.final_query_openings = None;
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::MissingQueryOpenings {
+                round: RoundLabel::Final,
+            }
+        );
+    }
+
+    #[test]
+    fn test_dropped_opened_row_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0]
+                .query_openings
+                .as_mut()
+                .expect("a committed oracle carries its openings")
+                .row_evals
+                .pop();
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::QueryOpeningCount {
+                round: RoundLabel::Round(0),
+                expected: 21,
+                got: 20,
+            }
+        );
+    }
+
+    #[test]
+    fn test_short_opened_row_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.round_proofs[0]
+                .query_openings
+                .as_mut()
+                .expect("a committed oracle carries its openings")
+                .row_evals[0]
+                .pop();
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::OpenedRowArity {
+                round: RoundLabel::Round(0),
+                query: 0,
+                expected: 4,
+                got: 3,
+            }
+        );
+    }
+
+    #[test]
+    fn test_overlong_final_polynomial_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.final_polynomial.push(EF::ONE);
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::FinalPolynomialLength {
+                expected: 1,
+                got: 2,
+            }
+        );
+    }
+
+    /// A prover that truncates rather than pads is the other side of the same `!=`.
+    #[test]
+    fn test_truncated_final_polynomial_rejected() {
+        let err = shape_error_after(|proof| {
+            proof.final_polynomial.pop();
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::FinalPolynomialLength {
+                expected: 1,
+                got: 0,
+            }
         );
     }
 
@@ -1435,9 +1794,13 @@ mod babybear_pcs {
         // `[8, 6, 4]` is one tree at spread 8 and three at spread 0, so the root-count check
         // that runs before anything else rejects it.
         let err = verify_at_a_different_spread(&[8, 6, 4], 8, 0);
-        assert!(
-            matches!(err, p3_stir::StirError::InvalidProofShape),
-            "{err:?}"
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::CommitmentRootCount {
+                commitment: 0,
+                expected: 3,
+                got: 1,
+            }
         );
     }
 
@@ -1446,13 +1809,19 @@ mod babybear_pcs {
         // The case the root-count check cannot see, and the one the layout-agreement claim
         // actually rests on. `[8, 7, 4]` is `{8,7} | {4}` at spread 1 and `{8} | {7,4}` at
         // spread 3: two trees either way, so the root-count check and the bucket-count check
-        // both pass, and the disagreement only surfaces further in, on the dimensions the
-        // input MMCS opening is checked against. Keep both cases — collapsing this one back
-        // into a root-count mismatch stops exercising that path.
+        // both pass. Keep both cases — collapsing this one back into a root-count mismatch
+        // stops exercising that path.
+        //
+        // The two layouts put different native heights in each bucket, so the second bucket
+        // derives a different `StirConfig` and its round schedule no longer matches.
         let err = verify_at_a_different_spread(&[8, 7, 4], 1, 3);
-        assert!(
-            matches!(err, p3_stir::StirError::InvalidProofShape),
-            "{err:?}"
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::RoundCount {
+                instance: Some(1),
+                expected: 2,
+                got: 1,
+            }
         );
     }
 
@@ -2087,9 +2456,14 @@ mod babybear_pcs {
             (commit_b, vec![(domain, vec![(zeta, opening_b)])]),
         ];
         let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
-        assert!(
-            matches!(res, Err(p3_stir::StirError::InvalidProofShape)),
-            "truncated input_openings must be rejected as InvalidProofShape, got {res:?}"
+        let err = res.expect_err("truncated input_openings must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::InputOpeningCount {
+                log_height: log_d + 1,
+                expected: 2,
+                got: 1,
+            }
         );
     }
 
@@ -2142,9 +2516,13 @@ mod babybear_pcs {
             (commit_b, vec![(domain, vec![(zeta, opening_b)])]),
         ];
         let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
-        assert!(
-            matches!(res, Err(p3_stir::StirError::InvalidProofShape)),
-            "Some -> None input opening must be rejected as InvalidProofShape, got {res:?}"
+        let err = res.expect_err("a blanked input opening must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::MissingInputOpening {
+                log_height: log_d + 1,
+                commitment: 0,
+            }
         );
     }
 
@@ -2189,9 +2567,15 @@ mod babybear_pcs {
         let opening = opening_values[0][0][0].clone();
         let claims = vec![(commit, vec![(domain, vec![(zeta, opening)])])];
         let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
-        assert!(
-            matches!(res, Err(p3_stir::StirError::InvalidProofShape)),
-            "truncated opened_values must be rejected as InvalidProofShape, got {res:?}"
+        let err = res.expect_err("truncated opened_values must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::InputOpenedRowCount {
+                log_height: log_d + 1,
+                commitment: 0,
+                expected: 14,
+                got: 13,
+            }
         );
     }
 
@@ -2266,9 +2650,17 @@ mod babybear_pcs {
         // a degree-2^6 one.
         let err = verify_with_claimed_degrees(&[8, 8], &[8, 6])
             .expect_err("an understated native height must be rejected");
-        assert!(
-            matches!(err, p3_stir::StirError::InvalidProofShape),
-            "{err:?}"
+        // Two classes rather than one give a different `combine_key`, hence a different
+        // `StirConfig`, hence a different first-round query count. The disagreement is caught
+        // by the opened-row shape check before any algebraic check runs.
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::InputOpenedRowCount {
+                log_height: 9,
+                commitment: 0,
+                expected: 21,
+                got: 20,
+            }
         );
     }
 
@@ -2278,9 +2670,14 @@ mod babybear_pcs {
         // there is only one and skips it entirely.
         let err = verify_with_claimed_degrees(&[8, 6], &[8, 8])
             .expect_err("an overstated native height must be rejected");
-        assert!(
-            matches!(err, p3_stir::StirError::InvalidProofShape),
-            "{err:?}"
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::InputOpenedRowCount {
+                log_height: 9,
+                commitment: 0,
+                expected: 17,
+                got: 21,
+            }
         );
     }
 
@@ -2464,6 +2861,175 @@ mod babybear_pcs {
         );
     }
 
+    /// An opening point on the LDE coset makes a quotient denominator vanish.
+    ///
+    /// `batch_multiplicative_inverse` panics on a zero input, so the verifier must reject
+    /// first. Matches `FriError::OpeningPointMatchesQueryPoint`.
+    #[test]
+    fn test_pcs_rejects_opening_point_on_the_evaluation_domain() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        // A degree-4 matrix leaves a 2^3 LDE coset folded into two fibers of four lanes, so
+        // the first-round queries cover every coset position.
+        let log_d = 2;
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 1);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![(&data, vec![vec![zeta]])],
+            &mut p_ch,
+        );
+
+        // Claim the same value at the coset's first point instead. `open` cannot be asked
+        // for one: it would divide by zero building its own denominators.
+        let coset_point = Challenge::from(Val::GENERATOR);
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let _v_zeta: Challenge = v_ch.sample_algebra_element();
+        let claims = vec![(
+            commit,
+            vec![(domain, vec![(coset_point, opening_values[0][0][0].clone())])],
+        )];
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
+            .expect_err("an opening point on the evaluation domain must be rejected");
+        assert!(
+            matches!(
+                err,
+                StirError::OpeningPointMatchesQueryPoint {
+                    commitment: 0,
+                    matrix: 0,
+                    point: 0,
+                }
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[test]
+    fn test_pcs_rejects_dropped_height_bucket() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+        let log_d = 6;
+
+        let domain =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << log_d);
+        let mat = RowMajorMatrix::<Val>::rand(&mut rng, 1 << log_d, 3);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain, mat)]);
+        p_ch.observe(commit.clone());
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![(&data, vec![vec![zeta]])],
+            &mut p_ch,
+        );
+
+        // The claims pin one STIR instance per distinct shared LDE height, so a proof with
+        // fewer must be rejected before the transcript is touched.
+        assert_eq!(proof.len(), 1);
+        proof.pop();
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+        let claims = vec![(
+            commit,
+            vec![(domain, vec![(v_zeta, opening_values[0][0][0].clone())])],
+        )];
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
+            .expect_err("a missing height bucket must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::BucketCount {
+                expected: 1,
+                got: 0,
+            }
+        );
+    }
+
+    /// An input opening at a bucket the commitment has no matrices at must be rejected.
+    ///
+    /// This is the mirror of [`test_pcs_input_opening_present_to_none_rejected`]: the slot
+    /// exists and is occupied, but by rows from a different LDE domain, so folding them into
+    /// this bucket's reduced opening would bind the wrong codeword.
+    #[test]
+    fn test_pcs_rejects_input_opening_at_wrong_bucket() {
+        let (pcs, challenger_template) = get_pcs();
+        let mut rng = seeded_rng();
+
+        // Two commitments two octaves apart, so each gets its own shared LDE height — hence
+        // its own bucket, with the taller one first.
+        let domain_tall =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << 8);
+        let domain_short =
+            <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 1 << 6);
+        let mat_tall = RowMajorMatrix::<Val>::rand(&mut rng, 1 << 8, 3);
+        let mat_short = RowMajorMatrix::<Val>::rand(&mut rng, 1 << 6, 3);
+
+        let mut p_ch = challenger_template.clone();
+        let (commit_tall, data_tall) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_tall, mat_tall)]);
+        p_ch.observe(commit_tall.clone());
+        let (commit_short, data_short) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, vec![(domain_short, mat_short)]);
+        p_ch.observe(commit_short.clone());
+
+        let zeta: Challenge = p_ch.sample_algebra_element();
+        let data_and_points = vec![
+            (&data_tall, vec![vec![zeta]]),
+            (&data_short, vec![vec![zeta]]),
+        ];
+        let (opening_values, mut proof) =
+            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        assert_eq!(proof.len(), 2, "two heights must give two buckets");
+
+        // Copy the short commitment's own opening into its (rightly empty) slot at the tall
+        // bucket.
+        let short_opening = proof[1].1[1].clone();
+        assert!(short_opening.is_some());
+        assert!(proof[0].1[1].is_none());
+        proof[0].1[1] = short_opening;
+
+        let mut v_ch = challenger_template;
+        v_ch.observe(commit_tall.clone());
+        v_ch.observe(commit_short.clone());
+        let v_zeta: Challenge = v_ch.sample_algebra_element();
+
+        let claims = vec![
+            (
+                commit_tall,
+                vec![(domain_tall, vec![(v_zeta, opening_values[0][0][0].clone())])],
+            ),
+            (
+                commit_short,
+                vec![(
+                    domain_short,
+                    vec![(v_zeta, opening_values[1][0][0].clone())],
+                )],
+            ),
+        ];
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
+            .expect_err("an opening at the wrong bucket must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::UnexpectedInputOpening {
+                log_height: 9,
+                commitment: 1,
+            }
+        );
+    }
+
     #[test]
     fn test_pcs_rejects_stray_initial_commitment() {
         let (pcs, challenger_template) = get_pcs();
@@ -2499,7 +3065,7 @@ mod babybear_pcs {
         )];
         let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
             .expect_err("a stray initial commitment must be rejected");
-        assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
+        assert_eq!(shape_of(err), ProofShapeError::UnexpectedInitialCommitment);
     }
 }
 
@@ -2680,16 +3246,24 @@ mod babybear_stir_multi {
         let proofs = [&proof];
         let err = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
             .expect_err("a witness replayed from another grind site must be rejected");
-        assert!(matches!(err, p3_stir::StirError::InvalidPowWitness { .. }));
+        assert!(
+            matches!(
+                err,
+                StirError::InvalidPowWitness { round } if round == RoundLabel::Round(round_with_pow)
+            ),
+            "{err:?}"
+        );
     }
 
-    #[test]
-    fn test_multi_disagreeing_replicated_witness_rejected() {
+    /// Prove two identical-height instances, apply `mutate` to the second, and verify.
+    ///
+    /// Equal heights line the round indices up 1:1, so every grind site is shared exactly.
+    fn multi_shape_error_after(
+        mutate: impl FnOnce(&mut StirProof<EF, MyMmcs, F>),
+    ) -> ProofShapeError {
         let (params, dft, challenger) = make_params(1, 2, 32, 12);
         let log_degree = 8;
         let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
-        // Two identical-height instances so their round indices line up 1:1 and share every
-        // grind site exactly.
         let config_refs = [&config, &config];
 
         let mut rng = seeded_rng();
@@ -2702,15 +3276,94 @@ mod babybear_stir_multi {
         let mut results = prove_stir_multi(&config_refs, polys, &dft, &mut p_ch).into_iter();
         let proof_a = results.next().expect("bucket a").0;
         let mut proof_b = results.next().expect("bucket b").0;
-
-        // Disagree bucket B's round-0 folding-grind witness from bucket A's replicated copy.
-        proof_b.round_proofs[0].folding_pow_witness += F::ONE;
+        mutate(&mut proof_b);
 
         let mut v_ch = challenger;
         let proofs = [&proof_a, &proof_b];
         let err = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
-            .expect_err("disagreeing replicated witnesses across buckets must be rejected");
-        assert!(matches!(err, p3_stir::StirError::InvalidProofShape));
+            .expect_err("a shape-mutated batch must be rejected");
+        shape_of(err)
+    }
+
+    #[test]
+    fn test_multi_disagreeing_folding_witness_rejected() {
+        let err = multi_shape_error_after(|proof| {
+            proof.round_proofs[0].folding_pow_witness += F::ONE;
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::ReplicatedWitnessMismatch {
+                round: RoundLabel::Round(0),
+                stage: GrindStage::Folding,
+            }
+        );
+    }
+
+    /// The query grind sits after the OOD absorb, so its witness is checked separately.
+    #[test]
+    fn test_multi_disagreeing_query_witness_rejected() {
+        let err = multi_shape_error_after(|proof| {
+            proof.round_proofs[0].pow_witness += F::ONE;
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::ReplicatedWitnessMismatch {
+                round: RoundLabel::Round(0),
+                stage: GrindStage::Query,
+            }
+        );
+    }
+
+    /// A batched round-count mismatch names the instance that carries it.
+    #[test]
+    fn test_multi_round_count_names_its_instance() {
+        let err = multi_shape_error_after(|proof| {
+            proof.round_proofs.pop();
+        });
+        assert_eq!(
+            err,
+            ProofShapeError::RoundCount {
+                instance: Some(1),
+                expected: 3,
+                got: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn test_multi_proof_count_mismatch_rejected() {
+        let (params, dft, challenger) = make_params(1, 2, 32, 12);
+        let log_degree = 8;
+        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
+        let config_refs = [&config, &config];
+
+        let mut rng = seeded_rng();
+        let poly: Vec<EF> = (0..1usize << log_degree).map(|_| rng.random()).collect();
+
+        let mut p_ch = challenger.clone();
+        let results = prove_stir_multi(&[&config], vec![poly], &dft, &mut p_ch);
+        let proof = &results[0].0;
+
+        let mut v_ch = challenger;
+        let err = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &[proof], &mut v_ch)
+            .expect_err("one proof for two configs must be rejected");
+        assert_eq!(
+            shape_of(err),
+            ProofShapeError::InstanceCount {
+                expected: 2,
+                got: 1,
+            }
+        );
+    }
+
+    /// An empty batch has no transcript operations, matching the prover, so it verifies.
+    #[test]
+    fn test_multi_empty_batch_verifies() {
+        let (_params, _dft, challenger) = make_params(1, 2, 32, 12);
+        let mut v_ch = challenger;
+        let outputs = verify_stir_multi::<F, EF, MyMmcs, Challenger>(&[], &[], &mut v_ch)
+            .expect("an empty batch must verify");
+        assert!(outputs.is_empty());
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/Plonky3/Plonky3/pull/1990#discussion_r3853544260.

## The problem

`StirError::InvalidProofShape` was a unit variant:

```rust
/// The proof has the wrong number of rounds, queries, or OOD answers.
#[error("Invalid proof shape")]
InvalidProofShape,
```

It was raised from **22 different call sites** across `verifier.rs` and `pcs.rs` — a wrong
round count, a missing initial commitment, an over-long shake polynomial, a truncated input
opening at one LDE-height bucket, a disagreeing replicated grind witness. Receiving it told
a caller only that *something* about the proof's shape was wrong. As the review comment put
it: "receiving that as an error doesn't help much."

## The fix

A new `ProofShapeError` enum, one variant per check, carrying where the mismatch was and
both numbers. `StirError::InvalidProofShape` transparently wraps it:

```rust
/// The proof's shape disagrees with the configuration or the public input.
#[error(transparent)]
InvalidProofShape(#[from] ProofShapeError),
```

This is the shape `p3-uni-stark` already uses — `VerificationError::InvalidProofShape`
wrapping `InvalidProofShapeError` — so nothing new is invented here; the STIR verifier
catches up with its sibling, down to `got`/`maximum` field naming and lowercase messages.

Before / after, on the same tampered proofs:

```
Invalid proof shape   →  round 0: shake polynomial has 1024 coefficients, expected at most 19
Invalid proof shape   →  final round: missing query openings
Invalid proof shape   →  bucket 2^9, commitment 0: 21 opened rows, expected 22
Invalid proof shape   →  instance 1: expected 3 round proofs, got 2
```

Every variant is pinned by data the verifier already holds — the round schedule and query
counts from `StirConfig`, the bucket and opening layout from the claimed evaluations — so
these are always malformed-proof reports, never failed algebraic checks. Those keep their
own `StirError` variants.

## Two supporting types

`RoundLabel::{Round(usize), Final}` replaces the `num_rounds` sentinel that every
round-carrying variant used to label the final round. Before, a three-round proof reported
`round 3`; now it reports `final round`. The sentinel predated this PR (`error_round:
num_rounds` already fed `InvalidMmcsProof`) but was invisible while the shape error was a
unit variant, so `StirError`'s own round variants take the type too.

`GrindStage::{Folding, Query}` names which of a round's two proof-of-work grinds a
replicated-witness disagreement came from, in the batched lockstep path.

## Compound checks split

Four checks tested two independent conditions and reported one error. Each is now split, so
the variant you get is unambiguous:

| Was one check | Now |
|---|---|
| `ans.len() > max \|\| shake.len() > max - 1` | `AnsPolynomialTooLong` / `ShakePolynomialTooLong` |
| `rows.len() != n \|\| any(row.len() != arity)` | `QueryOpeningCount` / `OpenedRowArity` |
| `fibers.len() != n \|\| any(f.len() != arity)` | `FiberCount` / `FiberArity` |
| `match (commitment, is_external) { _ => Err }` | `MissingInitialCommitment` / `UnexpectedInitialCommitment` |

The last is the interesting one: a proof that *omits* a commitment STIR should have
committed, and a proof that *smuggles in* a commitment to an externally bound oracle, are
opposite failures and the crate already had a test for each. They now assert different
errors.

## What is not a proof-shape error

`ExternalSourceError` holds the checks on the caller's external initial-oracle fiber source.
A `Vec<Src>` of closures cannot be deserialised, so its shape is caller-constructed rather
than attacker-supplied — a wrong answer there is a caller bug, and the message should say so
rather than blaming the proof:

```
external initial oracle: round 0: source returned 18 fibers, expected 19
```

## Robustness fixes found along the way

Three defects surfaced while auditing what each check could actually report. All are
reproduced under test.

**`batch_multiplicative_inverse` panicked on a coinciding opening point.** A claimed opening
point sitting on a queried fiber lane makes a quotient denominator vanish, and
`batch_multiplicative_inverse` is documented to panic on a zero input, so
`TwoAdicStirPcs::verify` aborted the process instead of returning `Err`. `p3-fri`
(`FriError::OpeningPointMatchesQueryPoint`, added in #1762) and `p3-circle` both reject it;
STIR now does too. No soundness impact — `zeta` from the extension field makes a collision
negligible for STARK use — but a direct PCS caller opening at a base-field coset point hit a
real abort.

**`verify_stir_multi` panicked on an empty batch.** With empty `configs`, `max_m == 0` skips
the round loop and the final witness collection indexed an empty vector. It now returns
`Ok(vec![])`, which is transcript-exact against the prover: `grind(0)` returns `F::ZERO` and
`check_witness(0, _)` returns `true`, both before touching the sponge.

**Two `assert_eq!`s on caller-supplied lengths.** `proofs.len() != configs.len()` is now
`ProofShapeError::InstanceCount`, and `sources.len() != b` is
`ExternalSourceError::SourceCount`. No `assert!` remains in `verifier.rs`.

## Two variants deleted as dead by construction

`HeightClassCount` and `MissingCombineCoefficient` both compared `native_heights.len()`
against itself: `expected_ro_by_class` is sized by `native_heights`, `Combine` runs exactly
when that holds two or more classes, and its coefficient map is keyed by those same heights.
Neither was constructible. The one gap — a bucket with zero classes, from a commitment
claimed with an empty matrix list — is rejected earlier by
`StirConfigError::StartingFoldingFactorExceedsDegree`, since such a bucket always derives
`log_stir_degree == 1`.

They are now `expect`s, matching the two neighbouring invariants of the same kind three
lines away (`expect("bucket_native_heights is built from these claims")`).

## Module move

`StirError` moves from `verifier.rs` to a new `stir::error` module, next to
`ProofShapeError` — mirroring `uni-stark/src/error.rs`, and keeping the error definitions out
of an already 1400-line verifier. The crate-root path `p3_stir::StirError` is unchanged;
`p3_stir::verifier::StirError` is gone, and the commit carries a `BREAKING CHANGE:` footer
for release-plz.

## Tests

88 in `tests/stir.rs`, up from 65 on main. Every shape assertion compares the whole error
value — no `..` wildcards, except on `InvalidMmcsProof` whose `source` is not `PartialEq`.

Three harnesses keep each case to a few lines: `shape_error_after` (mutate a
committed-oracle proof), `verify_external_initial` (mutate the proof *and* the caller's fiber
source), and `multi_shape_error_after` (mutate one instance of a batch).

Coverage that did not exist before this PR:

- **`verify_stir_with_external_initial` had no direct test at all** — it was only exercised
  through the PCS. There is now an honest positive test plus three rejections.
- **An input opening placed at the *wrong* LDE-height bucket had no test** — the
  `has_at_bucket` branch that rejects it was never hit.
- **Both `GrindStage` values, both directions of each length check**, a mutation at round 1
  (so `round` is pinned as threaded rather than hard-coded 0), the final-round label, the
  batch-count checks, the empty batch, and the coset opening point.

The two native-height tests also got sharper. They previously asserted only
`InvalidProofShape`; the typed error revealed that the rejection actually lands on the
*opened-row count*, because a different class count means a different `combine_key`, hence a
different `StirConfig`, hence a different first-round query count. They now assert that
mismatch exactly, and their comments say so.

Not covered, deliberately: `MissingCommitment` is defensive — the initial commitment's
presence is already pinned before any round runs, and every later round reads the preceding
round's commitment.

## Follow-up left out

In `verify_stir_multi`, only `RoundCount` names the offending instance. The uniform version
is a recursive `StirError::Instance { instance, source: Box<Self> }` wrapper applied at each
per-instance `?`, which would cover `InvalidPowWitness`, `InvalidMmcsProof`,
`InvalidShakeConsistency` and the shape errors raised inside the shared query-fetch path in
one go. It works, but interpolating `{source}` makes thiserror infer
`Box<StirError<E, IE>>: Display` as a bound on `impl Display for StirError<E, IE>` — the impl
requires itself, and rustc reports `error[E0275]`. The escape is a hand-written `Display` +
`Error` for all twelve variants, trading this crate's colocated `#[error(...)]` messages for
~60 lines of `write!`. The right shape for a follow-up is threading `instance` through
`RoundRowsRequest` and the two fetch methods instead.

## Verification

- `cargo test -p p3-stir` — 157 tests pass (88 in `tests/stir.rs`, up from 65)
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo doc --no-deps --workspace --document-private-items` with
  `RUSTDOCFLAGS=-D rustdoc::broken_intra_doc_links` — clean
- `cargo +nightly fmt --all --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
