### PR TITLE
perf(fri): closed-form fold_row, in-place fold_matrix, hoisted verifier alpha ladder, fused hiding LDE

### DIFF
--- a/fri/benches/fold_even_odd.rs
+++ b/fri/benches/fold_even_odd.rs
@@ -1,4 +1,5 @@
 use core::marker::PhantomData;
+use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
@@ -13,6 +14,8 @@ use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
+const LOG_ARITIES: [usize; 3] = [1, 2, 3];
+
 fn bench<F: TwoAdicField, EF: ExtensionField<F>>(c: &mut Criterion, log_sizes: &[usize])
 where
     StandardUniform: Distribution<EF>,
@@ -22,18 +25,21 @@ where
     group.sample_size(10);
     let folding = TwoAdicFriFolding::<(), ()>(PhantomData);
 
-    for log_size in log_sizes {
-        let n = 1 << log_size;
+    for log_arity in LOG_ARITIES {
+        let arity = 1 << log_arity;
 
-        let mut rng = SmallRng::seed_from_u64(n as u64);
-        let beta = rng.sample(StandardUniform);
-        let mat = RowMajorMatrix::<EF>::rand(&mut rng, n, 2);
+        for log_size in log_sizes {
+            let n = 1 << log_size;
 
-        group.bench_function(BenchmarkId::from_parameter(n), |b| {
-            b.iter(|| {
-                folding.fold_matrix(beta, 1, mat.clone());
+            let mut rng = SmallRng::seed_from_u64(n as u64);
+            let beta = rng.sample(StandardUniform);
+            // The input always holds `2 * n` evaluations, laid out as `arity` per folded output.
+            let mat = RowMajorMatrix::<EF>::rand(&mut rng, (2 * n) / arity, arity);
+
+            group.bench_function(BenchmarkId::new(format!("log_arity_{log_arity}"), n), |b| {
+                b.iter(|| black_box(folding.fold_matrix(beta, log_arity, mat.as_view())));
             });
-        });
+        }
     }
 }
 

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -11,6 +11,7 @@ use p3_matrix::bitrev::{BitReversalPerm, BitReversibleMatrix};
 use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixCow};
 use p3_matrix::horizontally_truncated::HorizontallyTruncated;
 use p3_matrix::row_index_mapped::RowIndexMappedView;
+use p3_maybe_rayon::prelude::*;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{CryptoRng, RngExt, SeedableRng};
 use spin::Mutex;
@@ -220,18 +221,26 @@ where
                 let shift = Val::GENERATOR / domain.shift();
                 let random_values = &all_random_values[i * h * w..(i + 1) * h * w];
 
-                // Commit to the bit-reversed LDE.
-                let mut lde_evals = self
-                    .inner
-                    .dft
-                    .coset_lde_batch(evals, self.inner.fri.log_blowup + 1, shift)
-                    .to_row_major_matrix();
+                // The quotient chunk and its mask are both extended onto the same coset, and the
+                // DFT is linear, so they share a single forward transform. Recover the chunk's
+                // coefficients and scale coefficient `j` by `shift^j`, which places them on the
+                // coset exactly as `coset_lde_batch(evals, log_blowup + 1, shift)` would.
+                let mut lde_coeffs = self.inner.dft.idft_batch(evals).values;
+                let shift_powers = shift.powers().collect_n(h);
+                lde_coeffs
+                    .par_chunks_exact_mut(w)
+                    .zip(shift_powers)
+                    .for_each(|(row, shift_pow)| {
+                        for value in row {
+                            *value *= shift_pow;
+                        }
+                    });
+                lde_coeffs.resize((h * w) << (self.inner.fri.log_blowup + 1), Val::ZERO);
 
-                // Evaluate `v_H(X) * r(X)` over the LDE, where:
+                // Add in the coefficients of `v_H(X) * r(X)`, where:
                 // - `v_H` is the coset vanishing polynomial, here equal to (GENERATOR * X / domain.shift)^n - 1,
                 // - and `r` is a random polynomial.
-                let mut vanishing_poly_coeffs =
-                    Val::zero_vec((h * w) << (self.inner.fri.log_blowup + 1));
+                // These are already coset-adjusted, so they are not scaled by `shift^j`.
                 let p = shift.exp_u64(h as u64);
                 Val::GENERATOR
                     .powers()
@@ -240,22 +249,17 @@ where
                     .for_each(|(i, p_i)| {
                         for j in 0..w {
                             let mul_coeff = p_i * random_values[i * w + j];
-                            vanishing_poly_coeffs[i * w + j] -= mul_coeff;
-                            vanishing_poly_coeffs[(h + i) * w + j] = p * mul_coeff;
+                            lde_coeffs[i * w + j] -= mul_coeff;
+                            lde_coeffs[(h + i) * w + j] = p * mul_coeff;
                         }
                     });
-                let random_eval = self
-                    .inner
+
+                // Commit to the bit-reversed LDE.
+                self.inner
                     .dft
-                    .dft_batch(DenseMatrix::new(vanishing_poly_coeffs, w))
-                    .to_row_major_matrix();
-
-                // Add the quotient chunk evaluations over the LDE to the evaluations of `v_H(X) * r(X)`.
-                for i in 0..h * w * (1 << (self.inner.fri.log_blowup + 1)) {
-                    lde_evals.values[i] += random_eval.values[i];
-                }
-
-                lde_evals.bit_reverse_rows().to_row_major_matrix()
+                    .dft_batch(DenseMatrix::new(lde_coeffs, w))
+                    .bit_reverse_rows()
+                    .to_row_major_matrix()
             })
             .collect()
     }

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -11,7 +11,6 @@ use p3_matrix::bitrev::{BitReversalPerm, BitReversibleMatrix};
 use p3_matrix::dense::{DenseMatrix, RowMajorMatrix, RowMajorMatrixCow};
 use p3_matrix::horizontally_truncated::HorizontallyTruncated;
 use p3_matrix::row_index_mapped::RowIndexMappedView;
