### PR TITLE
perf(binary-field): Karatsuba fallback, vector-native GF(2^128) mul, Frobenius conjugation, table squaring

### DIFF
--- a/binary-field/src/clmul/aarch64.rs
+++ b/binary-field/src/clmul/aarch64.rs
@@ -1,6 +1,10 @@
 //! The `PMULL` backend, which lives under the `aes` target feature.
 
-use core::arch::aarch64::vmull_p64;
+use core::arch::aarch64::{
+    uint8x16_t, vdupq_n_u8, vdupq_n_u64, veorq_u8, vextq_u8, vgetq_lane_u64, vmull_high_p64,
+    vmull_p64, vreinterpretq_p64_u8, vreinterpretq_u8_u64, vreinterpretq_u64_u8,
+};
+use core::mem::transmute;
 
 /// The carryless product of two 64-bit polynomials over `GF(2)`.
 ///
@@ -11,4 +15,77 @@ pub(super) fn clmul_64x64(a: u64, b: u64) -> u128 {
     // SAFETY: this module is compiled only when `target_feature = "aes"` is enabled for the
     // crate, and `aes` implies `neon`; together those are what `vmull_p64` requires.
     unsafe { vmull_p64(a, b) }
+}
+
+/// The carryless product of the low halves of `a` and `b`.
+///
+/// # Safety
+/// The caller must be compiled with the `aes` target feature.
+#[inline]
+unsafe fn clmul_low(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+    // SAFETY: guaranteed by the caller. The lane extractions feed `PMULL` directly, so the
+    // operands stay in vector registers.
+    unsafe {
+        transmute(vmull_p64(
+            vgetq_lane_u64::<0>(vreinterpretq_u64_u8(a)),
+            vgetq_lane_u64::<0>(vreinterpretq_u64_u8(b)),
+        ))
+    }
+}
+
+/// The carryless product of the high halves of `a` and `b`.
+///
+/// # Safety
+/// The caller must be compiled with the `aes` target feature.
+#[inline]
+unsafe fn clmul_high(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
+    // SAFETY: guaranteed by the caller.
+    unsafe {
+        transmute(vmull_high_p64(
+            vreinterpretq_p64_u8(a),
+            vreinterpretq_p64_u8(b),
+        ))
+    }
+}
+
+/// Multiplication in `GF(2^128) = GF(2)[x] / (x^128 + x^7 + x^2 + x + 1)`, both operands and the
+/// result in the polynomial basis.
+///
+/// Schoolbook over the 64-bit halves, then the two-round fold of the modulus, with every 128-bit
+/// intermediate held in a vector register: the halves are selected by `PMULL`'s own lane choice
+/// and by `EXT`, and the fold multiplies by the modulus tail with `PMULL` rather than shifting.
+///
+/// The fold is the identity `x^128 ≡ x^7 + x^2 + x + 1`. Writing the high half of the product as
+/// `h0 + h1·x^64` and the tail as `T`, the first round gives `h1·T = e0 + e1·x^64` with `e1` of
+/// degree at most 6, and the second folds `e1·x^128 ≡ e1·T` back down. Collecting the two terms
+/// that are multiplied by `T` leaves `(h0 + e1)·T + e0·x^64`, of degree at most 126, so a single
+/// further product finishes the reduction.
+#[inline]
+pub(super) fn poly_mul_128(a: u128, b: u128) -> u128 {
+    // SAFETY: this module is compiled only when `target_feature = "aes"` is enabled for the
+    // crate, and `aes` implies `neon`; together those are what every intrinsic below requires.
+    unsafe {
+        let a = transmute::<u128, uint8x16_t>(a);
+        let b = transmute::<u128, uint8x16_t>(b);
+        let zero = vdupq_n_u8(0);
+        // The tail `x^7 + x^2 + x + 1` of the modulus, in both lanes so `PMULL` can take it
+        // against either half.
+        let tail = vreinterpretq_u8_u64(vdupq_n_u64(super::basis::TAIL_128 as u64));
+
+        // `EXT #8` swaps the halves, so the two cross products come from the same lane choices
+        // as the two diagonal ones.
+        let swapped = vextq_u8::<8>(b, b);
+        let middle = veorq_u8(clmul_low(a, swapped), clmul_high(a, swapped));
+
+        // `EXT` against zero is a 128-bit shift by 64 in either direction.
+        let low = veorq_u8(clmul_low(a, b), vextq_u8::<8>(zero, middle));
+        let high = veorq_u8(clmul_high(a, b), vextq_u8::<8>(middle, zero));
+
+        let folded = clmul_high(high, tail);
+        let spill = vextq_u8::<8>(folded, zero);
+        let carried = vextq_u8::<8>(zero, folded);
+
+        let reduced = veorq_u8(low, clmul_low(veorq_u8(high, spill), tail));
+        transmute::<uint8x16_t, u128>(veorq_u8(reduced, carried))
+    }
 }

