### PR TITLE
perf(stir): sub-coset virtual oracle, cheaper multiplies, barycentric Ans check

### DIFF
--- a/stir/benches/stir.rs
+++ b/stir/benches/stir.rs
@@ -6,7 +6,7 @@
 //! # Benchmark parameters
 //!
 //! `max_pow_bits = 0` is used throughout so benchmarks measure the cryptographic core
-//! (DFTs, Merkle trees, Lagrange folds, shake polynomial arithmetic) without PoW
+//! (DFTs, Merkle trees, Lagrange folds, answer polynomial arithmetic) without PoW
 //! grinding noise.  Real deployments add PoW overhead on top of these numbers.
 //!
 //! Two theorem-compatible configurations are benchmarked:

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -91,7 +91,7 @@ pub struct StirParameters<M> {
     /// Fixed proof-of-work difficulty in bits applied to each Fiat-Shamir grinding step.
     ///
     /// This can reduce the algebraic target only for challenges sampled immediately after
-    /// the corresponding grind. OOD and shake-check errors receive no PoW credit.
+    /// the corresponding grind. OOD and Ans-check errors receive no PoW credit.
     pub max_pow_bits: usize,
 
     /// Merkle tree commitment scheme for codeword commitments.
@@ -154,7 +154,7 @@ pub struct StirRoundConfig<F> {
     ///
     /// Derived as `max(0, security_level − query_algebraic_bits)` and capped at
     /// `max_pow_bits`. Only the query-failure and random-combination terms are eligible:
-    /// the OOD points are sampled before this grind, while the shake challenge follows a
+    /// the OOD points are sampled before this grind, while the Ans challenge follows a
     /// later prover message, so both must meet the target without PoW credit.
     pub pow_bits: usize,
 
@@ -351,10 +351,10 @@ pub enum StirConfigError {
         max_pow_bits: usize,
     },
 
-    /// A stage's OOD/shake checks fell below the buffered target; these terms receive no
+    /// A stage's OOD/Ans checks fell below the buffered target; these terms receive no
     /// PoW credit.
     #[error(
-        "{stage} OOD/shake checks reach only {unprotected_alg:.4} bits, below the buffered \
+        "{stage} OOD/Ans checks reach only {unprotected_alg:.4} bits, below the buffered \
          target {buffered_security_level}; these challenges are not protected by the \
          query-phase PoW"
     )]
@@ -619,10 +619,10 @@ where
         // summing every algebraic failure mode across the protocol is bounded by
         // `2^{-security_level}`. Exact term count: each of the `total_folds - 1`
         // intermediate rounds has six independent terms (query tier: query
-        // failure, OOD, random-combination, shake-check; folding tier: proximity-gaps,
+        // failure, OOD, random-combination, Ans-check; folding tier: proximity-gaps,
         // sumcheck); the final stage has three (folding tier + final query failure); a
         // `Combine` bucket adds one more (Theorem 7.1's `ε_com` term, §4.5).
-        // The buffer applies to every per-event term. OOD, shake-check, and Combine must
+        // The buffer applies to every per-event term. OOD, Ans-check, and Combine must
         // reach the buffered target algebraically because the query-phase grind does not
         // protect them.
         const TERMS_PER_INTERMEDIATE_ROUND: usize = 6;
@@ -723,7 +723,7 @@ where
         };
 
         // Size eta against both classes of error: PoW-eligible folding/query terms target
-        // `pow_target_bits`, while OOD and shake terms must reach the full buffered target.
+        // `pow_target_bits`, while OOD and Ans terms must reach the full buffered target.
         // Round 0 folds by `log_starting_folding_factor` (k0), not the steady-state
         // `log_folding_factor` used from round 1 on.
         let mut final_eta = params.soundness_type.stir_initial_eta(
@@ -735,7 +735,7 @@ where
             field_size_bits,
         )?;
         // Combine (§4.5) is not PoW-eligible (it runs once, before the query phase's
-        // grind), so — like OOD and shake-check — it must reach the full buffered target
+        // grind), so — like OOD and Ans-check — it must reach the full buffered target
         // on its own. Evaluated at `log_degree`/`log_inv_rate` as they stand here: round
         // 0's own starting degree and rate, matching what Combine merges at (immediately
         // before the round-0 fold).
@@ -1544,7 +1544,7 @@ mod tests {
                     );
                     assert!(
                         unprotected_alg >= buffered - eps,
-                        "{}: OOD/shake={unprotected_alg:.4} < {buffered:.4} without PoW",
+                        "{}: OOD/Ans={unprotected_alg:.4} < {buffered:.4} without PoW",
                         label("intermediate-unprotected"),
                     );
 

--- a/stir/src/error.rs
+++ b/stir/src/error.rs
@@ -99,14 +99,6 @@ pub enum ProofShapeError {
         got: usize,
     },
 
-    /// The shake polynomial is `Ans`'s quotient sum, one degree below `Ans` itself.
-    #[error("{round}: shake polynomial has {got} coefficients, expected at most {maximum}")]
-    ShakePolynomialTooLong {
-        round: RoundLabel,
-        maximum: usize,
-        got: usize,
-    },
-
     /// A committed oracle is read through a Merkle multi-opening the proof must supply.
     #[error("{round}: missing query openings")]
     MissingQueryOpenings { round: RoundLabel },
@@ -251,9 +243,9 @@ pub enum StirError<MmcsError, InputError = ()> {
         source: MmcsError,
     },
 
-    /// The shake polynomial identity failed at the random evaluation point.
-    #[error("{round}: shake polynomial consistency check failed")]
-    InvalidShakeConsistency { round: RoundLabel },
+    /// `Ans` did not interpolate the round's claimed values at the random evaluation point.
+    #[error("{round}: ans polynomial consistency check failed")]
+    InvalidAnsConsistency { round: RoundLabel },
 
     /// A virtual-oracle evaluation landed in the prior round's challenge set.
     #[error("{round}, query {query}: invalid virtual-oracle query")]
@@ -305,7 +297,7 @@ impl<E, IE> StirError<E, IE> {
             Self::InvalidMmcsProof { round, source } => {
                 StirError::InvalidMmcsProof { round, source }
             }
-            Self::InvalidShakeConsistency { round } => StirError::InvalidShakeConsistency { round },
+            Self::InvalidAnsConsistency { round } => StirError::InvalidAnsConsistency { round },
             Self::InvalidRoundConsistency { round, query } => {
                 StirError::InvalidRoundConsistency { round, query }
             }

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -3,13 +3,13 @@
 //! This crate implements the STIR polynomial commitment scheme, a univariate PCS
 //! that achieves shorter proofs than FRI by replacing many direct proximity queries
 //! with a small number of out-of-domain (OOD) samples combined with an answer
-//! polynomial / shake polynomial argument.
+//! polynomial argument.
 //!
 //! # Structure
 //!
 //! - [`config`]: Protocol parameters ([`StirParameters`], [`StirConfig`], [`StirRoundConfig`]).
 //! - [`proof`]: Proof types ([`StirProof`], [`StirRoundProof`], [`StirQueryOpenings`]).
-//! - [`utils`]: Polynomial arithmetic primitives (shake, ans, Horner eval, synthetic division).
+//! - [`utils`]: Polynomial arithmetic primitives (ans, Horner eval, synthetic division).
 //! - [`prover`]: The STIR prover ([`prover::prove_stir`]).
 //! - [`verifier`]: The STIR verifier ([`verifier::verify_stir`]).
 //! - [`error`]: Verification failures ([`StirError`], [`ProofShapeError`]).
@@ -20,10 +20,10 @@
 //! Several deliberate implementation choices differ from the construction stated in
 //! the paper:
 //!
-//! - **Prover-assisted Ans/shake check.** The paper's verifier interpolates `Ans` itself.
-//!   Here the prover sends `Ans` and a shake polynomial, and the verifier checks the
-//!   identity at a transcript-derived random point. Its Schwartz–Zippel error is included
-//!   explicitly in STIR's parameter validation.
+//! - **Prover-assisted Ans check.** The paper's verifier interpolates `Ans` itself. Here the
+//!   prover sends `Ans`, and the verifier checks it against the barycentric interpolant
+//!   through the round's points at a transcript-derived random point. Its Schwartz–Zippel
+//!   error is included explicitly in STIR's parameter validation.
 //! - **Fixed `s` schedule.** OOD sample count is fixed per the paper's recommended schedule
 //!   (`s = 1` for Johnson, `s = 2` for capacity); [`config::StirConfig::new`] does not search
 //!   for the smallest valid `s`.
@@ -39,7 +39,7 @@
 //!   `ceil(log2(6 · total_folds))` buffer to every per-round error term. Each round
 //!   contributes up to six independent algebraic failure modes (query tier: query failure,
 //!   OOD, random-combination,
-//!   shake-check; folding tier: proximity-gaps, sumcheck), so the union bound over the full
+//!   Ans-check; folding tier: proximity-gaps, sumcheck), so the union bound over the full
 //!   protocol is `≤ 6 · total_folds · 2^{-buffered_security_level}`. The paper's "+1 / +0"
 //!   rule only delivers the claimed bits when `total_folds ≤ 2` and per-round terms are
 //!   collapsed; the explicit log keeps deeper protocols tight across every term.

--- a/stir/src/proof.rs
+++ b/stir/src/proof.rs
@@ -62,11 +62,13 @@ pub struct StirRoundProof<EF: Field, M: Mmcs<EF>, Witness> {
     /// Answer polynomial coefficients.
     ///
     /// The unique polynomial `Ans(X)` of degree `< |P|` interpolating `(y_i, v_i)` for every
-    /// `y_i ∈ P` (OOD + queried points) and its claimed value `v_i`. Sent by the prover so the
-    /// verifier avoids the O(|P|²) Newton interpolation; the verifier instead checks
-    /// `Ans(rho)` against the barycentric interpolant through `(y_i, v_i)` at a random `rho`.
-    /// `ans_polynomial` is observed in the transcript before `rho` is sampled, so a malicious
-    /// prover cannot fit `Ans` to a known `rho`.
+    /// `y_i ∈ P` (OOD + queried points) and its claimed value `v_i`. The verifier needs `Ans`
+    /// in coefficient form — every later round evaluates it on each queried fiber — so the
+    /// prover sends the coefficients and the verifier only confirms them, checking `Ans(rho)`
+    /// against the barycentric interpolant through `(y_i, v_i)` at a random `rho` instead of
+    /// rebuilding them by Newton's divided differences. `ans_polynomial` is observed in the
+    /// transcript before `rho` is sampled, so a malicious prover cannot fit `Ans` to a known
+    /// `rho`.
     pub ans_polynomial: Vec<EF>,
 
     /// Merkle openings for the STIR queries, sharing one pruned multi-opening proof.

--- a/stir/src/proof.rs
+++ b/stir/src/proof.rs
@@ -65,10 +65,10 @@ pub struct StirRoundProof<EF: Field, M: Mmcs<EF>, Witness> {
     /// `y_i ∈ P` (OOD + queried points) and its claimed value `v_i`. The verifier needs `Ans`
     /// in coefficient form — every later round evaluates it on each queried fiber — so the
     /// prover sends the coefficients and the verifier only confirms them, checking `Ans(rho)`
-    /// against the barycentric interpolant through `(y_i, v_i)` at a random `rho` instead of
-    /// rebuilding them by Newton's divided differences. `ans_polynomial` is observed in the
-    /// transcript before `rho` is sampled, so a malicious prover cannot fit `Ans` to a known
-    /// `rho`.
+    /// against the barycentric interpolant through `(y_i, v_i)` at a random `rho` at a lower
+    /// constant than rebuilding them by Newton's divided differences. `ans_polynomial` is
+    /// observed in the transcript before `rho` is sampled, so a malicious prover cannot fit
+    /// `Ans` to a known `rho`.
     pub ans_polynomial: Vec<EF>,
 
     /// Merkle openings for the STIR queries, sharing one pruned multi-opening proof.

--- a/stir/src/proof.rs
+++ b/stir/src/proof.rs
@@ -63,18 +63,11 @@ pub struct StirRoundProof<EF: Field, M: Mmcs<EF>, Witness> {
     ///
     /// The unique polynomial `Ans(X)` of degree `< |P|` interpolating `(y_i, v_i)` for every
     /// `y_i ∈ P` (OOD + queried points) and its claimed value `v_i`. Sent by the prover so the
-    /// verifier avoids the O(|P|²) Newton interpolation; correctness against the queried/OOD
-    /// values is enforced together with `shake_polynomial` at a random `rho`.
+    /// verifier avoids the O(|P|²) Newton interpolation; the verifier instead checks
+    /// `Ans(rho)` against the barycentric interpolant through `(y_i, v_i)` at a random `rho`.
+    /// `ans_polynomial` is observed in the transcript before `rho` is sampled, so a malicious
+    /// prover cannot fit `Ans` to a known `rho`.
     pub ans_polynomial: Vec<EF>,
-
-    /// Shake polynomial coefficients.
-    ///
-    /// `S(X) = sum_{y in P} (Ans(X) - Ans(y)) / (X - y)` where `P` is the set of all OOD +
-    /// queried points. Sent by the prover and checked by the verifier at a random evaluation
-    /// point: `S(rho) == sum_i (Ans(rho) - v_i) / (rho - y_i)`. Both `ans_polynomial` and
-    /// `shake_polynomial` are observed in the transcript before `rho` is sampled, so a
-    /// malicious prover cannot fit `Ans` to a known `rho`.
-    pub shake_polynomial: Vec<EF>,
 
     /// Merkle openings for the STIR queries, sharing one pruned multi-opening proof.
     ///

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -295,12 +295,16 @@ where
 
     /// The prefix of `fold_coeffs` that can be non-zero.
     ///
-    /// `fold_coeffs` spans the fold domain, but the folded polynomial's true degree is bounded
-    /// by the round's degree schedule (a fixed factor smaller); evaluating only that prefix
-    /// cuts Horner's work by the same factor.
+    /// `fold_coeffs` runs to whatever length the fold's source implied — the fold domain when
+    /// the round folded a committed codeword, the folded sub-coset when it folded a virtual
+    /// witness — and either can reach past the folded polynomial's true degree, which the
+    /// round's degree schedule bounds. Evaluating only that prefix skips the trailing zeros.
     fn truncated_fold_coeffs(&self) -> &[EF] {
         let rc = &self.config.round_configs[self.round];
         let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);
+        // The clamp below would silently shorten the prefix rather than fail, so the bound is
+        // pinned here.
+        debug_assert!(folded_degree_bound <= self.fold_coeffs.len());
         &self.fold_coeffs[..folded_degree_bound.min(self.fold_coeffs.len())]
     }
 
@@ -406,6 +410,11 @@ where
         let log_witness_len = self.config.round_configs[self.round].log_degree - self.log_arity;
         let log_sub_coset = log_witness_len.max(log_answer_len).min(next_log_domain);
         let sub_coset_len = 1usize << log_sub_coset;
+        // No degree/folding schedule the config can produce makes the cap at the next domain
+        // binding. Were it ever to bind, the sub-coset would silently alias `f_{i+1}` or
+        // truncate the evaluations below rather than fail, so both widths are pinned here.
+        debug_assert!(log_witness_len <= log_sub_coset);
+        debug_assert!(log_answer_len <= log_sub_coset);
 
         let (ans_evals, vanishing_evals) = tracing::debug_span!("eval_low_degree_pair_on_coset")
             .in_scope(|| {
@@ -697,8 +706,13 @@ where
             }
             Oracle::Coeffs(coeffs) => {
                 // The fold's coefficients past `final_len` are zero, since the witness they
-                // come from respects the round's degree bound.
+                // come from respects the round's degree bound. The truncation below would
+                // silently drop a non-zero tail rather than fail, so the bound is pinned here.
                 let mut folded = fold_poly_coeffs(coeffs, final_gamma, final_log_arity);
+                debug_assert!(
+                    folded.len() >= final_len && folded[final_len..].iter().all(|c| c.is_zero()),
+                    "the folded witness must respect the final degree bound"
+                );
                 folded.resize(final_len, EF::ZERO);
                 folded
             }

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -22,9 +22,8 @@ use tracing::instrument;
 use crate::config::StirConfig;
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    compute_shake_polynomial, eval_poly_at_base, eval_poly_parallel, fold_codeword,
-    fold_domain_params, fold_poly_coeffs, interpolate_poly, next_domain_shift, sample_ood_points,
-    vanishing_poly_from_roots,
+    eval_poly_at_base, eval_poly_parallel, fold_codeword, fold_domain_params, fold_poly_coeffs,
+    interpolate_poly, next_domain_shift, sample_ood_points, vanishing_poly_from_roots,
 };
 
 /// Prove that a polynomial (given in coefficient form over `EF`) has low degree,
@@ -162,7 +161,7 @@ struct RoundOutput<F, EF: Field, M: Mmcs<EF>, Witness> {
 ///
 /// The phases, in order: \[grind\] `fold_and_commit` -> absorb commitment -> squeeze OOD points
 /// -> `ood_answers` -> absorb answers -> \[grind\] -> squeeze `r_comb` and query indices ->
-/// `record_queries` -> `ans_shake` -> absorb Ans/shake -> squeeze rho -> `finish`.
+/// `record_queries` -> `answer_poly` -> absorb Ans -> squeeze rho -> `finish`.
 struct RoundProver<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
     config: &'a StirConfig<F, EF, M, Challenger>,
     round: usize,
@@ -190,7 +189,6 @@ struct RoundProver<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
     seen_query_indices: Vec<usize>,
 
     ans_poly: Vec<EF>,
-    shake_poly: Vec<EF>,
     all_points: Vec<EF>,
 }
 
@@ -232,7 +230,6 @@ where
             query_answers: Vec::new(),
             seen_query_indices: Vec::new(),
             ans_poly: Vec::new(),
-            shake_poly: Vec::new(),
             all_points: Vec::new(),
         }
     }
@@ -356,10 +353,10 @@ where
         self.seen_query_indices = seen.into_iter().collect();
     }
 