-use p3_maybe_rayon::prelude::*;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{CryptoRng, RngExt, SeedableRng};
 use spin::Mutex;
@@ -222,19 +221,14 @@ where
                 let random_values = &all_random_values[i * h * w..(i + 1) * h * w];
 
                 // The quotient chunk and its mask are both extended onto the same coset, and the
-                // DFT is linear, so they share a single forward transform. Recover the chunk's
-                // coefficients and scale coefficient `j` by `shift^j`, which places them on the
-                // coset exactly as `coset_lde_batch(evals, log_blowup + 1, shift)` would.
-                let mut lde_coeffs = self.inner.dft.idft_batch(evals).values;
-                let shift_powers = shift.powers().collect_n(h);
-                lde_coeffs
-                    .par_chunks_exact_mut(w)
-                    .zip(shift_powers)
-                    .for_each(|(row, shift_pow)| {
-                        for value in row {
-                            *value *= shift_pow;
-                        }
-                    });
+                // DFT is linear, so they share a single forward transform. Recovering the chunk's
+                // coefficients with `shift.inverse()` scales coefficient `j` by `shift^j`, placing
+                // them on the coset exactly as `coset_lde_batch(evals, log_blowup + 1, shift)` would.
+                let mut lde_coeffs = self
+                    .inner
+                    .dft
+                    .coset_idft_batch(evals, shift.inverse())
+                    .values;
                 lde_coeffs.resize((h * w) << (self.inner.fri.log_blowup + 1), Val::ZERO);
 
                 // Add in the coefficients of `v_H(X) * r(X)`, where:
@@ -250,7 +244,7 @@ where
                         for j in 0..w {
                             let mul_coeff = p_i * random_values[i * w + j];
                             lde_coeffs[i * w + j] -= mul_coeff;
-                            lde_coeffs[(h + i) * w + j] = p * mul_coeff;
+                            lde_coeffs[(h + i) * w + j] += p * mul_coeff;
                         }
                     });
 