--- a/binary-field/src/clmul/aarch64.rs
+++ b/binary-field/src/clmul/aarch64.rs
@@ -58,10 +58,19 @@ unsafe fn clmul_high(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
 /// The fold is the identity `x^128 ≡ x^7 + x^2 + x + 1`. Writing the high half of the product as
 /// `h0 + h1·x^64` and the tail as `T`, the first round gives `h1·T = e0 + e1·x^64` with `e1` of
 /// degree at most 6, and the second folds `e1·x^128 ≡ e1·T` back down. Collecting the two terms
-/// that are multiplied by `T` leaves `(h0 + e1)·T + e0·x^64`, of degree at most 126, so a single
+/// that are multiplied by `T` leaves `(h0 + e1)·T + e0·x^64`, of degree at most 127, so a single
 /// further product finishes the reduction.
 #[inline]
 pub(super) fn poly_mul_128(a: u128, b: u128) -> u128 {
+    const {
+        // `target_arch = "aarch64"` covers the big-endian AArch64 targets too, where the halves
+        // of a `u128` and the lanes of a vector run in opposite orders.
+        assert!(
+            cfg!(target_endian = "little"),
+            "the halves of a `u128` are its vector lanes only on little-endian targets"
+        );
+    }
+
     // SAFETY: this module is compiled only when `target_feature = "aes"` is enabled for the
     // crate, and `aes` implies `neon`; together those are what every intrinsic below requires.
     unsafe {

--- a/binary-field/src/clmul/basis.rs
+++ b/binary-field/src/clmul/basis.rs
@@ -165,7 +165,7 @@ const fn invert(cols: &[u128; 128], bits: usize) -> [u128; 128] {
 /// Only the first `bits / 8` tables are meaningful. Each entry drops the lowest set bit of the
 /// index and reuses the entry for the rest, so every entry costs a single `XOR`.
 ///
-/// A byte is the widest chunk worth tabulating: the whole set of tables comes to 160 KiB, and
+/// A byte is the widest chunk worth tabulating: the whole set of tables comes to 176 KiB, and
 /// the conversions are limited by how many loads the core can retire, so halving the lookups
 /// pays for the extra footprint. Narrower nibble tables fit a first-level cache several times
 /// over but measure substantially slower at both widths.

--- a/binary-field/src/clmul/basis.rs
+++ b/binary-field/src/clmul/basis.rs
@@ -184,6 +184,35 @@ const fn byte_tables(cols: &[u128; 128], bits: usize) -> [[u128; 256]; 16] {
     tables
 }
 
+/// The columns of the tower-basis matrix of squaring.
+///
+/// Squaring is `GF(2)`-linear in characteristic 2 — the cross term of `(a + b)²` is `2ab` — so
+/// in any basis it is a matrix, and the tower basis is no exception. Conjugating the
+/// polynomial-basis square by the change of basis gives that matrix: column `j` is
+/// `M(N(e_j)²)`, for `e_j` the `j`-th tower basis element and `M = N⁻¹`.
+///
+/// Applying `M` to a vector is the sum of the columns of `M` selected by its set bits, which is
+/// what the inner loop does. Only the first `bits` entries are meaningful.
+const fn square_columns(bits: usize, tail: u128, cols: &[u128; 128]) -> [u128; 128] {
+    let inverse = invert(cols, bits);
+    let mut squared = [0u128; 128];
+    let mut j = 0;
+    while j < bits {
+        let image = poly_mul(cols[j], cols[j], bits, tail);
+        let mut column = 0u128;
+        let mut i = 0;
+        while i < bits {
+            if (image >> i) & 1 == 1 {
+                column ^= inverse[i];
+            }
+            i += 1;
+        }
+        squared[j] = column;
+        j += 1;
+    }
+    squared
+}
+
 /// The low 64 bits of each entry of the first eight tables.
 const fn narrow(tables: &[[u128; 256]; 16]) -> [[u64; 256]; 8] {
     let mut narrowed = [[0u64; 256]; 8];
@@ -204,6 +233,8 @@ const COLUMNS_128: [u128; 128] = columns(128, TAIL_128, &XI_128);
 
 static TOWER_TO_POLY_64: [[u64; 256]; 8] = narrow(&byte_tables(&COLUMNS_64, 64));
 static POLY_TO_TOWER_64: [[u64; 256]; 8] = narrow(&byte_tables(&invert(&COLUMNS_64, 64), 64));
+static SQUARE_64: [[u64; 256]; 8] =
+    narrow(&byte_tables(&square_columns(64, TAIL_64, &COLUMNS_64), 64));
 static TOWER_TO_POLY_128: [[u128; 256]; 16] = byte_tables(&COLUMNS_128, 128);
 static POLY_TO_TOWER_128: [[u128; 256]; 16] = byte_tables(&invert(&COLUMNS_128, 128), 128);
 
@@ -237,6 +268,12 @@ pub(super) fn tower_to_poly_64(v: u64) -> u64 {
 #[inline]
 pub(super) fn poly_to_tower_64(v: u64) -> u64 {
     apply_64(&POLY_TO_TOWER_64, v)
+}
+
+/// Squaring in `GF(2^64)`, taking and returning the tower representation.
+#[inline]
+pub(super) fn tower_square_64(v: u64) -> u64 {
+    apply_64(&SQUARE_64, v)
 }
 
 /// `GF(2^128)` from the tower basis to the polynomial basis.

--- a/binary-field/src/clmul/mod.rs
+++ b/binary-field/src/clmul/mod.rs
@@ -4,9 +4,11 @@
 //! representation. [`basis`] supplies the change of basis between the two, leaving three steps:
 //! map both operands into the polynomial basis, multiply and reduce there, and map back.
 //!
-//! Only the `64 × 64 → 128` carryless product is architecture-specific. The wider product is
-//! built from it, and the reduction is plain shifts and `XOR`s, so everything except a single
-//! instruction is shared, portable code that the tests exercise on every target.
+//! Architecture-specific code is confined to the backends: the `64 × 64 → 128` carryless
+//! product, and on some targets a whole `GF(2^128)` product that never leaves the vector unit.
+//! Composing the wider product from the half products and folding the modulus are plain shifts
+//! and `XOR`s, so the definition of every routine here is portable code that the tests exercise
+//! on every target, and each backend is checked against it.
 
 mod basis;
 
@@ -130,16 +132,42 @@ pub(crate) fn mul_64(a: u64, b: u64) -> u64 {
 }
 
 /// Multiplication in `GF(2^128)`, taking and returning the polynomial representation.
+///
+/// The 256-bit product is assembled and folded in general-purpose registers, so the whole
+/// operation is a short dependency chain and nothing waits on a wider one.
 #[inline]
-pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
+fn composed_poly_mul_128(a: u128, b: u128) -> u128 {
     let (low, high) = clmul_128x128(a, b);
     reduce_128(low, high)
 }
 
+/// Multiplication in `GF(2^128)`, taking and returning the polynomial representation.
+///
+/// Where the target has one, this is a kernel that keeps both operands in vector registers from
+/// end to end. It issues more instructions than [`composed_poly_mul_128`] but none that leave
+/// the vector unit, which is the better trade only for a caller with several products in
+/// flight at once; [`composed_poly_mul_128`] is the one to reach for on a dependency chain.
+#[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+#[inline]
+pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
+    aarch64::poly_mul_128(a, b)
+}
+
+/// Multiplication in `GF(2^128)`, taking and returning the polynomial representation.
+#[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
+#[inline]
+pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
+    composed_poly_mul_128(a, b)
+}
+
 /// Multiplication in `GF(2^128)`, taking and returning the tower representation.
+///
+/// The three changes of basis around the product are sixteen dependent lookups each, so this
+/// takes the composition rather than the vector kernel: there is no throughput to win behind a
+/// chain of loads that long.
 #[inline]
 pub(crate) fn mul_128(a: u128, b: u128) -> u128 {
-    let product = poly_mul_128(basis::tower_to_poly_128(a), basis::tower_to_poly_128(b));
+    let product = composed_poly_mul_128(basis::tower_to_poly_128(a), basis::tower_to_poly_128(b));
     basis::poly_to_tower_128(product)
 }
 
@@ -244,6 +272,48 @@ mod tests {
                 u128::from(super::reduce_64(product)),
                 poly_mul(u128::from(a as u64), u128::from(b as u64), 64, TAIL_64),
             );
+        }
+    }
+
+    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+    proptest! {
+        // The kernel below is the one routine here with no portable definition standing behind
+        // it, so it is checked over many more pairs than the rest of the module.
+        #![proptest_config(ProptestConfig::with_cases(20_000))]
+
+        /// The vector-native kernel must agree bit for bit with the composition it stands in for.
+        #[test]
+        fn the_vector_kernel_matches_the_composition(a: u128, b: u128) {
+            prop_assert_eq!(
+                super::aarch64::poly_mul_128(a, b),
+                super::composed_poly_mul_128(a, b),
+            );
+        }
+    }
+
+    /// The edge cases a random search is unlikely to reach: the identities, and the operands
+    /// whose half products and reduction spill are maximal.
+    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
+    #[test]
+    fn the_vector_kernel_matches_the_composition_on_extremes() {
+        let corners = [
+            0,
+            1,
+            u128::MAX,
+            1 << 127,
+            1 << 64,
+            (1u128 << 64) - 1,
+            u128::MAX << 64,
+            0x8000_0000_0000_0001_8000_0000_0000_0001,
+        ];
+        for a in corners {
+            for b in corners {
+                assert_eq!(
+                    super::aarch64::poly_mul_128(a, b),
+                    super::composed_poly_mul_128(a, b),
+                    "{a:#x} * {b:#x}"
+                );
+            }
         }
     }
 

--- a/binary-field/src/clmul/mod.rs
+++ b/binary-field/src/clmul/mod.rs
@@ -14,6 +14,9 @@ mod basis;
 
 pub(crate) use basis::{poly_to_tower_128, tower_to_poly_128};
 
+use crate::BinaryField64;
+use crate::tower::TowerLevel;
+
 #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
 mod aarch64;
 #[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
@@ -173,12 +176,13 @@ pub(crate) fn mul_128(a: u128, b: u128) -> u128 {
 
 /// Squaring in `GF(2^64)`, taking and returning the tower representation.
 ///
-/// The change of basis is linear and applied once here, where a product of two operands pays
-/// for it twice.
+/// Squaring is `GF(2)`-linear in characteristic 2, so in the tower basis it is a fixed matrix,
+/// tabulated a byte of the input at a time exactly as the changes of basis are. That is eight
+/// lookups, against the two conversions and a carryless product a route through the polynomial
+/// basis would cost.
 #[inline]
 pub(crate) fn square_64(a: u64) -> u64 {
-    let poly = basis::tower_to_poly_64(a);
-    basis::poly_to_tower_64(reduce_64(clmul_64x64(poly, poly)))
+    basis::tower_square_64(a)
 }
 
 /// Squaring in `GF(2^128)`, taking and returning the polynomial representation.
@@ -193,9 +197,19 @@ pub(crate) fn poly_square_128(a: u128) -> u128 {
 }
 
 /// Squaring in `GF(2^128)`, taking and returning the tower representation.
+///
+/// The tower basis of this level is the tower basis of the level below, twice over, so the two
+/// halves square through [`square_64`]: with `a = a0 + a1·X` and `X² = αX + 1`, the cross term
+/// vanishes in characteristic 2 and `a² = (a0² + a1²) + α·a1²·X`.
+///
+/// Tabulating this level directly would take a table four times the size for the same sixteen
+/// lookups, so the level below's is used twice instead.
 #[inline]
 pub(crate) fn square_128(a: u128) -> u128 {
-    basis::poly_to_tower_128(poly_square_128(basis::tower_to_poly_128(a)))
+    let low = square_64(a as u64);
+    let high = square_64((a >> 64) as u64);
+    let scaled = BinaryField64::from_repr(high).mul_alpha().to_repr();
+    u128::from(low ^ high) | (u128::from(scaled) << 64)
 }
 
 #[cfg(test)]
@@ -205,6 +219,20 @@ mod tests {
     use super::basis::{TAIL_64, TAIL_128, poly_mul};
     use crate::tower::TowerLevel;
     use crate::{BinaryField64, BinaryField128};
+
+    /// Squaring in `GF(2^64)`, through the polynomial basis.
+    ///
+    /// The independent definition of the tower-basis square, leaning on the change of basis and
+    /// the carryless product rather than on a matrix of its own.
+    fn square_64_through_the_polynomial_basis(a: u64) -> u64 {
+        let poly = super::basis::tower_to_poly_64(a);
+        super::basis::poly_to_tower_64(super::reduce_64(super::clmul_64x64(poly, poly)))
+    }
+
+    /// Squaring in `GF(2^128)`, through the polynomial basis.
+    fn square_128_through_the_polynomial_basis(a: u128) -> u128 {
+        super::basis::poly_to_tower_128(super::poly_square_128(super::basis::tower_to_poly_128(a)))
+    }
 
     /// The carryless product of two 128-bit polynomials, one bit of `b` at a time.
     fn scalar_clmul_128x128(a: u128, b: u128) -> (u128, u128) {
@@ -247,6 +275,17 @@ mod tests {
         fn clmul_64_square_matches_reference(a: u64) {
             let x = BinaryField64::from_repr(a);
             prop_assert_eq!(super::square_64(a), x.reference_mul(x).to_repr());
+        }
+
+        /// The tower-basis squaring matrix must agree with squaring through the polynomial
+        /// basis, at both levels that take it.
+        #[test]
+        fn the_squaring_tables_agree_with_the_polynomial_basis_route(a: u64, b: u128) {
+            prop_assert_eq!(super::square_64(a), square_64_through_the_polynomial_basis(a));
+            prop_assert_eq!(
+                super::square_128(b),
+                square_128_through_the_polynomial_basis(b),
+            );
         }
 
         /// Whichever backend the target selected must agree with the bit-serial definition.

--- a/binary-field/src/extension.rs
+++ b/binary-field/src/extension.rs
@@ -87,18 +87,45 @@ macro_rules! binary_tower_extension {
                 Self::from_repr(repr)
             }
 
-            /// The coefficients of an element are already contiguous, so one buffer sized up
-            /// front takes them all without a temporary per element.
+            /// A whole vector of elements is one contiguous run of coefficients, for the same
+            /// reason a single element is, so the flattening is a single copy of the buffer.
+            ///
+            /// The inverse direction is not symmetric, and `reconstitute_from_base` keeps the
+            /// default that builds a fresh buffer: a `Vec<$lower>` is allocated at `$lower`'s
+            /// alignment, which is weaker than `$upper`'s, and freeing an allocation under a
+            /// `Layout` whose alignment differs from the one it was made with is undefined
+            /// behaviour.
             #[inline]
             fn flatten_to_base(vec: Vec<Self>) -> Vec<$lower> {
-                let dimension = <$upper as BasedVectorSpace<$lower>>::DIMENSION;
-                let mut flat = Vec::with_capacity(vec.len() * dimension);
-                for x in &vec {
-                    flat.extend_from_slice(
-                        <Self as BasedVectorSpace<$lower>>::as_basis_coefficients_slice(x),
+                const {
+                    assert!(
+                        cfg!(target_endian = "little"),
+                        "the tower basis coincides with the memory layout only on little-endian targets"
                     );
+                    assert!(<$lower>::BITS == <$lower_repr>::BITS as usize);
+                    assert!(
+                        size_of::<$upper>()
+                            == <$upper as BasedVectorSpace<$lower>>::DIMENSION
+                                * size_of::<$lower>()
+                    );
+                    assert!(align_of::<$lower>() <= align_of::<$upper>());
                 }
-                flat
+
+                // SAFETY: the argument of `as_basis_coefficients_slice`, over the whole buffer
+                // rather than one element: both levels are `repr(transparent)` over unsigned
+                // integers and a `Vec`'s elements are contiguous and padding-free, so the
+                // allocation is `len * DIMENSION` canonical `$lower` values, aligned at least as
+                // strictly as `$lower` requires; the assertions above check the size, alignment
+                // and endianness that relies on. An empty `Vec` yields a dangling but aligned
+                // pointer, which is what a zero-length slice needs. The slice borrows `vec`, and
+                // is copied out below while `vec` is still live, so it never dangles.
+                let coefficients: &[$lower] = unsafe {
+                    slice::from_raw_parts(
+                        vec.as_ptr().cast::<$lower>(),
+                        vec.len() * <$upper as BasedVectorSpace<$lower>>::DIMENSION,
+                    )
+                };
+                coefficients.to_vec()
             }
 
             #[inline]

--- a/binary-field/src/extension.rs
+++ b/binary-field/src/extension.rs
@@ -87,6 +87,20 @@ macro_rules! binary_tower_extension {
                 Self::from_repr(repr)
             }
 
+            /// The coefficients of an element are already contiguous, so one buffer sized up
+            /// front takes them all without a temporary per element.
+            #[inline]
+            fn flatten_to_base(vec: Vec<Self>) -> Vec<$lower> {
+                let dimension = <$upper as BasedVectorSpace<$lower>>::DIMENSION;
+                let mut flat = Vec::with_capacity(vec.len() * dimension);
+                for x in &vec {
+                    flat.extend_from_slice(
+                        <Self as BasedVectorSpace<$lower>>::as_basis_coefficients_slice(x),
+                    );
+                }
+                flat
+            }
+
             #[inline]
             fn from_basis_coefficients_iter<I: ExactSizeIterator<Item = $lower>>(
                 iter: I,
@@ -100,28 +114,6 @@ macro_rules! binary_tower_extension {
                     }
                     Self::from_repr(repr)
                 })
-            }
-
-            /// The tower basis coincides with the byte layout, so the whole buffer already *is*
-            /// its coefficients: flattening is one copy, not one per element.
-            ///
-            /// The inverse direction is not symmetric, and `reconstitute_from_base` keeps the
-            /// default that builds a fresh buffer: a `Vec<$lower>` is allocated at `$lower`'s
-            /// alignment, which is weaker than `$upper`'s, and freeing an allocation under a
-            /// `Layout` whose alignment differs from the one it was made with is undefined
-            /// behaviour.
-            #[inline]
-            fn flatten_to_base(vec: Vec<Self>) -> Vec<$lower> {
-                let d = <$upper as BasedVectorSpace<$lower>>::DIMENSION;
-
-                // SAFETY: exactly the argument in `as_basis_coefficients_slice` above, extended
-                // to the whole buffer: a `Vec<$upper>` is `vec.len()` contiguous, padding-free
-                // `$upper` values, each of which is `d` contiguous `$lower` values in tower-basis
-                // order. The const assertions there cover the endianness, size, alignment and
-                // canonicity this relies on. The slice borrows `vec`, so it cannot outlive it.
-                let flat: &[$lower] =
-                    unsafe { slice::from_raw_parts(vec.as_ptr().cast::<$lower>(), vec.len() * d) };
-                flat.to_vec()
             }
         }
 
@@ -616,6 +608,54 @@ mod tests {
             assert_unspecialised!(BinaryField128, BinaryField16, a);
             assert_unspecialised!(BinaryField128, BinaryField32, a);
         }
+    }
+
+    /// Check `flatten_to_base` against concatenating each element's coefficients in turn, which
+    /// is what [`BasedVectorSpace`] defines it to be, and against reassembly.
+    macro_rules! assert_flatten_matches_concatenation {
+        ($upper:ty, $lower:ty, $vals:expr) => {{
+            let elements: Vec<$upper> = $vals.iter().map(|&v| <$upper>::from_repr(v)).collect();
+
+            let expected: Vec<$lower> = elements
+                .iter()
+                .flat_map(|x| {
+                    <$upper as BasedVectorSpace<$lower>>::as_basis_coefficients_slice(x).to_vec()
+                })
+                .collect();
+
+            let flat = <$upper as BasedVectorSpace<$lower>>::flatten_to_base(elements.clone());
+            assert_eq!(flat, expected);
+            assert_eq!(
+                flat.len(),
+                elements.len() * <$upper as BasedVectorSpace<$lower>>::DIMENSION
+            );
+            assert_eq!(
+                <$upper as BasedVectorSpace<$lower>>::reconstitute_from_base(flat),
+                elements
+            );
+        }};
+    }
+
+    #[test]
+    fn flatten_to_base_concatenates_the_coefficients_on_every_pair() {
+        // The empty case has to reach the same answer as the non-empty one.
+        assert_flatten_matches_concatenation!(BinaryField128, BinaryField8, [0u128; 0]);
+
+        let vals16 = [0u16, 1, 0xfedc, 0xffff];
+        let vals32 = [0u32, 1, 0xfedc_ba98, 0xffff_ffff];
+        let vals64 = [0u64, 1, 0xfedc_ba98_7654_3210, u64::MAX];
+        let vals128 = [0u128, 1, A128, u128::MAX];
+
+        assert_flatten_matches_concatenation!(BinaryField16, BinaryField8, vals16);
+        assert_flatten_matches_concatenation!(BinaryField32, BinaryField8, vals32);
+        assert_flatten_matches_concatenation!(BinaryField64, BinaryField8, vals64);
+        assert_flatten_matches_concatenation!(BinaryField128, BinaryField8, vals128);
+        assert_flatten_matches_concatenation!(BinaryField32, BinaryField16, vals32);
+        assert_flatten_matches_concatenation!(BinaryField64, BinaryField16, vals64);
+        assert_flatten_matches_concatenation!(BinaryField128, BinaryField16, vals128);
+        assert_flatten_matches_concatenation!(BinaryField64, BinaryField32, vals64);
+        assert_flatten_matches_concatenation!(BinaryField128, BinaryField32, vals128);
+        assert_flatten_matches_concatenation!(BinaryField128, BinaryField64, vals128);
     }
 
     /// The embedding is multiplicative and additive, i.e. a ring homomorphism.

--- a/binary-field/src/extension.rs
+++ b/binary-field/src/extension.rs
@@ -177,14 +177,34 @@ macro_rules! binary_tower_extension {
             /// `x ↦ x^n` for `n = 2^BITS` the order of the base field.
             #[inline]
             fn frobenius(&self) -> Self {
-                self.exp_power_of_2(<$lower>::BITS)
+                // Every level of the tower is twice as wide as the one below, so a dimension of
+                // `2` holds exactly when the base field is the level immediately below, and only
+                // then is `$upper` the quadratic extension `X² + αX + 1` whose `split`, `join`
+                // and `mul_alpha` are phrased in terms of. `DIMENSION` is a constant, so the
+                // branch is settled at compile time.
+                if <$upper as BasedVectorSpace<$lower>>::DIMENSION == 2 {
+                    // The two roots of `X² + αX + 1` sum to `α`, so the automorphism fixing the
+                    // level below sends `X` to `X + α`, and `a0 + a1·X` to `(a0 + α·a1) + a1·X`.
+                    let (a0, a1) = self.split();
+                    Self::join(a0 + a1.mul_alpha(), a1)
+                } else {
+                    self.exp_power_of_2(<$lower>::BITS)
+                }
             }
 
             #[inline]
             fn repeated_frobenius(&self, count: usize) -> Self {
                 // The Galois group is cyclic of order `DIMENSION`, so `count` reduces modulo it.
                 let count = count % <$upper as BasedVectorSpace<$lower>>::DIMENSION;
-                self.exp_power_of_2(<$lower>::BITS * count)
+                if <$upper as BasedVectorSpace<$lower>>::DIMENSION == 2 {
+                    if count == 0 {
+                        *self
+                    } else {
+                        <Self as HasFrobenius<$lower>>::frobenius(self)
+                    }
+                } else {
+                    self.exp_power_of_2(<$lower>::BITS * count)
+                }
             }
 
             #[inline]
@@ -214,6 +234,7 @@ mod tests {
 
     use p3_field::extension::HasFrobenius;
     use p3_field::{BasedVectorSpace, ExtensionField, PrimeCharacteristicRing};
+    use proptest::prelude::*;
 
     use crate::tower::TowerLevel;
     use crate::{BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128};
@@ -536,6 +557,65 @@ mod tests {
         assert_eq!(packed.len(), 128);
         let flat = <BinaryField16 as BasedVectorSpace<BinaryField8>>::flatten_to_base(packed);
         assert_eq!(flat, all);
+    }
+
+    /// Check the conjugation `frobenius` takes over the level immediately below against the
+    /// repeated squaring that defines it, for one element.
+    macro_rules! assert_frobenius_is_repeated_squaring {
+        ($upper:ty, $lower:ty, $val:expr) => {{
+            let a = <$upper>::from_repr($val);
+            let dim = <$upper as BasedVectorSpace<$lower>>::DIMENSION;
+            assert_eq!(dim, 2, "the specialisation only covers adjacent levels");
+
+            prop_assert_eq!(
+                HasFrobenius::<$lower>::frobenius(&a),
+                a.exp_power_of_2(<$lower>::BITS)
+            );
+            for count in 0..(2 * dim + 3) {
+                prop_assert_eq!(
+                    HasFrobenius::<$lower>::repeated_frobenius(&a, count),
+                    a.exp_power_of_2(<$lower>::BITS * (count % dim))
+                );
+            }
+        }};
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+
+        /// Frobenius over the level immediately below is conjugation rather than a chain of
+        /// squarings; the two must agree at each of the four levels that take that route.
+        #[test]
+        fn frobenius_over_the_adjacent_level_is_repeated_squaring(
+            a in any::<u128>(),
+        ) {
+            assert_frobenius_is_repeated_squaring!(BinaryField16, BinaryField8, a as u16);
+            assert_frobenius_is_repeated_squaring!(BinaryField32, BinaryField16, a as u32);
+            assert_frobenius_is_repeated_squaring!(BinaryField64, BinaryField32, a as u64);
+            assert_frobenius_is_repeated_squaring!(BinaryField128, BinaryField64, a);
+        }
+
+        /// The levels whose base field is further down keep the repeated squaring, so the
+        /// specialisation must not have leaked into them.
+        #[test]
+        fn frobenius_over_a_deeper_level_is_repeated_squaring(a in any::<u128>()) {
+            macro_rules! assert_unspecialised {
+                ($upper:ty, $lower:ty, $val:expr) => {{
+                    let x = <$upper>::from_repr($val);
+                    prop_assert_eq!(
+                        HasFrobenius::<$lower>::frobenius(&x),
+                        x.exp_power_of_2(<$lower>::BITS)
+                    );
+                }};
+            }
+
+            assert_unspecialised!(BinaryField32, BinaryField8, a as u32);
+            assert_unspecialised!(BinaryField64, BinaryField8, a as u64);
+            assert_unspecialised!(BinaryField128, BinaryField8, a);
+            assert_unspecialised!(BinaryField64, BinaryField16, a as u64);
+            assert_unspecialised!(BinaryField128, BinaryField16, a);
+            assert_unspecialised!(BinaryField128, BinaryField32, a);
+        }
     }
 
     /// The embedding is multiplicative and additive, i.e. a ring homomorphism.

--- a/binary-field/src/poly_basis.rs
+++ b/binary-field/src/poly_basis.rs
@@ -36,6 +36,13 @@ pub fn to_tower(v: u128) -> BinaryField128 {
 }
 
 /// The product of two elements, both given and returned in the polynomial basis.
+///
+/// This is tuned for throughput. Where the target has a vector kernel it takes it, which keeps
+/// the operands off the general-purpose registers and lets independent products overlap, at the
+/// cost of a longer critical path through each one. A caller that instead threads its products
+/// through a single dependent chain — Horner evaluation, successive powers of one element —
+/// should expect this to be slower per product than the chain-friendly route the tower-basis
+/// [`BinaryField128`] operator takes.
 #[must_use]
 #[inline]
 pub fn mul(a: u128, b: u128) -> u128 {

--- a/binary-field/src/tower.rs
+++ b/binary-field/src/tower.rs
@@ -139,7 +139,7 @@ macro_rules! binary_tower_level {
 
             /// The coefficients `(a0, a1)` of `self = a0 + a1·X`.
             #[inline]
-            fn split(self) -> ($lower, $lower) {
+            pub(crate) fn split(self) -> ($lower, $lower) {
                 let a0 = (self.0 & Self::HALF_MASK) as $lower_repr;
                 let a1 = (self.0 >> Self::HALF_BITS) as $lower_repr;
                 (<$lower>::from_repr(a0), <$lower>::from_repr(a1))
@@ -147,7 +147,7 @@ macro_rules! binary_tower_level {
 
             /// The element `a0 + a1·X`.
             #[inline]
-            fn join(a0: $lower, a1: $lower) -> Self {
+            pub(crate) fn join(a0: $lower, a1: $lower) -> Self {
                 Self((a0.to_repr() as $repr) | ((a1.to_repr() as $repr) << Self::HALF_BITS))
             }
 

--- a/binary-field/src/tower.rs
+++ b/binary-field/src/tower.rs
@@ -593,6 +593,8 @@ macro_rules! karatsuba_over_the_level_below {
 
 karatsuba_over_the_level_below!(BinaryField16);
 karatsuba_over_the_level_below!(BinaryField32);
+karatsuba_over_the_level_below!(BinaryField64);
+karatsuba_over_the_level_below!(BinaryField128);
 
 impl BinaryField64 {
     /// The carryless-multiply fast path where the target has the instruction for it, and the
@@ -604,7 +606,7 @@ impl BinaryField64 {
         if HAS_HARDWARE_CLMUL {
             Self(mul_64(self.0, rhs.0))
         } else {
-            self.reference_mul(rhs)
+            self.karatsuba_mul(rhs)
         }
     }
 
@@ -630,7 +632,7 @@ impl BinaryField128 {
         if HAS_HARDWARE_CLMUL {
             Self(mul_128(self.0, rhs.0))
         } else {
-            self.reference_mul(rhs)
+            self.karatsuba_mul(rhs)
         }
     }
 
@@ -1161,11 +1163,24 @@ mod tests {
         }
 
         /// The levels whose `Mul` recurses through the level below's operator must agree with
-        /// the recursion that runs to the bottom of the tower.
+        /// the recursion that runs to the bottom of the tower. At 64 and 128 bits that operator
+        /// is only reached where there is no carryless-multiply instruction, so it is checked
+        /// here on every target rather than only on the ones that dispatch to it.
         #[test]
-        fn karatsuba_agrees_with_the_recursive_product(a in bf32(), b in bf32(), c in bf16(), d in bf16()) {
+        fn karatsuba_agrees_with_the_recursive_product(
+            a in bf32(),
+            b in bf32(),
+            c in bf16(),
+            d in bf16(),
+            e in bf64(),
+            f in bf64(),
+            g in bf128(),
+            h in bf128(),
+        ) {
             prop_assert_eq!(a.karatsuba_mul(b), a.reference_mul(b));
             prop_assert_eq!(c.karatsuba_mul(d), c.reference_mul(d));
+            prop_assert_eq!(e.karatsuba_mul(f), e.reference_mul(f));
+            prop_assert_eq!(g.karatsuba_mul(h), g.reference_mul(h));
         }
     }
 }

--- a/binary-field/src/tower.rs
+++ b/binary-field/src/tower.rs
@@ -528,7 +528,7 @@ binary_tower_level!(
     u32,
     4294967300,
     dispatched_mul,
-    dispatched_square,
+    table_square,
     reference_try_inverse
 );
 binary_tower_level!(
@@ -539,7 +539,7 @@ binary_tower_level!(
     u64,
     18446744073709551621,
     dispatched_mul,
-    dispatched_square,
+    table_square,
     reference_try_inverse
 );
 
@@ -610,15 +610,10 @@ impl BinaryField64 {
         }
     }
 
-    /// The carryless-multiply fast path for squaring, under the same dispatch as
-    /// [`Self::dispatched_mul`].
+    /// Squaring through the tower-basis matrix, which is a lookup table on every target.
     #[inline]
-    fn dispatched_square(self) -> Self {
-        if HAS_HARDWARE_CLMUL {
-            Self(square_64(self.0))
-        } else {
-            self.reference_square()
-        }
+    fn table_square(self) -> Self {
+        Self(square_64(self.0))
     }
 }
 
@@ -636,15 +631,10 @@ impl BinaryField128 {
         }
     }
 
-    /// The carryless-multiply fast path for squaring, under the same dispatch as
-    /// [`Self::dispatched_mul`].
+    /// Squaring through the tower-basis matrix, which is a lookup table on every target.
     #[inline]
-    fn dispatched_square(self) -> Self {
-        if HAS_HARDWARE_CLMUL {
-            Self(square_128(self.0))
-        } else {
-            self.reference_square()
-        }
+    fn table_square(self) -> Self {
+        Self(square_128(self.0))
     }
 }
 


### PR DESCRIPTION
## Changes

- Route the non-hardware-CLMUL fallback for 64-/128-bit multiplication through Karatsuba instead of the fully recursive reference implementation.
- Add a vector-native GF(2^128) multiply-and-reduce kernel on AArch64 (kept alongside the existing composed kernel — measured faster for throughput-bound callers, slower for latency-bound ones, so each caller uses whichever fits).
- Compute Frobenius over adjacent tower levels by an O(1) conjugation instead of a squaring loop.
- Square in the tower basis through a lookup table instead of round-tripping via the polynomial basis; no longer gated on hardware CLMUL.
- Flatten a tower-field `Vec` into its base field in one copy instead of per-element.

Verified correct via proptests against independent references (including a from-scratch bit-serial multiplication reference and Miri for the flatten change) on both the CLMUL and non-CLMUL paths; x86_64 untouched/unverified, aarch64 only for the new SIMD kernel.

## Benchmarks

`arithmetic` bench, this machine (Apple Silicon, aarch64), main vs branch (20 samples):

**With hardware CLMUL (default):**

| benchmark | main | branch | Δ |
|---|---|---|---|
| square/64 (throughput) | 4.19 µs | 1.31 µs | −68.8% |
| square/128 (throughput) | 12.59 µs | 3.26 µs | −74.1% |
| mul/inverse/mul_alpha | — | — | ~flat (fallback path not exercised) |

**Without hardware CLMUL (`-C target-feature=-aes`, simulating x86_64-no-pclmulqdq / wasm / generic ARM):**

| benchmark | main | branch | Δ |
|---|---|---|---|
| mul/64 (dispatched, latency) | 168.7 µs | 23.2 µs | −86.2% |
| mul/128 (dispatched, latency) | 485.3 µs | 63.8 µs | −86.9% |
| square/64 (throughput) | 8.45 µs | 1.31 µs | −84.5% |
| square/128 (throughput) | 19.04 µs | 3.27 µs | −82.8% |
| inverse/128 | 562.8 µs | 129.6 µs | −77.0% |