-    /// Interpolate the answer polynomial and derive the shake polynomial. Both are prover
-    /// messages and must be absorbed by the caller before rho is squeezed — otherwise a
-    /// malicious prover could fit Ans to satisfy the shake identity at a known rho.
-    fn ans_shake(&mut self) -> (&[EF], &[EF]) {
+    /// Interpolate the answer polynomial. It is a prover message and must be absorbed by the
+    /// caller before rho is squeezed — otherwise a malicious prover could fit Ans to satisfy
+    /// the interpolation identity at a known rho.
+    fn answer_poly(&mut self) -> &[EF] {
         self.all_points = self
             .ood_points
             .iter()
@@ -374,8 +371,7 @@ where
             .collect();
 
         self.ans_poly = interpolate_poly(&self.all_points, &all_values);
-        self.shake_poly = compute_shake_polynomial(&self.ans_poly, &self.all_points);
-        (&self.ans_poly, &self.shake_poly)
+        &self.ans_poly
     }
 
     /// Derive the next virtual witness in coefficient form. Touches no transcript state, so it
@@ -486,7 +482,6 @@ where
             next_log_domain,
             seen_query_indices: core::mem::take(&mut self.seen_query_indices),
             ans_poly: core::mem::take(&mut self.ans_poly),
-            shake_poly: core::mem::take(&mut self.shake_poly),
         }
     }
 }
@@ -499,7 +494,6 @@ struct RoundFinish<F, EF: Field, M: Mmcs<EF>> {
     next_log_domain: usize,
     seen_query_indices: Vec<usize>,
     ans_poly: Vec<EF>,
-    shake_poly: Vec<EF>,
 }
 
 /// Prove one intermediate STIR round (Construction 5.2): fold the current oracle, sample OOD
@@ -550,7 +544,7 @@ where
     challenger.observe_algebra_slice(&ood_answers);
 
     // Step 3: query-phase PoW. It protects the immediately following combination challenge
-    // and query indices. It does not strengthen the earlier OOD samples or the later shake
+    // and query indices. It does not strengthen the earlier OOD samples or the later Ans
     // challenge, which is separated from this grind by prover-controlled messages.
     let pow_witness = challenger.grind(rc.pow_bits);
 
@@ -581,14 +575,12 @@ where
             .all(|o| o.row_evals.iter().all(|row| row.len() == arity))
     );
 
-    // Step 4: Answer polynomial, shake polynomial, and shake-check challenge.
-    let (ans_poly, shake_poly) = state.ans_shake();
+    // Step 4: Answer polynomial and its consistency challenge.
     // Bind ans_poly into the transcript BEFORE rho is sampled — otherwise a malicious prover
-    // could fit Ans to satisfy the shake identity at a known rho.
-    challenger.observe_algebra_slice(ans_poly);
-    challenger.observe_algebra_slice(shake_poly);
+    // could fit Ans to satisfy the interpolation identity at a known rho.
+    challenger.observe_algebra_slice(state.answer_poly());
 
-    // Sample and discard the shake-check challenge so the transcript state
+    // Sample and discard the Ans-consistency challenge so the transcript state
     // stays consistent with the verifier.
     let _rho: EF = challenger.sample_algebra_element();
 
@@ -603,7 +595,6 @@ where
             ood_answers,
             pow_witness,
             ans_polynomial: finish.ans_poly,
-            shake_polynomial: finish.shake_poly,
             query_openings,
         },
         next_oracle: finish.next_oracle,
@@ -1114,7 +1105,7 @@ where
             })
             .collect();
 
-        // Phase 4: per-instance answer/shake polynomial absorb and shake-check challenge.
+        // Phase 4: per-instance answer-polynomial absorb and consistency challenge.
         struct Phase4<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
             rp: RoundProver<'a, F, EF, Dft, M, Challenger>,
             commit: M::Commitment,
@@ -1126,11 +1117,7 @@ where
             .into_iter()
             .map(|p| {
                 let mut rp = p.rp;
-                let (ans, shake) = rp.ans_shake();
-                let ans = ans.to_vec();
-                let shake = shake.to_vec();
-                challenger.observe_algebra_slice(&ans);
-                challenger.observe_algebra_slice(&shake);
+                challenger.observe_algebra_slice(rp.answer_poly());
                 let _rho: EF = challenger.sample_algebra_element();
                 Phase4 {
                     rp,
@@ -1151,7 +1138,6 @@ where
                 ood_answers: p.ood_answers,
                 pow_witness,
                 ans_polynomial: finish.ans_poly,
-                shake_polynomial: finish.shake_poly,
                 query_openings: p.query_openings,
             });
             if r == offset(i) {
@@ -1429,9 +1415,9 @@ where
 /// Recover polynomial coefficients from a natural-order codeword on coset `shift * <g>`.
 ///
 /// The returned vector has length `codeword.len()`. Trailing zero coefficients are not
-/// stripped: callers downstream (`add_polys`, `codeword_from_coeffs`) either handle
-/// variable-length inputs or explicitly resize, and a content-dependent length here
-/// would make the contract brittle against future refactors.
+/// stripped: downstream callers either handle variable-length inputs or explicitly resize,
+/// and a content-dependent length here would make the contract brittle against future
+/// refactors.
 pub fn coeffs_from_codeword<F, EF, Dft>(dft: &Dft, codeword: &[EF], shift: F) -> Vec<EF>
 where
     F: TwoAdicField,

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -22,8 +22,9 @@ use tracing::instrument;
 use crate::config::StirConfig;
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    compute_shake_polynomial, eval_poly_parallel, fold_codeword, fold_domain_params,
-    interpolate_poly, next_domain_shift, sample_ood_points, vanishing_poly_from_roots,
+    compute_shake_polynomial, eval_poly_at_base, eval_poly_parallel, fold_codeword,
+    fold_domain_params, fold_poly_coeffs, interpolate_poly, next_domain_shift, sample_ood_points,
+    vanishing_poly_from_roots,
 };
 
 /// Prove that a polynomial (given in coefficient form over `EF`) has low degree,
@@ -126,10 +127,23 @@ where
     prove_stir_inner(config, initial_codeword, dft, challenger, true)
 }
 