@@ -509,9 +503,9 @@ mod tests {
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
     use p3_commit::ExtensionMmcs;
-    use p3_dft::Radix2Dit;
-    use p3_field::Field;
+    use p3_dft::{Radix2Bowers, Radix2DFTSmallBatch, Radix2Dit};
     use p3_field::extension::BinomialExtensionField;
+    use p3_field::{Field, PrimeCharacteristicRing};
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
     use rand::SeedableRng;
@@ -530,6 +524,8 @@ mod tests {
     type Dft = Radix2Dit<Val>;
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
     type MyPcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
+    /// Same wrapper, left generic over the DFT backend.
+    type HidingPcs<D> = HidingFriPcs<Val, D, ValMmcs, ChallengeMmcs, StdRng>;
 
     type Commitment = <ValMmcs as Mmcs<Val>>::Commitment;
     type Domain = TwoAdicMultiplicativeCoset<Val>;
@@ -721,5 +717,168 @@ mod tests {
             }
             other => panic!("wrong error variant: {other:?}"),
         }
+    }
+
+    /// Seed for the wrapper's mask RNG, replayed by [`expected_quotient_ldes`].
+    const QUOTIENT_RNG_SEED: u64 = 5;
+
+    /// Blowup used by the quotient-LDE tests below.
+    const QUOTIENT_LOG_BLOWUP: usize = 1;
+
+    /// One quotient chunk's LDE written as two independent forward transforms: a coset LDE of the
+    /// chunk plus a full-size DFT of the `v_H * r` mask, summed pointwise.
+    fn quotient_lde_two_transforms<D: TwoAdicSubgroupDft<Val>>(
+        dft: &D,
+        evals: RowMajorMatrix<Val>,
+        random_values: &[Val],
+        shift: Val,
+    ) -> RowMajorMatrix<Val> {
+        let h = evals.height();
+        let w = evals.width();
+
+        let mut lde_evals = dft
+            .coset_lde_batch(evals, QUOTIENT_LOG_BLOWUP + 1, shift)
+            .to_row_major_matrix();
+
+        let mut vanishing_poly_coeffs = Val::zero_vec((h * w) << (QUOTIENT_LOG_BLOWUP + 1));
+        let p = shift.exp_u64(h as u64);
+        Val::GENERATOR
+            .powers()
+            .take(h)
+            .enumerate()
+            .for_each(|(i, p_i)| {
+                for j in 0..w {
+                    let mul_coeff = p_i * random_values[i * w + j];
+                    vanishing_poly_coeffs[i * w + j] -= mul_coeff;
+                    vanishing_poly_coeffs[(h + i) * w + j] = p * mul_coeff;
+                }
+            });
+        let random_eval = dft
+            .dft_batch(DenseMatrix::new(vanishing_poly_coeffs, w))
+            .to_row_major_matrix();
+
+        for i in 0..h * w * (1 << (QUOTIENT_LOG_BLOWUP + 1)) {
+            lde_evals.values[i] += random_eval.values[i];
+        }
+
+        lde_evals.bit_reverse_rows().to_row_major_matrix()
+    }
+
+    /// Replay the mask draws `get_quotient_ldes` makes from `QUOTIENT_RNG_SEED`, then extend every
+    /// chunk with [`quotient_lde_two_transforms`].
+    fn expected_quotient_ldes<D: TwoAdicSubgroupDft<Val>>(
+        dft: &D,
+        domains: &[Domain],
+        mats: &[RowMajorMatrix<Val>],
+    ) -> Vec<RowMajorMatrix<Val>> {
+        let mut rng = StdRng::seed_from_u64(QUOTIENT_RNG_SEED);
+
+        let cis = get_zp_cis(domains);
+        let last_chunk = domains.len() - 1;
+        let last_chunk_ci_inv = cis[last_chunk].inverse();
+        let mul_coeffs = (0..last_chunk)
+            .map(|i| cis[i] * last_chunk_ci_inv)
+            .collect_vec();
+
+        let randomized = mats
+            .iter()
+            .map(|mat| mat.with_random_cols(NUM_RANDOM_CODEWORDS, &mut rng))
+            .collect_vec();
+        let h = randomized[0].height();
+        let w = randomized[0].width();
+        let mut all_random_values = (0..last_chunk * h * w)
+            .map(|_| rng.random())
+            .chain(core::iter::repeat_n(Val::ZERO, h * w))
+            .collect::<Vec<_>>();
+        for j in 0..last_chunk {
+            let mul_coeff = mul_coeffs[j];
+            for k in 0..h * w {
+                let t = all_random_values[j * h * w + k] * mul_coeff;
+                all_random_values[last_chunk * h * w + k] -= t;
+            }
+        }
+
+        domains
+            .iter()
+            .zip(randomized)
+            .enumerate()
+            .map(|(i, (domain, evals))| {
+                let shift = Val::GENERATOR / domain.shift();
+                quotient_lde_two_transforms(
+                    dft,
+                    evals,
+                    &all_random_values[i * h * w..(i + 1) * h * w],
+                    shift,
+                )
+            })
+            .collect()
+    }
+
+    /// `get_quotient_ldes` shares one forward transform between a chunk and its mask. That relies
+    /// on backend conventions (natural-order coefficients through `coset_idft_batch`/`dft_batch`,
+    /// and `bit_reverse_rows` inverting the committed order), so pin it per backend.
+    fn check_fused_quotient_ldes<D: TwoAdicSubgroupDft<Val> + Clone>(dft: &D) {
+        for (log_h, width, num_chunks) in [(3, 4, 2), (4, 3, 4)] {
+            let mut rng = SmallRng::seed_from_u64(11);
+            let perm = Perm::new_from_rng_128(&mut rng);
+            let val_mmcs = ValMmcs::new(MyHash::new(perm.clone()), MyCompress::new(perm), 0);
+            let fri_params = FriParameters {
+                log_blowup: QUOTIENT_LOG_BLOWUP,
+                log_final_poly_len: 0,
+                max_log_arity: 1,
+                num_queries: 2,
+                commit_proof_of_work_bits: 0,
+                query_proof_of_work_bits: 0,
+                mmcs: ChallengeMmcs::new(val_mmcs.clone()),
+            };
+            let pcs = HidingPcs::new(
+                dft.clone(),
+                val_mmcs,
+                fri_params,
+                NUM_RANDOM_CODEWORDS,
+                StdRng::seed_from_u64(QUOTIENT_RNG_SEED),
+            );
+
+            // Chunk domains as the quotient prover builds them: a disjoint domain, split evenly.
+            let trace_domain =
+                Pcs::<Challenge, Challenger>::natural_domain_for_degree(&pcs, 1 << log_h);
+            let domains = trace_domain
+                .create_disjoint_domain(num_chunks << log_h)
+                .split_domains(num_chunks);
+            let mats = domains
+                .iter()
+                .map(|domain| RowMajorMatrix::<Val>::rand(&mut rng, domain.size(), width))
+                .collect_vec();
+
+            let expected = expected_quotient_ldes(dft, &domains, &mats);
+            let fused = Pcs::<Challenge, Challenger>::get_quotient_ldes(
+                &pcs,
+                domains.iter().copied().zip(mats).collect_vec(),
+                num_chunks,
+            );
+
+            assert_eq!(fused.len(), expected.len());
+            for (got, want) in fused.iter().zip(&expected) {
+                assert_eq!(
+                    got.values, want.values,
+                    "log_h={log_h} width={width} num_chunks={num_chunks}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn fused_quotient_lde_matches_two_transforms_radix2_dit() {
+        check_fused_quotient_ldes(&Radix2Dit::<Val>::default());
+    }
+
+    #[test]
+    fn fused_quotient_lde_matches_two_transforms_radix2_bowers() {
+        check_fused_quotient_ldes(&Radix2Bowers);
+    }
+
+    #[test]
+    fn fused_quotient_lde_matches_two_transforms_small_batch() {
+        check_fused_quotient_ldes(&Radix2DFTSmallBatch::<Val>::default());
     }
 }

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -8,6 +8,7 @@ use p3_commit::Mmcs;
 use p3_dft::{Radix2DFTSmallBatch, TwoAdicSubgroupDft};
 use p3_field::{ExtensionField, Field, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::prelude::*;
 use p3_util::{log2_strict_usize, reverse_slice_index_bits};
 use tracing::{debug_span, info_span, instrument};
 
@@ -261,7 +262,10 @@ where
             // to the current folded polynomial, we need to multiply by a random factor.
             // We use beta^arity as the random factor to maintain independence.
             let beta_pow = beta.exp_power_of_2(log_arity);
-            izip!(&mut folded, v).for_each(|(c, x)| *c += beta_pow * x);
+            folded
+                .par_iter_mut()
+                .zip(v.par_iter())
+                .for_each(|(c, &x)| *c += beta_pow * x);
         }
     }
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -102,15 +102,28 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
         log_height: usize,
         log_arity: usize,
         beta: EF,
-        evals: impl Iterator<Item = EF>,
+        mut evals: impl Iterator<Item = EF>,
     ) -> EF {
         let arity = 1 << log_arity;
-        let evals: Vec<_> = evals.collect();
-        assert_eq!(evals.len(), arity, "Expected {} evaluations", arity);
 
         // Compute the evaluation points in the subgroup
         let subgroup_start = F::two_adic_generator(log_height + log_arity)
             .exp_u64(reverse_bits_len(index, log_height) as u64);
+
+        if log_arity == 1 {
+            // The two interpolation points are `{s, -s}` for `s = subgroup_start`, so
+            //     f(beta) = (y_0 + y_1) / 2 + (y_0 - y_1) * beta / (2 s).
+            // This is the closed form used by the arity-2 kernel of `fold_matrix`.
+            let (lo, hi) = evals.next_tuple().expect("Expected 2 evaluations");
+            assert!(evals.next().is_none(), "Expected 2 evaluations");
+
+            let halve_inv_power = subgroup_start.double().inverse();
+            return (lo + hi).halve() + (lo - hi) * beta * halve_inv_power;
+        }
+
+        let evals: Vec<_> = evals.collect();
+        assert_eq!(evals.len(), arity, "Expected {} evaluations", arity);
+
         let mut xs: Vec<F> = F::two_adic_generator(log_arity)
             .shifted_powers(subgroup_start)
             .take(arity)
@@ -768,4 +781,48 @@ fn compute_inverse_denominators<F: TwoAdicField, EF: ExtensionField<F>, M: Matri
             )
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_baby_bear::BabyBear;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<BabyBear, 4>;
+
+    /// `fold_row`'s arity-2 closed form must agree with the generic barycentric path.
+    #[test]
+    fn fold_row_arity_two_matches_lagrange_interpolation() {
+        let mut rng = SmallRng::seed_from_u64(0);
+        let folding = TwoAdicFriFolding::<(), ()>(PhantomData);
+
+        for log_height in 0..6 {
+            for index in 0..(1 << log_height) {
+                let beta: EF = rng.random();
+                let evals: [EF; 2] = [rng.random(), rng.random()];
+
+                // The interpolation points the generic path would build for this row.
+                let subgroup_start = F::two_adic_generator(log_height + 1)
+                    .exp_u64(reverse_bits_len(index, log_height) as u64);
+                let xs = [subgroup_start, -subgroup_start];
+                let expected = lagrange_interpolate_at(&xs, &evals, beta);
+
+                let folded = FriFoldingStrategy::<F, EF>::fold_row(
+                    &folding,
+                    index,
+                    log_height,
+                    1,
+                    beta,
+                    evals.into_iter(),
+                );
+                assert_eq!(folded, expected);
+            }
+        }
+    }
 }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -172,6 +172,8 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
             //   Step 1 (beta):   fold pairs → g(s^2), g(-s^2) where g = f_e + beta*f_o
             //   Step 2 (beta^2): fold pair  → g(beta^2) = f(beta)
 
+            // Every row splits into whole `(lo, hi)` pairs.
+            debug_assert!(m.width().is_multiple_of(2));
             let pairs_per_row = m.width() / 2;
             let initial_height = m.height() * pairs_per_row;
             let g_inv = F::two_adic_generator(log2_strict_usize(initial_height) + 1).inverse();

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -172,9 +172,8 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
             //   Step 1 (beta):   fold pairs → g(s^2), g(-s^2) where g = f_e + beta*f_o
             //   Step 2 (beta^2): fold pair  → g(beta^2) = f(beta)
 
-            let mut data = m.to_row_major_matrix().values;
-
-            let initial_height = data.len() / 2;
+            let pairs_per_row = m.width() / 2;
+            let initial_height = m.height() * pairs_per_row;
             let g_inv = F::two_adic_generator(log2_strict_usize(initial_height) + 1).inverse();
             let mut halve_inv_powers = g_inv
                 .shifted_powers(F::ONE.halve())
@@ -182,17 +181,28 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
             reverse_slice_index_bits(&mut halve_inv_powers);
 
             let two = F::ONE + F::ONE;
-            let mut current_beta = beta;
-            let mut next_data = EF::zero_vec(initial_height);
 
-            for step in 0..log_arity {
-                let current_len = data.len();
-                let height = current_len / 2;
-                // Since j << 1 is always >= j, we never overwrite data we haven't read yet.
-                if step > 0 {
-                    for j in 0..height {
-                        halve_inv_powers[j] = two * halve_inv_powers[j << 1].square();
+            // The first fold reads the borrowed matrix row by row, so `m` is never copied.
+            let mut data = EF::zero_vec(initial_height);
+            data.par_chunks_exact_mut(pairs_per_row)
+                .zip(m.par_rows())
+                .zip(halve_inv_powers.par_chunks_exact(pairs_per_row))
+                .for_each(|((out, row), inv_powers)| {
+                    for (o, (lo, hi), &halve_inv_power) in
+                        izip!(out.iter_mut(), row.tuples::<(EF, EF)>(), inv_powers)
+                    {
+                        *o = (lo + hi).halve() + (lo - hi) * beta * halve_inv_power;
                     }
+                });
+
+            let mut current_beta = beta.square();
+            let mut next_data = EF::zero_vec(initial_height / 2);
+
+            for _ in 1..log_arity {
+                let height = data.len() / 2;
+                // Since j << 1 is always >= j, we never overwrite data we haven't read yet.
+                for j in 0..height {
+                    halve_inv_powers[j] = two * halve_inv_powers[j << 1].square();
                 }
                 next_data[..height]
                     .par_iter_mut()
@@ -207,9 +217,9 @@ impl<F: TwoAdicField, InputProof: Sync, InputError: Debug + Sync, EF: ExtensionF
                     });
                 current_beta = current_beta.square();
 
-                // Swap buffers conceptually (just truncate data and copy back, or ping-pong).
+                // Ping-pong the two buffers; the tail of the new `data` is stale and dropped.
+                core::mem::swap(&mut data, &mut next_data);
                 data.truncate(height);
-                data.copy_from_slice(&next_data[..height]);
             }
 
             data
@@ -822,6 +832,36 @@ mod tests {
                     evals.into_iter(),
                 );
                 assert_eq!(folded, expected);
+            }
+        }
+    }
+
+    /// `fold_matrix` folds row `i` of its input exactly as `fold_row` folds that row on its own.
+    #[test]
+    fn fold_matrix_matches_fold_row() {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let folding = TwoAdicFriFolding::<(), ()>(PhantomData);
+
+        for log_arity in 1..4 {
+            for log_height in 0..5 {
+                let beta: EF = rng.random();
+                let m = RowMajorMatrix::<EF>::rand(&mut rng, 1 << log_height, 1 << log_arity);
+
+                let folded = FriFoldingStrategy::<F, EF>::fold_matrix(
+                    &folding,
+                    beta,
+                    log_arity,
+                    m.as_view(),
+                );
+                assert_eq!(folded.len(), m.height());
+
+                for (index, &expected) in folded.iter().enumerate() {
+                    let row = m.row(index).unwrap().into_iter();
+                    let folded_row = FriFoldingStrategy::<F, EF>::fold_row(
+                        &folding, index, log_height, log_arity, beta, row,
+                    );
+                    assert_eq!(folded_row, expected);
+                }
             }
         }
     }

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -7,7 +7,9 @@ use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
-use p3_field::{ExtensionField, Field, HornerIter, TwoAdicField, batch_multiplicative_inverse};
+use p3_field::{
+    ExtensionField, Field, HornerIter, TwoAdicField, batch_multiplicative_inverse, dot_product,
+};
 use p3_matrix::Dimensions;
 use p3_util::{log2_strict_usize, reverse_bits_len};
 use thiserror::Error;