+/// The oracle a STIR round folds.
+///
+/// Only the initial oracle is committed and opened, so only it has to be held on its whole
+/// domain. Every later oracle is virtual — the next round folds it and nothing else reads it —
+/// so it is carried in coefficient form, whose length is the degree bound rather than the
+/// blown-up domain size.
+enum Oracle<EF> {
+    /// A natural-order codeword on the round's domain.
+    Evals(Vec<EF>),
+    /// Coefficients of the round's virtual witness, in ascending degree order.
+    Coeffs(Vec<EF>),
+}
+
 /// Output of proving one intermediate STIR round.
 struct RoundOutput<F, EF: Field, M: Mmcs<EF>, Witness> {
     proof: StirRoundProof<EF, M, Witness>,
-    next_codeword: Vec<EF>,
+    next_oracle: Oracle<EF>,
     next_commit_data: M::ProverData<RowMajorMatrix<EF>>,
     next_shift: F,
     next_log_domain: usize,
@@ -160,7 +174,9 @@ struct RoundProver<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
     next_log_domain: usize,
     next_shift: F,
 
-    folded_codeword: Vec<EF>,
+    /// The folded oracle on the fold-query domain, present only when the fold ran in
+    /// evaluation form and therefore already materialized every fold-domain value.
+    folded_codeword: Option<Vec<EF>>,
     fold_coeffs: Vec<EF>,
     next_commit_codeword: Vec<EF>,
     new_data: Option<M::ProverData<RowMajorMatrix<EF>>>,
@@ -205,7 +221,7 @@ where
             fold_shift,
             next_log_domain: current_log_domain - 1,
             next_shift: next_domain_shift(current_shift, log_arity),
-            folded_codeword: Vec::new(),
+            folded_codeword: None,
             fold_coeffs: Vec::new(),
             next_commit_codeword: Vec::new(),
             new_data: None,
@@ -225,24 +241,26 @@ where
     /// first prover message and must be absorbed by the caller.
     fn fold_and_commit(
         &mut self,
-        current_oracle_codeword: &[EF],
+        current_oracle: &Oracle<EF>,
         current_shift: F,
         current_log_domain: usize,
         gamma: EF,
     ) -> M::Commitment {
-        // `fold_codeword` interpolates at subgroup coordinates `g^{·}`. The codeword
-        // lives on the coset `current_shift · <g>`, so passing `gamma / current_shift`
-        // yields exactly Construction 4.5's coset fold at challenge `gamma`.
-        let fold_beta = gamma * EF::from(current_shift.inverse());
-        self.folded_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
-            fold_codeword::<F, EF>(
-                current_oracle_codeword,
-                fold_beta,
-                self.log_arity,
-                current_log_domain,
-            )
-        });
-        self.fold_coeffs = coeffs_from_codeword(self.dft, &self.folded_codeword, self.fold_shift);
+        self.fold_coeffs = match current_oracle {
+            Oracle::Evals(codeword) => {
+                // `fold_codeword` interpolates at subgroup coordinates `g^{·}`. The codeword
+                // lives on the coset `current_shift · <g>`, so passing `gamma / current_shift`
+                // yields exactly Construction 4.5's coset fold at challenge `gamma`.
+                let fold_beta = gamma * EF::from(current_shift.inverse());
+                let folded = tracing::debug_span!("fold_codeword").in_scope(|| {
+                    fold_codeword::<F, EF>(codeword, fold_beta, self.log_arity, current_log_domain)
+                });
+                let coeffs = coeffs_from_codeword(self.dft, &folded, self.fold_shift);
+                self.folded_codeword = Some(folded);
+                coeffs
+            }
+            Oracle::Coeffs(coeffs) => fold_poly_coeffs(coeffs, gamma, self.log_arity),
+        };
 
         self.next_commit_codeword = codeword_from_coeffs(
             self.dft,
@@ -278,23 +296,28 @@ where
         ]
     }
 
+    /// The prefix of `fold_coeffs` that can be non-zero.
+    ///
+    /// `fold_coeffs` spans the fold domain, but the folded polynomial's true degree is bounded
+    /// by the round's degree schedule (a fixed factor smaller); evaluating only that prefix
+    /// cuts Horner's work by the same factor.
+    fn truncated_fold_coeffs(&self) -> &[EF] {
+        let rc = &self.config.round_configs[self.round];
+        let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);
+        &self.fold_coeffs[..folded_degree_bound.min(self.fold_coeffs.len())]
+    }
+
     /// Evaluate the folded polynomial at the sampled OOD points. The answers are the round's
     /// second prover message and must be absorbed by the caller.
     fn ood_answers(&mut self, ood_points: Vec<EF>) -> &[EF] {
-        // `fold_coeffs` is padded to the next round's full domain size, but the folded
-        // polynomial's true degree is bounded by the round's degree schedule (a fixed
-        // factor smaller); evaluating only the non-trivially-zero prefix cuts Horner's
-        // work by that same factor.
-        let rc = &self.config.round_configs[self.round];
-        let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);
-        let truncated = &self.fold_coeffs[..folded_degree_bound.min(self.fold_coeffs.len())];
-
-        self.ood_points = ood_points;
-        self.ood_answers = self
-            .ood_points
+        let truncated = self.truncated_fold_coeffs();
+        let ood_answers = ood_points
             .iter()
             .map(|&z| eval_poly_parallel(truncated, z))
             .collect();
+
+        self.ood_points = ood_points;
+        self.ood_answers = ood_answers;
         &self.ood_answers
     }
 
@@ -303,13 +326,32 @@ where
         let fold_gen = F::two_adic_generator(self.fold_log_domain);
         let mut seen: alloc::collections::BTreeSet<usize> = alloc::collections::BTreeSet::new();
 
+        let mut unique_indices: Vec<usize> = Vec::new();
         for &j in &query_indices {
             if seen.insert(j) {
-                self.query_points
-                    .push(EF::from(self.fold_shift) * EF::from(fold_gen.exp_u64(j as u64)));
-                self.query_answers.push(self.folded_codeword[j]);
+                unique_indices.push(j);
             }
         }
+        // The queried fold-domain points are base-field elements, so a coefficient-form
+        // evaluation below runs as extension-by-base Horner.
+        let query_base_points: Vec<F> = unique_indices
+            .iter()
+            .map(|&j| self.fold_shift * fold_gen.exp_u64(j as u64))
+            .collect();
+
+        let truncated = self.truncated_fold_coeffs();
+        let query_answers: Vec<EF> = self.folded_codeword.as_ref().map_or_else(
+            || {
+                query_base_points
+                    .par_iter()
+                    .map(|&x| eval_poly_at_base(truncated, x))
+                    .collect()
+            },
+            |codeword| unique_indices.iter().map(|&j| codeword[j]).collect(),
+        );
+
+        self.query_answers = query_answers;
+        self.query_points = query_base_points.into_iter().map(EF::from).collect();
         self.query_indices = query_indices;
         self.seen_query_indices = seen.into_iter().collect();
     }
@@ -336,18 +378,25 @@ where
         (&self.ans_poly, &self.shake_poly)
     }
 