@@ -816,14 +818,64 @@ where
     }
     let mut inverse_denominators = batch_multiplicative_inverse(&denominators).into_iter();
 
+    // Within one `log_height`, the powers of `alpha` form a ladder that advances once per opened
+    // column, walking (batch, matrix, point, column) in a fixed order. The column counts come from
+    // the claimed evaluations, which `verify_multi_batch` above has already bound every opened row
+    // to, so the ladder is the same for every query.
+    //
+    // Writing `off` for the ladder position at which an opening point starts, that point contributes
+    //
+    //     sum_i alpha^(off + i) * (p_i(z) - p_i(x)) / (z - x).
+    //
+    // The `p_i(z)` half depends only on the claimed values, so it is shared across all queries. The
+    // remaining `p_i(x)` half is a dot product of extension-field powers against an authenticated
+    // base-field row. This mirrors how the prover builds the same combination in `TwoAdicFriPcs`.
+    let opening_points = || {
+        commitments_with_opening_points
+            .iter()
+            .flat_map(|(_, mats)| {
+                mats.iter().flat_map(|(mat_domain, mat_points_and_values)| {
+                    let log_height = log2_strict_usize(mat_domain.size()) + params.log_blowup;
+                    mat_points_and_values
+                        .iter()
+                        .map(move |(_, ps_at_z)| (log_height, ps_at_z))
+                })
+            })
+    };
+
+    // The longest ladder over all heights bounds how many powers of alpha are ever needed.
+    let mut ladder_lens = BTreeMap::<usize, usize>::new();
+    for (log_height, ps_at_z) in opening_points() {
+        *ladder_lens.entry(log_height).or_insert(0) += ps_at_z.len();
+    }
+    let alpha_powers = alpha
+        .powers()
+        .collect_n(ladder_lens.into_values().max().unwrap_or(0));
+
+    // For each opening point, its ladder start and `sum_i alpha^(off + i) * p_i(z)`.
+    let mut ladder_offsets = BTreeMap::<usize, usize>::new();
+    let point_reductions: Vec<(usize, Challenge)> = opening_points()
+        .map(|(log_height, ps_at_z)| {
+            let offset = ladder_offsets.entry(log_height).or_insert(0);
+            let start = *offset;
+            *offset += ps_at_z.len();
+            let sum_at_z = dot_product(
+                alpha_powers[start..*offset].iter().copied(),
+                ps_at_z.iter().copied(),
+            );
+            (start, sum_at_z)
+        })
+        .collect();
+
     // Combine each query's authenticated values into its reduced openings.
     indices
         .iter()
         .enumerate()
         .map(|(query, _)| {
-            // For each log_height, we store the alpha power and compute the reduced opening.
-            // log_height -> (alpha_pow, reduced_opening)
-            let mut reduced_openings = BTreeMap::<usize, (Challenge, Challenge)>::new();
+            // log_height -> reduced_opening
+            let mut reduced_openings = BTreeMap::<usize, Challenge>::new();
+            // The per-opening-point data above, replayed in the same order for this query.
+            let mut reductions = point_reductions.iter();
 
             for (batch, (batch_opening, (_, mats))) in input_openings
                 .iter()
@@ -839,12 +891,13 @@ where
                 {
                     let log_height = log2_strict_usize(mat_domain.size()) + params.log_blowup;
 
-                    let (alpha_pow, ro) = reduced_openings
+                    let ro = reduced_openings
                         .entry(log_height) // Get a mutable reference to the entry.
-                        .or_insert((Challenge::ONE, Challenge::ZERO));
+                        .or_insert(Challenge::ZERO);
 
-                    // For each polynomial `f` in our matrix, compute `(f(z) - f(x))/(z - x)`,
-                    // scale by the appropriate alpha power and add to the reduced opening for this log_height.
+                    // For each opening point, combine this matrix's polynomials with the powers of
+                    // alpha at that point's ladder position, map the combination through
+                    // `(f(z) - f(x))/(z - x)` and add it to the reduced opening for this log_height.
                     for (point, (_z, ps_at_z)) in mat_points_and_values.iter().enumerate() {
                         if mat_opening.len() != ps_at_z.len() {
                             return Err(FriError::PointEvaluationCountMismatch {
@@ -862,13 +915,22 @@ where
                         let quotient = inverse_denominators
                             .next()
                             .expect("one inverse was precomputed per opening point");
-                        for (&p_at_x, &p_at_z) in mat_opening.iter().zip(ps_at_z.iter()) {
-                            // Note we just checked batch proofs to ensure p_at_x is correct.
-                            // x, z were sent by the verifier.
-                            // ps_at_z was sent to the verifier and we are using fri to prove it is correct.
-                            *ro += *alpha_pow * (p_at_z - p_at_x) * quotient;
-                            *alpha_pow *= alpha;
-                        }
+                        // The ladder position and the combination of the claimed values at this
+                        // opening point, precomputed above in this same iteration order.
+                        let &(offset, sum_at_z) = reductions
+                            .next()
+                            .expect("one reduction was precomputed per opening point");
+
+                        // Note we just checked batch proofs to ensure mat_opening is correct.
+                        // x, z were sent by the verifier.
+                        // ps_at_z was sent to the verifier and we are using fri to prove it is correct.
+                        let sum_at_x: Challenge = dot_product(
+                            alpha_powers[offset..offset + mat_opening.len()]
+                                .iter()
+                                .copied(),
+                            mat_opening.iter().copied(),
+                        );
+                        *ro += (sum_at_z - sum_at_x) * quotient;
                     }
                 }
             }
@@ -876,18 +938,14 @@ where
             // The blowup-height entry exists only for a height-1 (constant) trace matrix.
             // Its quotient `(f(zeta) - f(x)) / (zeta - x)` must then be zero.
             // One check after all batches suffices: the random combining challenge rules out cancellation.
-            if let Some((_, ro)) = reduced_openings.get(&params.log_blowup)
+            if let Some(ro) = reduced_openings.get(&params.log_blowup)
                 && !ro.is_zero()
             {
                 return Err(FriError::FinalPolyMismatch);
             }
 
             // Return reduced openings descending by log_height.
-            Ok(reduced_openings
-                .into_iter()
-                .rev()
-                .map(|(log_height, (_, ro))| (log_height, ro))
-                .collect())
+            Ok(reduced_openings.into_iter().rev().collect())
         })
         .collect()
 }


### PR DESCRIPTION
## Changes

- `fold_row`: closed-form arity-2 fast path instead of generic Lagrange interpolation (verifier hot path).
- `fold_matrix`: fold the borrowed input matrix in place for high arities instead of cloning it up front, buffer-swap instead of copy between fold steps.
- `open_inputs`: hoist the query-invariant alpha ladder out of the per-query loop; per-column cost drops from EF×EF to EF×base-field (verifier hot path).
- `HidingFriPcs::get_quotient_ldes`: fuse the chunk LDE and mask transforms into a single forward DFT.
- Parallelize the reduced-opening roll-in in `commit_phase`.
- Benchmark fix: stop timing a matrix clone inside the measured closure.

All bit-identical to `main` (verified via differential testing against independent reference implementations for every commit, including a per-DFT-backend regression test for the hiding LDE fusion).

## Benchmarks

`fold_matrix` bench (arity 1, all field types), this machine, main vs branch (20 samples):

| field | size | main | branch | Δ |
|---|---|---|---|---|
| BabyBear | 4K–4M | 11.5 µs–13.4 ms | 11.1 µs–12.9 ms | −3.6% to −4.9% |
| Goldilocks | 4K–4M | 16.0 µs–19.2 ms | 14.0 µs–18.2 ms | −4.4% to −12.3% |
| Mersenne31^2 | 4K–4M | 32.2 µs–37.4 ms | 30.2 µs–35.5 ms | −3.1% to −6.3% |