-    /// Evaluate the next virtual witness on the next round's domain. Touches no transcript
-    /// state, so it may run after the caller has moved on to other instances.
+    /// Derive the next virtual witness in coefficient form. Touches no transcript state, so it
+    /// may run after the caller has moved on to other instances.
     fn finish(mut self, r_comb: EF) -> RoundFinish<F, EF, M> {
         // Construction 5.2: f_{i+1} = DegCor((g_i − Ans_i) / Z_{G_i}).
+        //
+        // f_{i+1} is virtual: it is never committed, never opened, and only ever folded by the
+        // next round, whose fold is a coefficient regroup. Its degree is bounded by the round's
+        // degree schedule, so it is already determined by its values on a sub-coset of L_{i+1}
+        // of that size — every `stride`-th natural-order point, which is exactly the subgroup
+        // coset of that size. Quotient, degree correction, and the inverse transform back to
+        // coefficients therefore run on the sub-coset rather than on all of L_{i+1}.
         //
         // DegCor(x) = (1 - (r_comb*x)^{gap+1}) / (1 - r_comb*x) is geometric in x over the
         // coset (base-field ratio, EF-valued start), so it is evaluated pointwise via two
         // `Powers` sweeps instead of a third DFT; its `(1 - r_comb*x)` denominator is folded
         // into the vanishing-polynomial batch inversion below (one inversion, not two). Ans
         // and the vanishing polynomial still need evaluating — their roots are this round's
-        // arbitrary interpolation points — but both are tiny next to the domain, so they go
-        // through the low-degree coset evaluation rather than a full-size DFT each.
+        // arbitrary interpolation points — but both go through the low-degree coset evaluation
+        // rather than a full-size DFT each.
         let all_points = core::mem::take(&mut self.all_points);
         let next_shift = self.next_shift;
         let next_log_domain = self.next_log_domain;
@@ -355,8 +404,13 @@ where
 
         let vanishing_coeffs = vanishing_poly_from_roots(&all_points);
         // Ans interpolates `num_answers` points and the vanishing polynomial has exactly
-        // `num_answers + 1` coefficients.
-        let log_answer_len = log2_ceil_usize(num_answers + 1).min(next_log_domain);
+        // `num_answers + 1` coefficients, so the sub-coset has to be at least that wide for
+        // the evaluations below to be the polynomials themselves rather than a truncation.
+        let log_answer_len = log2_ceil_usize(num_answers + 1);
+        let log_witness_len = self.config.round_configs[self.round].log_degree - self.log_arity;
+        let log_sub_coset = log_witness_len.max(log_answer_len).min(next_log_domain);
+        let sub_coset_len = 1usize << log_sub_coset;
+
         let (ans_evals, vanishing_evals) = tracing::debug_span!("eval_low_degree_pair_on_coset")
             .in_scope(|| {
                 eval_low_degree_pair_on_coset(
@@ -364,61 +418,69 @@ where
                     &self.ans_poly,
                     &vanishing_coeffs,
                     next_shift,
-                    next_log_domain,
-                    log_answer_len,
+                    log_sub_coset,
+                    log_answer_len.min(log_sub_coset),
                 )
             });
 
-        // x_j = next_shift * g^j, so step_j = r_comb * x_j = step_start * g^j, and the degree
-        // correction's numerator sweeps the same coset at stride `num_answers + 1`. Both are
-        // geometric with a base-field ratio, so each chunk seeds one exponentiation and then
-        // advances by a base-field multiply: no power tables, and no ext-by-ext products.
+        // x_m = next_shift * g^m over the sub-coset, so step_m = r_comb * x_m = step_start *
+        // g^m, and the degree correction's numerator sweeps the same coset at stride
+        // `num_answers + 1`. Both are geometric with a base-field ratio, so each chunk seeds
+        // one exponentiation and then advances by a base-field multiply: no power tables, and
+        // no ext-by-ext products.
         const POWER_CHUNK: usize = 1 << 12;
-        let g_next = F::two_adic_generator(next_log_domain);
-        let g_next_hi = g_next.exp_u64((num_answers + 1) as u64);
+        let g_sub = F::two_adic_generator(log_sub_coset);
+        let g_sub_hi = g_sub.exp_u64((num_answers + 1) as u64);
         let step_start = r_comb * next_shift;
         let step_start_hi = step_start.exp_u64((num_answers + 1) as u64);
 
         // The quotient denominators are the vanishing evaluations scaled by the degree
         // correction's `(1 - step)` denominator, so they are formed in place.
-        let next_oracle_codeword = tracing::debug_span!("quotient_sweep").in_scope(|| {
+        let next_oracle_evals = tracing::debug_span!("quotient_sweep").in_scope(|| {
             let mut combined_denoms = vanishing_evals;
             combined_denoms
                 .par_chunks_mut(POWER_CHUNK)
                 .enumerate()
                 .for_each(|(chunk_idx, chunk)| {
-                    let mut step = step_start * g_next.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                    let mut step = step_start * g_sub.exp_u64((chunk_idx * POWER_CHUNK) as u64);
                     for denom in chunk.iter_mut() {
                         *denom *= EF::ONE - step;
-                        step *= g_next;
+                        step *= g_sub;
                     }
                 });
             let combined_inverses = batch_multiplicative_inverse(&combined_denoms);
             drop(combined_denoms);
 
-            // `commit_as_fiber_matrix` has already copied the committed codeword into the
-            // Merkle tree, so the next oracle is formed in place over it.
-            let mut next_oracle_codeword = core::mem::take(&mut self.next_commit_codeword);
-            next_oracle_codeword
+            let stride = 1usize << (next_log_domain - log_sub_coset);
+            let commit_codeword = core::mem::take(&mut self.next_commit_codeword);
+            let mut next_oracle_evals: Vec<EF> = (0..sub_coset_len)
+                .into_par_iter()
+                .map(|m| commit_codeword[m * stride])
+                .collect();
+            drop(commit_codeword);
+
+            next_oracle_evals
                 .par_chunks_mut(POWER_CHUNK)
                 .zip(ans_evals.par_chunks(POWER_CHUNK))
                 .zip(combined_inverses.par_chunks(POWER_CHUNK))
                 .enumerate()
                 .for_each(|(chunk_idx, ((chunk, ans_chunk), inverse_chunk))| {
                     let mut numerator_step =
-                        step_start_hi * g_next_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                        step_start_hi * g_sub_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
                     for ((value, &ans), &inverse) in
                         chunk.iter_mut().zip(ans_chunk).zip(inverse_chunk)
                     {
                         *value = (*value - ans) * inverse * (EF::ONE - numerator_step);
-                        numerator_step *= g_next_hi;
+                        numerator_step *= g_sub_hi;
                     }
                 });
-            next_oracle_codeword
+            next_oracle_evals
         });
 
+        let next_coeffs = coeffs_from_codeword(self.dft, &next_oracle_evals, next_shift);
+
         RoundFinish {
-            next_codeword: next_oracle_codeword,
+            next_oracle: Oracle::Coeffs(next_coeffs),
             next_commit_data: self.new_data.take().expect("set by `fold_and_commit`"),
             next_shift,
             next_log_domain,
@@ -431,7 +493,7 @@ where
 
 /// Everything a finished round hands back once its transcript phases are done.
 struct RoundFinish<F, EF: Field, M: Mmcs<EF>> {
-    next_codeword: Vec<EF>,
+    next_oracle: Oracle<EF>,
     next_commit_data: M::ProverData<RowMajorMatrix<EF>>,
     next_shift: F,
     next_log_domain: usize,
@@ -450,7 +512,7 @@ fn prove_round<F, EF, Dft, M, Challenger>(
     round: usize,
     dft: &Dft,
     challenger: &mut Challenger,
-    current_oracle_codeword: &[EF],
+    current_oracle: &Oracle<EF>,
     current_shift: F,
     current_log_domain: usize,
     current_commit_data: Option<&M::ProverData<RowMajorMatrix<EF>>>,
@@ -474,12 +536,8 @@ where
     let folding_pow_witness = challenger.grind(rc.folding_pow_bits);
     let gamma: EF = challenger.sample_algebra_element();
 
-    let new_commit = state.fold_and_commit(
-        current_oracle_codeword,
-        current_shift,
-        current_log_domain,
-        gamma,
-    );
+    let new_commit =
+        state.fold_and_commit(current_oracle, current_shift, current_log_domain, gamma);
     challenger.observe(new_commit.clone());
 
     // Step 2: OOD sampling.
@@ -534,16 +592,8 @@ where
     // stays consistent with the verifier.
     let _rho: EF = challenger.sample_algebra_element();
 
-    // Step 5: Construction 5.2 — evaluate the next virtual witness directly on L_{i+1}:
-    // f_{i+1} = DegCor((g_i − Ans_i) / Z_{G_i}).
-    //
-    // DegCor(x) = (1 - (r_comb*x)^{gap+1}) / (1 - r_comb*x) is geometric in x over the
-    // coset (base-field ratio, EF-valued start), so it is evaluated pointwise via two
-    // `Powers` sweeps instead of a third DFT; its `(1 - r_comb*x)` denominator is folded
-    // into the vanishing-polynomial batch inversion below (one inversion, not two). Ans
-    // and the vanishing polynomial still need evaluating — their roots are this round's
-    // arbitrary interpolation points — but both are tiny next to the domain, so they go
-    // through the low-degree coset evaluation rather than a full-size DFT each.
+    // Step 5: Construction 5.2 — derive the next virtual witness
+    // f_{i+1} = DegCor((g_i − Ans_i) / Z_{G_i}) in coefficient form.
     let finish = state.finish(r_comb);
 
     RoundOutput {
@@ -556,7 +606,7 @@ where
             shake_polynomial: finish.shake_poly,
             query_openings,
         },
-        next_codeword: finish.next_codeword,
+        next_oracle: finish.next_oracle,
         next_commit_data: finish.next_commit_data,
         next_shift: finish.next_shift,
         next_log_domain: finish.next_log_domain,
@@ -588,7 +638,6 @@ struct FinalRoundProver<'a, F, EF: Field, Dft, M: Mmcs<EF>, Challenger> {
     final_new_log_domain: usize,
     final_new_shift: F,
 
-    final_codeword: Vec<EF>,
     final_poly: Vec<EF>,
 
     query_indices: Vec<usize>,
@@ -620,7 +669,6 @@ where
             current_log_domain,
             final_new_log_domain,
             final_new_shift,
-            final_codeword: Vec::new(),
             final_poly: Vec::new(),
             query_indices: Vec::new(),
             seen_query_indices: Vec::new(),
@@ -629,30 +677,41 @@ where
 
     /// Fold at `final_gamma` and derive the final polynomial. The returned coefficients are
     /// the round's only prover message and must be absorbed by the caller.
-    fn fold_and_derive(&mut self, current_oracle_codeword: &[EF], final_gamma: EF) -> &[EF] {
+    fn fold_and_derive(&mut self, current_oracle: &Oracle<EF>, final_gamma: EF) -> &[EF] {
         let final_log_arity = self.config.final_log_folding_factor();
-        // See the round-fold note in `RoundProver::fold_and_commit`: `gamma / current_shift`
-        // over subgroup coordinates is the paper's coset fold at challenge `gamma`.
-        let final_fold_beta = final_gamma * EF::from(self.current_shift.inverse());
-        self.final_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
-            fold_codeword::<F, EF>(
-                current_oracle_codeword,
-                final_fold_beta,
-                final_log_arity,
-                self.current_log_domain,
-            )
-        });
-        // The final polynomial has only `final_len` coefficients, far fewer than
-        // `final_codeword`'s full domain size. Rather than run a full-size iDFT and discard
-        // the (necessarily zero) high coefficients, gather a `final_len`-sized coset — every
-        // `stride`-th natural-order point, which is exactly the subgroup coset of that size —
-        // and run the small iDFT directly on it.
         let final_len = self.config.final_poly_len();
-        let stride = self.final_codeword.len() / final_len;
-        let final_poly_evals: Vec<EF> = (0..final_len)
-            .map(|i| self.final_codeword[i * stride])
-            .collect();
-        self.final_poly = coeffs_from_codeword(self.dft, &final_poly_evals, self.final_new_shift);
+        self.final_poly = match current_oracle {
+            Oracle::Evals(codeword) => {
+                // See the round-fold note in `RoundProver::fold_and_commit`:
+                // `gamma / current_shift` over subgroup coordinates is the paper's coset fold
+                // at challenge `gamma`.
+                let final_fold_beta = final_gamma * EF::from(self.current_shift.inverse());
+                let final_codeword = tracing::debug_span!("fold_codeword").in_scope(|| {
+                    fold_codeword::<F, EF>(
+                        codeword,
+                        final_fold_beta,
+                        final_log_arity,
+                        self.current_log_domain,
+                    )
+                });
+                // The final polynomial has only `final_len` coefficients, far fewer than
+                // `final_codeword`'s full domain size. Rather than run a full-size iDFT and
+                // discard the (necessarily zero) high coefficients, gather a `final_len`-sized
+                // coset — every `stride`-th natural-order point, which is exactly the subgroup
+                // coset of that size — and run the small iDFT directly on it.
+                let stride = final_codeword.len() / final_len;
+                let final_poly_evals: Vec<EF> =
+                    (0..final_len).map(|i| final_codeword[i * stride]).collect();
+                coeffs_from_codeword(self.dft, &final_poly_evals, self.final_new_shift)
+            }
+            Oracle::Coeffs(coeffs) => {
+                // The fold's coefficients past `final_len` are zero, since the witness they
+                // come from respects the round's degree bound.
+                let mut folded = fold_poly_coeffs(coeffs, final_gamma, final_log_arity);
+                folded.resize(final_len, EF::ZERO);
+                folded
+            }
+        };
         &self.final_poly
     }
 
@@ -689,7 +748,7 @@ fn prove_final_round<F, EF, Dft, M, Challenger>(
     config: &StirConfig<F, EF, M, Challenger>,
     dft: &Dft,
     challenger: &mut Challenger,
-    current_oracle_codeword: &[EF],
+    current_oracle: &Oracle<EF>,
     current_shift: F,
     current_log_domain: usize,
     current_commit_data: Option<&M::ProverData<RowMajorMatrix<EF>>>,
@@ -710,7 +769,7 @@ where
     let final_folding_pow_witness = challenger.grind(config.final_folding_pow_bits);
     let final_gamma: EF = challenger.sample_algebra_element();
 
-    let final_poly = state.fold_and_derive(current_oracle_codeword, final_gamma);
+    let final_poly = state.fold_and_derive(current_oracle, final_gamma);
     challenger.observe_algebra_slice(final_poly);
 
     let final_pow_witness = challenger.grind(config.final_pow_bits);
@@ -787,7 +846,7 @@ where
         (None, None)
     };
 
-    let mut current_oracle_codeword = initial_codeword;
+    let mut current_oracle = Oracle::Evals(initial_codeword);
     let mut current_shift = initial_shift;
     let mut current_log_domain = log_initial_domain;
 
@@ -805,7 +864,7 @@ where
             round,
             dft,
             challenger,
-            &current_oracle_codeword,
+            &current_oracle,
             current_shift,
             current_log_domain,
             current_commit_data.as_ref(),
@@ -816,7 +875,7 @@ where
         }
 
         round_proofs.push(output.proof);
-        current_oracle_codeword = output.next_codeword;
+        current_oracle = output.next_oracle;
         current_commit_data = Some(output.next_commit_data);
         current_shift = output.next_shift;
         current_log_domain = output.next_log_domain;
@@ -827,7 +886,7 @@ where
         config,
         dft,
         challenger,
-        &current_oracle_codeword,
+        &current_oracle,
         current_shift,
         current_log_domain,
         current_commit_data.as_ref(),
@@ -855,7 +914,7 @@ type StirMultiOutput<EF, M, Witness> = Vec<(StirProof<EF, M, Witness>, Vec<usize
 
 /// Per-instance mutable state threaded through [`prove_stir_multi_inner`]'s round loop.
 struct MultiInstanceState<F, EF: Field, M: Mmcs<EF>> {
-    codeword: Vec<EF>,
+    oracle: Oracle<EF>,
     shift: F,
     log_domain: usize,
     commit_data: Option<M::ProverData<RowMajorMatrix<EF>>>,
@@ -924,7 +983,7 @@ where
             (None, None)
         };
         states.push(MultiInstanceState {
-            codeword,
+            oracle: Oracle::Evals(codeword),
             shift: F::GENERATOR,
             log_domain: log_initial_domain,
             commit_data,
@@ -966,7 +1025,7 @@ where
                 );
                 let gamma: EF = challenger.sample_algebra_element();
                 let commit = rp.fold_and_commit(
-                    &states[i].codeword,
+                    &states[i].oracle,
                     states[i].shift,
                     states[i].log_domain,
                     gamma,
@@ -1098,7 +1157,7 @@ where
             if r == offset(i) {
                 states[i].first_round_query_indices = finish.seen_query_indices;
             }
-            states[i].codeword = finish.next_codeword;
+            states[i].oracle = finish.next_oracle;
             states[i].commit_data = Some(finish.next_commit_data);
             states[i].shift = finish.next_shift;
             states[i].log_domain = finish.next_log_domain;
@@ -1118,7 +1177,7 @@ where
     for i in 0..b {
         let mut frp = FinalRoundProver::new(configs[i], dft, states[i].shift, states[i].log_domain);
         let final_gamma: EF = challenger.sample_algebra_element();
-        let final_poly = frp.fold_and_derive(&states[i].codeword, final_gamma);
+        let final_poly = frp.fold_and_derive(&states[i].oracle, final_gamma);
         challenger.observe_algebra_slice(final_poly);
         final_provers.push(frp);
     }

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -302,10 +302,7 @@ where
     fn truncated_fold_coeffs(&self) -> &[EF] {
         let rc = &self.config.round_configs[self.round];
         let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);
-        // The clamp below would silently shorten the prefix rather than fail, so the bound is
-        // pinned here.
-        debug_assert!(folded_degree_bound <= self.fold_coeffs.len());
-        &self.fold_coeffs[..folded_degree_bound.min(self.fold_coeffs.len())]
+        &self.fold_coeffs[..folded_degree_bound]
     }
 
     /// Evaluate the folded polynomial at the sampled OOD points. The answers are the round's
@@ -408,13 +405,16 @@ where
         // the evaluations below to be the polynomials themselves rather than a truncation.
         let log_answer_len = log2_ceil_usize(num_answers + 1);
         let log_witness_len = self.config.round_configs[self.round].log_degree - self.log_arity;
-        let log_sub_coset = log_witness_len.max(log_answer_len).min(next_log_domain);
+        let log_sub_coset = log_witness_len.max(log_answer_len);
         let sub_coset_len = 1usize << log_sub_coset;
-        // No degree/folding schedule the config can produce makes the cap at the next domain
-        // binding. Were it ever to bind, the sub-coset would silently alias `f_{i+1}` or
-        // truncate the evaluations below rather than fail, so both widths are pinned here.
-        debug_assert!(log_witness_len <= log_sub_coset);
-        debug_assert!(log_answer_len <= log_sub_coset);
+        // No degree/folding schedule the config can produce makes this bind, but were it ever
+        // to, a clamp here would silently alias `f_{i+1}` or truncate the evaluations below
+        // rather than fail, producing a well-formed proof no verifier accepts several rounds
+        // downstream. Checked directly instead.
+        assert!(
+            log_sub_coset <= next_log_domain,
+            "sub-coset wider than L_{{i+1}}"
+        );
 
         let (ans_evals, vanishing_evals) = tracing::debug_span!("eval_low_degree_pair_on_coset")
             .in_scope(|| {
@@ -706,11 +706,14 @@ where
             }
             Oracle::Coeffs(coeffs) => {
                 // The fold's coefficients past `final_len` are zero, since the witness they
-                // come from respects the round's degree bound. The truncation below would
-                // silently drop a non-zero tail rather than fail, so the bound is pinned here.
+                // come from respects the round's degree bound. `resize` below zero-pads a
+                // short input harmlessly but silently truncates a non-zero tail from a long
+                // one, dropping real degree, so the length is checked directly and only the
+                // (cheaper) zero-tail claim is left to a debug assert.
                 let mut folded = fold_poly_coeffs(coeffs, final_gamma, final_log_arity);
+                assert!(folded.len() >= final_len);
                 debug_assert!(
-                    folded.len() >= final_len && folded[final_len..].iter().all(|c| c.is_zero()),
+                    folded[final_len..].iter().all(|c| c.is_zero()),
                     "the folded witness must respect the final degree bound"
                 );
                 folded.resize(final_len, EF::ZERO);

--- a/stir/src/soundness.rs
+++ b/stir/src/soundness.rs
@@ -181,7 +181,13 @@ fn combine_error_at_log_eta(
     )
 }
 
-fn shake_check_error(field_size_bits: usize, num_queries: usize, num_ood_samples: usize) -> f64 {
+/// Bits of security in the verifier's one-point check that `Ans` interpolates the round's
+/// `num_queries + num_ood_samples` claimed values.
+///
+/// `Ans` and the interpolant both have degree `< num_points`, so Schwartz–Zippel bounds the
+/// check's failure probability by `(num_points - 1) / |F|`. The `2 * num_points / |F|` charged
+/// here is a strict over-estimate of that, and so a conservative bound on the bits delivered.
+fn ans_check_error(field_size_bits: usize, num_queries: usize, num_ood_samples: usize) -> f64 {
     let num_points = (num_queries + num_ood_samples) as f64;
     field_size_bits as f64 - libm::log2(2. * num_points).max(0.)
 }
@@ -381,7 +387,7 @@ impl StirSoundness for SecurityAssumption {
     /// that automatic rather than a second value to keep in sync.
     ///
     /// Combine runs once, before the query phase's grind, so it is not PoW-eligible and
-    /// `target_bits` must be the full buffered target, as for OOD and the shake check.
+    /// `target_bits` must be the full buffered target, as for OOD and the Ans check.
     ///
     /// `CapacityBound` additionally carries Lemma 7.3's `delta < 1 - rho - 1/|L_0|` side
     /// condition, which under `delta = 1 - rho - eta` is the floor `eta >= 2/|L_0|` — the same
@@ -504,8 +510,8 @@ impl StirSoundness for SecurityAssumption {
             num_ood_samples,
             libm::log2(eta),
         );
-        let shake = shake_check_error(field_size_bits, num_queries, num_ood_samples);
-        ood.min(shake)
+        let ans_check = ans_check_error(field_size_bits, num_queries, num_ood_samples);
+        ood.min(ans_check)
     }
 
     fn stir_final_query_algebraic_bits(
@@ -676,7 +682,7 @@ mod tests {
     }
 
     #[test]
-    fn query_pow_does_not_credit_ood_or_shake_checks() {
+    fn query_pow_does_not_credit_ood_or_ans_checks() {
         let cb = SecurityAssumption::CapacityBound;
         let eligible = cb.stir_query_pow_eligible_bits(124, 20, 2, 0.01, 40, 2);
         let unprotected = cb.stir_query_unprotected_bits(124, 20, 2, 0.01, 40, 2);
@@ -686,7 +692,7 @@ mod tests {
         assert_eq!(
             unprotected,
             cb.ood_error_at_log_eta(20, 2, 124, 2, libm::log2(0.01))
-                .min(shake_check_error(124, 40, 2))
+                .min(ans_check_error(124, 40, 2))
         );
     }
 

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -2,8 +2,8 @@
 //!
 //! Provides the core operations over coefficient-form polynomials needed by the
 //! STIR prover and verifier: Horner evaluation, synthetic division, polynomial
-//! addition, Newton interpolation, shake polynomial construction, and the
-//! verifier-side shake consistency check.
+//! addition, Newton interpolation, and the verifier-side check that the prover's
+//! answer polynomial interpolates the round's claimed values.
 
 use alloc::vec;
 use alloc::vec::Vec;
@@ -348,27 +348,6 @@ where
     ood_points
 }
 
-/// Compute the shake polynomial for a set of evaluation points.
-///
-/// Given an answer polynomial `ans(X)` and the set `P = {y_1, ..., y_m}` of evaluation
-/// points where `ans(y_i)` is known, the **shake polynomial** is defined as:
-///
-/// ```text
-/// S(X) = sum_{y in P} (ans(X) - ans(y)) / (X - y)
-/// ```
-///
-/// Each term `(ans(X) - ans(y)) / (X - y)` is the result of synthetic division of
-/// `ans(X) - ans(y)` (a polynomial with a known root at `y`) by `(X - y)`.
-///
-/// The shake polynomial enables the verifier to check that `ans` correctly interpolates
-/// all `(y_i, ans(y_i))` pairs without recomputing a full Lagrange interpolation.
-pub fn compute_shake_polynomial<F: Field>(ans: &[F], points: &[F]) -> Vec<F> {
-    points
-        .iter()
-        .map(|&y| divide_by_linear(ans, y).0)
-        .fold(vec![], |acc, q| add_polys(&acc, &q))
-}
-
 /// Interpolate a polynomial through the given `(points, values)` pairs.
 ///
 /// Uses Newton's divided-difference method.
@@ -451,44 +430,68 @@ pub fn interpolate_poly<F: Field>(points: &[F], values: &[F]) -> Vec<F> {
     coeffs
 }
 
-/// Verify shake polynomial consistency at a random point `rho`.
+/// Verify at a random point `rho` that `ans` interpolates `(points, values)`.
 ///
-/// Checks that `S(rho) == sum_{y in P} (ans(rho) - val_y) / (rho - y)` using batch inversion.
+/// `ans` is compared against the barycentric form of the unique polynomial `I` of degree
+/// `< n` through the `n` pairs `(y_i, v_i)`:
 ///
-/// Returns `true` if the check passes.
-pub fn check_shake_consistency<F: Field>(
-    ans: &[F],
-    shake: &[F],
-    points: &[F],
-    values: &[F],
-    rho: F,
-) -> bool {
+/// ```text
+/// I(rho) = (sum_i w_i v_i / (rho - y_i)) / (sum_i w_i / (rho - y_i)),
+/// w_i = 1 / prod_{j != i} (y_i - y_j)
+/// ```
+///
+/// The identity `ans(rho) == I(rho)` is checked cross-multiplied, so the barycentric
+/// denominator is never inverted. That denominator equals `1 / prod_i (rho - y_i)` — the
+/// Lagrange basis sums to one — and so is non-zero for every `rho` outside the node set,
+/// which is exactly what the rejection below enforces.
+///
+/// Returns `true` if the check passes. Both `ans` (by the caller's length bound) and `I` have
+/// degree `< n`, so a caller that binds `ans` and the node set into the transcript before
+/// drawing `rho` gets soundness error at most `(n - 1) / |F|`.
+pub fn check_ans_interpolates<F: Field>(ans: &[F], points: &[F], values: &[F], rho: F) -> bool {
     if points.len() != values.len() {
         return false;
     }
 
-    // If rho coincides with one of the evaluation points the denominator (rho - y_i) would be
-    // zero.  This is negligible for a random rho but we handle it defensively: the shake identity
-    // does not apply at such a degenerate rho, so we report failure.
+    // At an interpolation node the barycentric denominators vanish and the identity says
+    // nothing, so report failure. A `rho` drawn after `ans` is bound lands there only with
+    // negligible probability.
     if points.contains(&rho) {
         return false;
     }
 
-    let ans_rho = eval_poly(ans, rho);
-    let shake_rho = eval_poly(shake, rho);
-
-    // Compute (rho - y_i) for all i and batch-invert.
-    let diffs: Vec<F> = points.iter().map(|&y| rho - y).collect();
-    let diff_invs = batch_multiplicative_inverse(&diffs);
-
-    // sum_i (ans(rho) - val_i) / (rho - y_i)
-    let expected: F = values
+    let n = points.len();
+    // The barycentric weight denominators `prod_{j != i} (y_i - y_j)` followed by the node
+    // distances `rho - y_i`, inverted in a single batch.
+    let mut denominators: Vec<F> = points
         .iter()
-        .zip(diff_invs.iter())
-        .map(|(&val, &inv)| (ans_rho - val) * inv)
-        .sum();
+        .enumerate()
+        .map(|(i, &y)| {
+            points
+                .iter()
+                .enumerate()
+                .filter(|&(j, _)| j != i)
+                .map(|(_, &z)| y - z)
+                .product()
+        })
+        .collect();
+    denominators.extend(points.iter().map(|&y| rho - y));
+    // A vanishing weight denominator means two nodes coincide, so no interpolant exists.
+    if denominators[..n].contains(&F::ZERO) {
+        return false;
+    }
+    let inverses = batch_multiplicative_inverse(&denominators);
+    let (weights, diff_invs) = inverses.split_at(n);
 
-    shake_rho == expected
+    let mut numerator = F::ZERO;
+    let mut denominator = F::ZERO;
+    for ((&w, &diff_inv), &v) in weights.iter().zip(diff_invs).zip(values) {
+        let term = w * diff_inv;
+        numerator += term * v;
+        denominator += term;
+    }
+
+    eval_poly(ans, rho) * denominator == numerator
 }
 
 /// Fold an entire natural-order codeword of size `N` by arity `k = 2^log_arity`.
@@ -1042,39 +1045,77 @@ mod tests {
     }
 
     #[test]
-    fn test_shake_polynomial_consistency() {
-        // Build ans poly through some points, compute shake, verify consistency.
+    fn test_check_ans_interpolates_accepts_the_interpolant() {
         let pts = vec![F::from_u64(1), F::from_u64(2), F::from_u64(3)];
         let vals = vec![F::from_u64(4), F::from_u64(9), F::from_u64(16)];
 
         let ans = interpolate_poly(&pts, &vals);
-        let shake = compute_shake_polynomial(&ans, &pts);
 
-        // Check at a random point (use a field element not in pts).
+        // Check at a field element outside `pts`.
         let rho = F::from_u64(7);
         assert!(
-            check_shake_consistency(&ans, &shake, &pts, &vals, rho),
-            "shake consistency should pass"
+            check_ans_interpolates(&ans, &pts, &vals, rho),
+            "the interpolant must satisfy the barycentric identity"
         );
     }
 
     #[test]
-    fn test_shake_consistency_fails_on_wrong_ans() {
+    fn test_check_ans_interpolates_rejects_a_corrupted_answer() {
         let pts = vec![F::from_u64(1), F::from_u64(2)];
         let vals = vec![F::from_u64(4), F::from_u64(9)];
 
-        let ans = interpolate_poly(&pts, &vals);
-        let shake = compute_shake_polynomial(&ans, &pts);
-
-        // Corrupt ans.
-        let mut bad_ans = ans;
+        let mut bad_ans = interpolate_poly(&pts, &vals);
         bad_ans[0] += F::ONE;
 
         let rho = F::from_u64(5);
         assert!(
-            !check_shake_consistency(&bad_ans, &shake, &pts, &vals, rho),
-            "shake consistency should fail on bad ans"
+            !check_ans_interpolates(&bad_ans, &pts, &vals, rho),
+            "a shifted answer polynomial must fail the identity"
         );
+    }
+
+    #[test]
+    fn test_check_ans_interpolates_rejects_a_perturbed_value_set() {
+        // The prover's `ans` interpolates the honest values; the verifier reconstructs the
+        // interpolant from the values it derived itself, so any disagreement must be caught.
+        let pts = vec![F::from_u64(1), F::from_u64(2), F::from_u64(3)];
+        let vals = vec![F::from_u64(4), F::from_u64(9), F::from_u64(16)];
+        let ans = interpolate_poly(&pts, &vals);
+
+        let rho = F::from_u64(7);
+        for i in 0..vals.len() {
+            let mut perturbed = vals.clone();
+            perturbed[i] += F::ONE;
+            assert!(
+                !check_ans_interpolates(&ans, &pts, &perturbed, rho),
+                "perturbing value {i} must fail the identity"
+            );
+        }
+    }
+
+    #[test]
+    fn test_check_ans_interpolates_rejects_degenerate_inputs() {
+        let pts = vec![F::from_u64(1), F::from_u64(2)];
+        let vals = vec![F::from_u64(4), F::from_u64(9)];
+        let ans = interpolate_poly(&pts, &vals);
+
+        // `rho` on a node leaves the barycentric denominators undefined.
+        assert!(!check_ans_interpolates(&ans, &pts, &vals, pts[0]));
+        // Mismatched lengths pin no interpolation problem at all.
+        assert!(!check_ans_interpolates(
+            &ans,
+            &pts,
+            &vals[..1],
+            F::from_u64(5)
+        ));
+        // Repeated nodes leave the barycentric weights undefined.
+        let dup_pts = vec![F::from_u64(1), F::from_u64(1)];
+        assert!(!check_ans_interpolates(
+            &ans,
+            &dup_pts,
+            &vals,
+            F::from_u64(5)
+        ));
     }
 
     #[test]

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -447,15 +447,17 @@ pub fn interpolate_poly<F: Field>(points: &[F], values: &[F]) -> Vec<F> {
 ///
 /// Returns `true` if the check passes. For `n >= 1`, both `ans` (by the caller's length bound)
 /// and `I` have degree `< n`, so a caller that binds `ans` and the node set into the transcript
-/// before drawing `rho` gets soundness error at most `(n - 1) / |F|`. An empty node set is
-/// interpolated only by the zero polynomial, and is decided exactly rather than at `rho`.
+/// before drawing `rho` gets soundness error at most `(n - 1) / |F|`. With no nodes the identity
+/// is vacuous, so that case is decided exactly (`ans` must be the zero polynomial) rather than
+/// at `rho`.
+#[must_use]
 pub fn check_ans_interpolates<F: Field>(ans: &[F], points: &[F], values: &[F], rho: F) -> bool {
     if points.len() != values.len() {
         return false;
     }
 
-    // No node constrains `ans`, so the barycentric sums below would both be empty and accept
-    // anything. The empty node set is interpolated only by the zero polynomial.
+    // With no nodes the identity is vacuous and the sums below would accept anything, so
+    // reject everything but the zero polynomial.
     if points.is_empty() {
         return ans.iter().all(|c| c.is_zero());
     }
@@ -606,6 +608,10 @@ fn fold_pass<F: TwoAdicField, EF: ExtensionField<F>>(
 /// Unlike [`fold_codeword`], which interpolates at subgroup coordinates and therefore takes the
 /// rescaled challenge `gamma / shift`, this form carries no domain shift and takes `gamma`
 /// itself.
+///
+/// `par_chunks` leaves a ragged final block when `coeffs.len()` isn't a multiple of `k`; that
+/// block is still folded correctly, since the missing high coefficients of `f` are zero.
+#[must_use]
 pub fn fold_poly_coeffs<F: Field>(coeffs: &[F], gamma: F, log_arity: usize) -> Vec<F> {
     coeffs
         .par_chunks(1 << log_arity)

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -120,9 +120,10 @@ pub fn eval_degree_correction<F: Field>(value: F, point: F, r_comb: F, gap: usiz
 ///
 /// The geometric sum's numerator and denominator both advance by a fixed ratio (a power of
 /// `g`) across the coset, so each is seeded once per `POWER_CHUNK`-sized chunk (one
-/// exponentiation) instead of once per point — mirroring the degree-correction sweep in
-/// `RoundProver::finish`. The `(1 − r_comb·x)` denominators do not depend on the group, so
-/// they are swept and inverted once for all of `groups` rather than once per group.
+/// exponentiation) and then advanced by a base-field multiply — mirroring the
+/// degree-correction sweep in `RoundProver::finish`. The `(1 − r_comb·x)` denominators do not
+/// depend on the group, so they are swept, inverted, and applied once for all of `groups`
+/// rather than once per group.
 pub fn combine_on_coset<F, EF>(
     groups: &[(EF, usize, &[EF])],
     r_comb: EF,
@@ -135,7 +136,7 @@ where
 {
     let n = 1usize << log_domain;
     let g = F::two_adic_generator(log_domain);
-    let step_start = r_comb * EF::from(shift);
+    let step_start = r_comb * shift;
 
     const POWER_CHUNK: usize = 1 << 12;
     let mut result = EF::zero_vec(n);
@@ -145,10 +146,10 @@ where
         .par_chunks_mut(POWER_CHUNK)
         .enumerate()
         .for_each(|(chunk_idx, chunk)| {
-            let mut step = step_start * EF::from(g.exp_u64((chunk_idx * POWER_CHUNK) as u64));
+            let mut step = step_start * g.exp_u64((chunk_idx * POWER_CHUNK) as u64);
             for d in chunk.iter_mut() {
                 *d = EF::ONE - step;
-                step *= EF::from(g);
+                step *= g;
             }
         });
 
@@ -167,25 +168,32 @@ where
     for &(r_i, gap, values) in groups {
         assert_eq!(values.len(), n, "group values must span the full coset");
 
+        // `r_i · (1 − step^(gap+1))` is swept directly, folding the group's shifting
+        // coefficient into the geometric numerator so that each point costs one product with
+        // its value rather than a separate multiplication by `r_i` and by the denominator.
         let g_hi = g.exp_u64((gap + 1) as u64);
-        let step_start_hi = step_start.exp_u64((gap + 1) as u64);
+        let r_step_start_hi = r_i * step_start.exp_u64((gap + 1) as u64);
         result
             .par_chunks_mut(POWER_CHUNK)
             .zip(values.par_chunks(POWER_CHUNK))
-            .zip(inv_denoms.par_chunks(POWER_CHUNK))
             .enumerate()
-            .for_each(|(chunk_idx, ((res_chunk, val_chunk), inv_chunk))| {
-                let mut step_hi =
-                    step_start_hi * EF::from(g_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64));
-                for ((res, &val), &inv_denom) in res_chunk.iter_mut().zip(val_chunk).zip(inv_chunk)
-                {
-                    let numer = EF::ONE - step_hi;
-                    *res += r_i * val * numer * inv_denom;
-                    step_hi *= EF::from(g_hi);
+            .for_each(|(chunk_idx, (res_chunk, val_chunk))| {
+                let mut r_step_hi =
+                    r_step_start_hi * g_hi.exp_u64((chunk_idx * POWER_CHUNK) as u64);
+                for (res, &val) in res_chunk.iter_mut().zip(val_chunk) {
+                    *res += val * (r_i - r_step_hi);
+                    r_step_hi *= g_hi;
                 }
             });
+    }
 
-        if let Some(p) = degenerate {
+    result
+        .par_iter_mut()
+        .zip(inv_denoms.par_iter())
+        .for_each(|(res, &inv_denom)| *res *= inv_denom);
+
+    if let Some(p) = degenerate {
+        for &(r_i, gap, values) in groups {
             result[p] += r_i * values[p] * EF::from_usize(gap + 1);
         }
     }

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -564,6 +564,22 @@ pub fn fold_codeword<F: TwoAdicField, EF: ExtensionField<F>>(
     data
 }
 
+/// Fold a coefficient-form polynomial at challenge `gamma` with arity `k = 2^log_arity`.
+///
+/// Writing `f(X) = Σ_{l<k} X^l · q_l(X^k)`, Construction 4.5's fold is `Σ_{l<k} gamma^l · q_l`,
+/// whose degree-`m` coefficient is `Σ_{l<k} gamma^l · f[l + k·m]` — the Horner evaluation at
+/// `gamma` of the `m`-th length-`k` block of `f`.
+///
+/// Unlike [`fold_codeword`], which interpolates at subgroup coordinates and therefore takes the
+/// rescaled challenge `gamma / shift`, this form carries no domain shift and takes `gamma`
+/// itself.
+pub fn fold_poly_coeffs<F: Field>(coeffs: &[F], gamma: F, log_arity: usize) -> Vec<F> {
+    coeffs
+        .par_chunks(1 << log_arity)
+        .map(|block| eval_poly(block, gamma))
+        .collect()
+}
+
 /// Compute the expected folded value for a single fiber (used by the verifier).
 ///
 /// Given:

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -536,40 +536,55 @@ pub fn fold_codeword<F: TwoAdicField, EF: ExtensionField<F>>(
     let new_height = codeword.len() / arity;
     assert!(new_height > 0);
 
-    let mut data = codeword.to_vec();
+    if log_arity == 0 {
+        return codeword.to_vec();
+    }
+
     let mut current_beta = beta;
     let mut cur_log_domain = log_domain_size;
-
-    for _ in 0..log_arity {
-        let height = data.len() / 2;
-
-        // fold(j) = (lo + hi)/2 + beta * (lo - hi) / (2 * g^j)
-        //         = (lo + hi)/2 + (beta/2) * g_inv^j * (lo - hi)
-        //
-        // g_orig has order `2^cur_log_domain`, so g_inv = g_orig.inverse() has the same
-        // order. halve_inv_powers[j] = (1/2) * g_orig^{-j}.
-        let g_orig_inv = F::two_adic_generator(cur_log_domain).inverse();
-        let halve_inv_powers: Vec<F> = g_orig_inv
-            .shifted_powers(F::ONE.halve())
-            .take(height)
-            .collect();
-
-        data = (0..height)
-            .into_par_iter()
-            .map(|j| {
-                let lo = data[j];
-                let hi = data[j + height];
-                let hip = EF::from(halve_inv_powers[j]);
-                (lo + hi).halve() + (lo - hi) * current_beta * hip
-            })
-            .collect();
-
+    // The first pass reads the caller's slice and every later pass reads its predecessor's
+    // output, so the input is never copied.
+    let mut data = fold_pass::<F, EF>(codeword, current_beta, cur_log_domain);
+    for _ in 1..log_arity {
         current_beta = current_beta.square();
         cur_log_domain -= 1;
+        data = fold_pass::<F, EF>(&data, current_beta, cur_log_domain);
     }
 
     debug_assert_eq!(data.len(), new_height);
     data
+}
+
+/// One arity-2 pass of [`fold_codeword`] over a natural-order codeword on a domain of size
+/// `2^log_domain_size`, pairing index `j` with `j + height`.
+fn fold_pass<F: TwoAdicField, EF: ExtensionField<F>>(
+    src: &[EF],
+    beta: EF,
+    log_domain_size: usize,
+) -> Vec<EF> {
+    let height = src.len() / 2;
+
+    // fold(j) = (lo + hi)/2 + beta * (lo - hi) / (2 * g^j)
+    //         = (lo + hi)/2 + (beta/2) * g_inv^j * (lo - hi)
+    //
+    // g_orig has order `2^log_domain_size`, so g_inv = g_orig.inverse() has the same
+    // order. halve_inv_powers[j] = (1/2) * g_orig^{-j}.
+    let g_orig_inv = F::two_adic_generator(log_domain_size).inverse();
+    let halve_inv_powers: Vec<F> = g_orig_inv
+        .shifted_powers(F::ONE.halve())
+        .take(height)
+        .collect();
+
+    (0..height)
+        .into_par_iter()
+        .map(|j| {
+            let lo = src[j];
+            let hi = src[j + height];
+            // The base-field twiddle multiplies first so that it dispatches through the cheap
+            // extension-by-base product, leaving `beta` as the pass's only extension product.
+            (lo + hi).halve() + (lo - hi) * halve_inv_powers[j] * beta
+        })
+        .collect()
 }
 
 /// Fold a coefficient-form polynomial at challenge `gamma` with arity `k = 2^log_arity`.

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -445,12 +445,19 @@ pub fn interpolate_poly<F: Field>(points: &[F], values: &[F]) -> Vec<F> {
 /// Lagrange basis sums to one — and so is non-zero for every `rho` outside the node set,
 /// which is exactly what the rejection below enforces.
 ///
-/// Returns `true` if the check passes. Both `ans` (by the caller's length bound) and `I` have
-/// degree `< n`, so a caller that binds `ans` and the node set into the transcript before
-/// drawing `rho` gets soundness error at most `(n - 1) / |F|`.
+/// Returns `true` if the check passes. For `n >= 1`, both `ans` (by the caller's length bound)
+/// and `I` have degree `< n`, so a caller that binds `ans` and the node set into the transcript
+/// before drawing `rho` gets soundness error at most `(n - 1) / |F|`. An empty node set is
+/// interpolated only by the zero polynomial, and is decided exactly rather than at `rho`.
 pub fn check_ans_interpolates<F: Field>(ans: &[F], points: &[F], values: &[F], rho: F) -> bool {
     if points.len() != values.len() {
         return false;
+    }
+
+    // No node constrains `ans`, so the barycentric sums below would both be empty and accept
+    // anything. The empty node set is interpolated only by the zero polynomial.
+    if points.is_empty() {
+        return ans.iter().all(|c| c.is_zero());
     }
 
     // At an interpolation node the barycentric denominators vanish and the identity says
@@ -1116,6 +1123,9 @@ mod tests {
             &vals,
             F::from_u64(5)
         ));
+        // An empty node set constrains nothing, so only the zero polynomial passes.
+        assert!(check_ans_interpolates(&[], &[], &[], F::from_u64(5)));
+        assert!(!check_ans_interpolates(&ans, &[], &[], F::from_u64(5)));
     }
 
     #[test]

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -14,7 +14,7 @@ use crate::config::{StirConfig, StirRoundConfig};
 use crate::error::{ExternalSourceError, GrindStage, ProofShapeError, RoundLabel, StirError};
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    check_shake_consistency, eval_poly, eval_poly_at_base, fold_domain_params,
+    check_ans_interpolates, eval_poly, eval_poly_at_base, fold_domain_params,
     lagrange_interpolate_at, next_domain_shift, reduce_mod_x_pow_minus_c, sample_ood_points,
     vanishing_poly_from_roots,
 };
@@ -129,15 +129,13 @@ fn single_matrix_opened_values<EF>(row_evals: &[Vec<EF>]) -> Vec<Vec<&[EF]>> {
         .collect()
 }
 
-/// Reject an `Ans`/shake pair longer than the round's degree bounds allow.
+/// Reject an `Ans` polynomial longer than the round's degree bound allows.
 ///
-/// - `Ans` interpolates `max_ans_len` points, so its degree is below that.
-/// - The shake polynomial is one degree lower.
-/// - A shorter pair is legitimate: the prover may strip trailing zeros.
-fn check_ans_and_shake_lengths<EF, MmcsError, InputError>(
+/// `Ans` interpolates `max_ans_len` points, so its degree is below that. A shorter polynomial
+/// is legitimate: the prover may strip trailing zeros.
+fn check_ans_length<EF, MmcsError, InputError>(
     round: RoundLabel,
     ans_polynomial: &[EF],
-    shake_polynomial: &[EF],
     max_ans_len: usize,
 ) -> Result<(), StirError<MmcsError, InputError>> {
     if ans_polynomial.len() > max_ans_len {
@@ -145,15 +143,6 @@ fn check_ans_and_shake_lengths<EF, MmcsError, InputError>(
             round,
             maximum: max_ans_len,
             got: ans_polynomial.len(),
-        }
-        .into());
-    }
-    let max_shake_len = max_ans_len.saturating_sub(1);
-    if shake_polynomial.len() > max_shake_len {
-        return Err(ProofShapeError::ShakePolynomialTooLong {
-            round,
-            maximum: max_shake_len,
-            got: shake_polynomial.len(),
         }
         .into());
     }
@@ -574,7 +563,7 @@ where
 
     // Step 3: query-phase PoW. It protects only the immediately following combination
     // challenge and query indices; configuration soundness gives no PoW credit to the
-    // earlier OOD samples or the later shake challenge.
+    // earlier OOD samples or the later Ans challenge.
     if !challenger.check_witness(rc.pow_bits, rp.pow_witness) {
         return Err(StirError::InvalidPowWitness {
             round: RoundLabel::Round(round),
@@ -611,33 +600,22 @@ where
         &query_indices,
     )?;
 
-    // Step 4: ans + shake polynomial observation and consistency check.
+    // Step 4: ans polynomial observation and consistency check.
     let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
-    // Ans interpolates |all_points| values, bounding both polynomials' lengths.
+    // Ans interpolates |all_points| values, bounding its length. That bound is what makes the
+    // one-point check below bind.
     let max_ans_len = all_points.len();
-    check_ans_and_shake_lengths(
-        RoundLabel::Round(round),
-        &rp.ans_polynomial,
-        &rp.shake_polynomial,
-        max_ans_len,
-    )?;
+    check_ans_length(RoundLabel::Round(round), &rp.ans_polynomial, max_ans_len)?;
 
-    // Bind ans_poly into the transcript BEFORE rho. The shake identity is a one-point check;
-    // observing both polys first means the prover commits to Ans before learning rho.
+    // Bind ans_poly into the transcript BEFORE rho. The interpolation identity is a one-point
+    // check; observing Ans first means the prover commits to it before learning rho.
     challenger.observe_algebra_slice(&rp.ans_polynomial);
-    challenger.observe_algebra_slice(&rp.shake_polynomial);
 
     let rho: EF = challenger.sample_algebra_element();
 
-    if !check_shake_consistency(
-        &rp.ans_polynomial,
-        &rp.shake_polynomial,
-        &all_points,
-        &all_values,
-        rho,
-    ) {
-        return Err(StirError::InvalidShakeConsistency {
+    if !check_ans_interpolates(&rp.ans_polynomial, &all_points, &all_values, rho) {
+        return Err(StirError::InvalidAnsConsistency {
             round: RoundLabel::Round(round),
         });
     }
@@ -1297,7 +1275,7 @@ where
             )?;
         }
 
-        // Phase 4: per-instance ans/shake absorb, shake-check challenge, and consistency.
+        // Phase 4: per-instance ans absorb, consistency challenge, and check.
         let mut finishes: Vec<(usize, RoundVerifyOutput<F, EF>)> = Vec::with_capacity(active.len());
         for (&i, rv) in active.iter().zip(rvs) {
             let local_r = r - offset(i);
@@ -1305,25 +1283,13 @@ where
             let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
             let max_ans_len = all_points.len();
-            check_ans_and_shake_lengths(
-                RoundLabel::Round(local_r),
-                &rp.ans_polynomial,
-                &rp.shake_polynomial,
-                max_ans_len,
-            )?;
+            check_ans_length(RoundLabel::Round(local_r), &rp.ans_polynomial, max_ans_len)?;
 
             challenger.observe_algebra_slice(&rp.ans_polynomial);
-            challenger.observe_algebra_slice(&rp.shake_polynomial);
             let rho: EF = challenger.sample_algebra_element();
 
-            if !check_shake_consistency(
-                &rp.ans_polynomial,
-                &rp.shake_polynomial,
-                &all_points,
-                &all_values,
-                rho,
-            ) {
-                return Err(StirError::InvalidShakeConsistency {
+            if !check_ans_interpolates(&rp.ans_polynomial, &all_points, &all_values, rho) {
+                return Err(StirError::InvalidAnsConsistency {
                     round: RoundLabel::Round(local_r),
                 });
             }

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -503,7 +503,6 @@ mod babybear_stir {
         for (rp_a, rp_b) in proof_a.round_proofs.iter().zip(proof_b.round_proofs.iter()) {
             assert_eq!(rp_a.ood_answers, rp_b.ood_answers);
             assert_eq!(rp_a.ans_polynomial, rp_b.ans_polynomial);
-            assert_eq!(rp_a.shake_polynomial, rp_b.shake_polynomial);
             assert_eq!(
                 rp_a.query_openings.as_ref().unwrap().row_evals.len(),
                 rp_b.query_openings.as_ref().unwrap().row_evals.len()
@@ -675,36 +674,21 @@ mod babybear_stir {
         let mut p_challenger = challenger.clone();
         let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
 
-        // Tamper the prover-supplied answer polynomial. The shake identity at the
-        // verifier-sampled rho should catch it with overwhelming probability.
+        // Tamper the prover-supplied answer polynomial. The tampered Ans no longer
+        // interpolates the values the verifier derives for itself, so the identity at the
+        // verifier-sampled rho catches it before any later check runs.
         assert!(!proof.round_proofs[0].ans_polynomial.is_empty());
         proof.round_proofs[0].ans_polynomial[0] += EF::from(F::ONE);
 
         let mut v_challenger = challenger;
-        assert!(
-            verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger).is_err()
-        );
-    }
-
-    #[test]
-    fn test_tampered_shake_polynomial_fails() {
-        let (params, dft, challenger) = make_params(1, 2);
-        let mut rng = seeded_rng();
-        let log_degree = 8;
-        let degree = 1usize << log_degree;
-        let poly_coeffs: Vec<EF> = (0..degree).map(|_| rng.random()).collect();
-
-        let config = StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params);
-        let mut p_challenger = challenger.clone();
-        let (mut proof, _query_indices) = prove_stir(&config, poly_coeffs, &dft, &mut p_challenger);
-
-        assert!(!proof.round_proofs[0].shake_polynomial.is_empty());
-        proof.round_proofs[0].shake_polynomial[0] += EF::from(F::ONE);
-
-        let mut v_challenger = challenger;
-        assert!(
-            verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger).is_err()
-        );
+        let err = verify_stir::<F, EF, MyMmcs, Challenger>(&config, &proof, &mut v_challenger)
+            .expect_err("a tampered answer polynomial must be rejected");
+        assert!(matches!(
+            err,
+            p3_stir::StirError::InvalidAnsConsistency {
+                round: RoundLabel::Round(0)
+            }
+        ));
     }
 
     #[test]
@@ -987,22 +971,6 @@ mod babybear_stir {
             ProofShapeError::AnsPolynomialTooLong {
                 round: RoundLabel::Round(0),
                 maximum: 20,
-                got: 1024,
-            }
-        );
-    }
-
-    /// Leaves `Ans` alone: the shake bound is one degree lower and checked separately.
-    #[test]
-    fn test_overlong_shake_polynomial_rejected() {
-        let err = shape_error_after(|proof| {
-            proof.round_proofs[0].shake_polynomial.resize(1024, EF::ONE);
-        });
-        assert_eq!(
-            err,
-            ProofShapeError::ShakePolynomialTooLong {
-                round: RoundLabel::Round(0),
-                maximum: 19,
                 got: 1024,
             }
         );

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -354,3 +354,35 @@ fn test_fold_codeword_higher_arity_agrees_with_fold_fiber() {
         }
     }
 }
+
+#[test]
+fn test_fold_poly_coeffs_agrees_with_the_evaluation_form_fold() {
+    use p3_dft::Radix2DitParallel;
+    use p3_stir::prover::{codeword_from_coeffs, coeffs_from_codeword};
+    use p3_stir::utils::{fold_codeword, fold_poly_coeffs};
+
+    let log_domain = 6;
+    let domain_size = 1usize << log_domain;
+    let dft = Radix2DitParallel::<F>::default();
+    let shift = F::GENERATOR;
+    let gamma = ef(31);
+
+    // Degree `domain_size - 1`, so each fold lands at degree `domain_size / k - 1` and the
+    // inverse DFT over the fold domain recovers the folded polynomial exactly.
+    let coeffs: Vec<EF> = (1..=domain_size).map(|i| ef(i as u64)).collect();
+    let codeword = codeword_from_coeffs(&dft, coeffs.clone(), shift, log_domain);
+
+    for log_arity in [1usize, 2, 3] {
+        // `fold_codeword` interpolates at subgroup coordinates, so the coset fold at `gamma`
+        // is reached through `gamma / shift`; `fold_poly_coeffs` takes `gamma` directly.
+        let beta = gamma * EF::from(shift.inverse());
+        let folded = fold_codeword::<F, EF>(&codeword, beta, log_arity, log_domain);
+        let fold_shift = shift.exp_power_of_2(log_arity);
+
+        assert_eq!(
+            fold_poly_coeffs(&coeffs, gamma, log_arity),
+            coeffs_from_codeword(&dft, &folded, fold_shift),
+            "coefficient and evaluation folds disagree at log_arity={log_arity}"
+        );
+    }
+}

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -4,8 +4,7 @@ use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_stir::utils::{
-    add_polys, check_shake_consistency, compute_shake_polynomial, divide_by_linear, eval_poly,
-    interpolate_poly,
+    add_polys, check_ans_interpolates, divide_by_linear, eval_poly, interpolate_poly,
 };
 
 type F = BabyBear;
@@ -166,45 +165,29 @@ fn test_interpolate_poly_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
-// compute_shake_polynomial + check_shake_consistency
+// check_ans_interpolates
 // ---------------------------------------------------------------------------
 
 #[test]
-fn test_shake_polynomial_degree_bound() {
-    // shake = sum_y (ans(X) - ans(y)) / (X - y); ans has degree d,
-    // each term has degree d-1, sum has degree d-1.
-    // Use extension field points for more variety.
-    let ans = vec![ef(1), ef(2), ef(3), ef(4)]; // degree-3 polynomial
-    let points = vec![ef(10), ef(20), ef(30)];
-    let shake = compute_shake_polynomial(&ans, &points);
-    // shake should be of degree <= 2 (ans degree - 1)
-    assert!(shake.len() <= 3);
-}
-
-#[test]
-fn test_shake_consistency_check() {
-    // Build ans by interpolation, compute shake, and check at a random rho.
+fn test_ans_interpolates_accepts_the_interpolant() {
     let points = vec![ef(1), ef(2), ef(3)];
     let values = vec![ef(5), ef(11), ef(23)];
     let ans = interpolate_poly(&points, &values);
-    let shake = compute_shake_polynomial(&ans, &points);
 
     // Any rho outside the points should pass.
     let rho = ef(100);
-    assert!(check_shake_consistency(&ans, &shake, &points, &values, rho));
+    assert!(check_ans_interpolates(&ans, &points, &values, rho));
 }
 
 #[test]
-fn test_shake_consistency_mismatched_lengths_returns_false() {
+fn test_ans_interpolates_mismatched_lengths_returns_false() {
     let points = vec![ef(1), ef(2), ef(3)];
     let values = vec![ef(5), ef(11), ef(23)];
     let ans = interpolate_poly(&points, &values);
-    let shake = compute_shake_polynomial(&ans, &points);
 
     let truncated_values = vec![ef(5), ef(11)];
-    assert!(!check_shake_consistency(
+    assert!(!check_ans_interpolates(
         &ans,
-        &shake,
         &points,
         &truncated_values,
         ef(100)
@@ -212,42 +195,43 @@ fn test_shake_consistency_mismatched_lengths_returns_false() {
 }
 
 #[test]
-fn test_shake_consistency_tampered_answer_fails() {
+fn test_ans_interpolates_tampered_answer_fails() {
     let points = vec![ef(1), ef(2), ef(3)];
     let values = vec![ef(5), ef(11), ef(23)];
-    let ans = interpolate_poly(&points, &values);
-    let shake = compute_shake_polynomial(&ans, &points);
+    let mut bad_ans = interpolate_poly(&points, &values);
 
-    // Tamper with the shake polynomial.
-    let mut bad_shake = shake;
-    bad_shake[0] += ef(1);
+    bad_ans[0] += ef(1);
     let rho = ef(42);
-    assert!(!check_shake_consistency(
-        &ans, &bad_shake, &points, &values, rho
-    ));
+    assert!(!check_ans_interpolates(&bad_ans, &points, &values, rho));
 }
 
 #[test]
-fn test_shake_consistency_tampered_value_fails() {
+fn test_ans_interpolates_perturbed_value_fails() {
+    // `ans` is built from the honest values, but the verifier reconstructs the interpolant
+    // from the values it derived itself, so a single perturbed value must be caught.
     let points = vec![ef(1), ef(2), ef(3)];
     let values = vec![ef(5), ef(11), ef(23)];
     let ans = interpolate_poly(&points, &values);
-    let shake = compute_shake_polynomial(&ans, &points);
 
-    // Tamper with a claimed value (so ans no longer matches).
-    let mut bad_values = values;
-    bad_values[0] = ef(999);
     let rho = ef(42);
-    // The ans was built from the original values, so the reconstructed ans from
-    // bad_values will differ → consistency check must fail.
-    let bad_ans = interpolate_poly(&points, &bad_values);
-    assert!(!check_shake_consistency(
-        &bad_ans,
-        &shake,
-        &points,
-        &bad_values,
-        rho
-    ));
+    for i in 0..values.len() {
+        let mut bad_values = values.clone();
+        bad_values[i] = ef(999);
+        assert!(
+            !check_ans_interpolates(&ans, &points, &bad_values, rho),
+            "perturbing value {i} must fail the identity"
+        );
+    }
+}
+
+#[test]
+fn test_ans_interpolates_rejects_rho_on_a_node() {
+    let points = vec![ef(1), ef(2), ef(3)];
+    let values = vec![ef(5), ef(11), ef(23)];
+    let ans = interpolate_poly(&points, &values);
+
+    // The barycentric denominators are undefined on a node, so the identity says nothing.
+    assert!(!check_ans_interpolates(&ans, &points, &values, points[1]));
 }
 
 // ---------------------------------------------------------------------------

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -1,11 +1,17 @@
 //! Unit tests for STIR polynomial arithmetic utilities.
 
 use p3_baby_bear::BabyBear;
+use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
+use p3_stir::prover::{codeword_from_coeffs, coeffs_from_codeword};
 use p3_stir::utils::{
-    add_polys, check_ans_interpolates, divide_by_linear, eval_poly, interpolate_poly,
+    add_polys, check_ans_interpolates, divide_by_linear, eval_poly, fold_codeword,
+    fold_poly_coeffs, interpolate_poly,
 };
+use proptest::prelude::*;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 type F = BabyBear;
 type EF = BinomialExtensionField<F, 4>;
@@ -234,6 +240,13 @@ fn test_ans_interpolates_rejects_rho_on_a_node() {
     assert!(!check_ans_interpolates(&ans, &points, &values, points[1]));
 }
 
+#[test]
+fn test_ans_interpolates_single_node() {
+    // n == 1 is the only input that exercises the empty-`product()` weight path.
+    assert!(check_ans_interpolates(&[ef(7)], &[ef(3)], &[ef(7)], ef(9)));
+    assert!(!check_ans_interpolates(&[ef(8)], &[ef(3)], &[ef(7)], ef(9)));
+}
+
 // ---------------------------------------------------------------------------
 // fold_codeword correctness
 // ---------------------------------------------------------------------------
@@ -266,6 +279,19 @@ fn test_fold_codeword_arity2_constant_polynomial() {
     for &v in &folded {
         assert_eq!(v, ef(5), "folded constant polynomial must stay constant");
     }
+}
+
+#[test]
+fn test_fold_codeword_zero_arity_is_identity() {
+    use p3_stir::utils::fold_codeword;
+
+    let codeword: Vec<EF> = (1..=16u64).map(ef).collect();
+    let beta = ef(11);
+    assert_eq!(
+        fold_codeword::<F, EF>(&codeword, beta, 0, 4),
+        codeword,
+        "arity-1 fold (log_arity = 0) must return the codeword unchanged"
+    );
 }
 
 #[test]
@@ -367,6 +393,50 @@ fn test_fold_poly_coeffs_agrees_with_the_evaluation_form_fold() {
             fold_poly_coeffs(&coeffs, gamma, log_arity),
             coeffs_from_codeword(&dft, &folded, fold_shift),
             "coefficient and evaluation folds disagree at log_arity={log_arity}"
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// The lemma the whole `Oracle::Coeffs` prover path rests on: `fold_poly_coeffs` and
+    /// `fold_codeword` (composed with `coeffs_from_codeword`) must agree, not just at the one
+    /// dense-degree, `GENERATOR`-shift shape above. `true_deg` is drawn independently of
+    /// `log_domain` so the coefficient tail past the true degree — and, once folded, past
+    /// `log_sub_coset`'s width — is genuinely zero rather than incidentally full, and `shift`
+    /// varies since it is never `GENERATOR` past round 0 in the real prover.
+    #[test]
+    fn test_fold_poly_coeffs_agrees_with_fold_codeword_over_shapes(
+        log_domain in 3usize..=8,
+        log_arity in 1usize..=3,
+        true_deg_seed in 0usize..(1 << 8),
+        shift_seed in 1u64..(1 << 20),
+        seed: u64,
+    ) {
+        prop_assume!(log_arity <= log_domain);
+
+        let domain_size = 1usize << log_domain;
+        let true_deg = 1 + (true_deg_seed % domain_size);
+        let shift = F::from_u64(shift_seed);
+
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let mut coeffs: Vec<EF> = (0..true_deg).map(|_| rng.random()).collect();
+        coeffs.resize(domain_size, EF::ZERO);
+        let gamma: EF = rng.random();
+
+        let dft = Radix2DitParallel::<F>::default();
+        let codeword = codeword_from_coeffs(&dft, coeffs.clone(), shift, log_domain);
+
+        // `fold_codeword` interpolates at subgroup coordinates, so the coset fold at `gamma`
+        // is reached through `gamma / shift`; `fold_poly_coeffs` takes `gamma` directly.
+        let beta = gamma * EF::from(shift.inverse());
+        let folded = fold_codeword::<F, EF>(&codeword, beta, log_arity, log_domain);
+        let fold_shift = shift.exp_power_of_2(log_arity);
+
+        prop_assert_eq!(
+            fold_poly_coeffs(&coeffs, gamma, log_arity),
+            coeffs_from_codeword(&dft, &folded, fold_shift),
         );
     }
 }


### PR DESCRIPTION
## Changes

- Materialize each round's virtual oracle on a degree-bounded sub-coset instead of the full domain, folding coefficients instead of evaluations from round 1 on.
- `combine_on_coset`: route geometric steps through base-field multiplies, apply the denominator inverse once per bucket instead of once per point.
- `fold_codeword`: route the twiddle multiply through base-field multiplication, drop a redundant input copy.
- **Wire-format change**: drop the shake polynomial from `StirRoundProof`, replace with a direct barycentric interpolation check (`Ans(ρ) == I(ρ)`). Smaller proofs, same soundness bound (still bounded by the pre-existing `shake_check_error`, now a strict over-estimate).
- Hardening: debug asserts pinning the sub-coset degree invariants, explicit empty-node handling in the new barycentric check.

Items 1-3 are bit-identical to `main` (verified via proof-byte hashing). Item 4 changes the proof format — no compatibility fixtures in this repo depend on it.

## Benchmarks

`stir_pcs` bench, this machine, main vs branch (20 samples):

| benchmark | main | branch | Δ |
|---|---|---|---|
| open/1bucket | 762 ms | 664 ms | −12.8% |
| open/2buckets_ratio2 | 894 ms | 673 ms | −24.7% |
| open/2buckets_ratio4 | 789 ms | 795 ms | +0.7% |
| open/3buckets_ratio4 | 849 ms | 729 ms | −14.1% |
| verify/1bucket | 2.38 ms | 2.37 ms | −0.5% |
| verify/2buckets_ratio2 | 2.59 ms | 2.55 ms | −1.7% |
| verify/2buckets_ratio4 | 2.57 ms | 2.51 ms | −2.5% |
| verify/3buckets_ratio4 | 2.66 ms | 2.64 ms | −0.7% |
