### PR TITLE
perf(binary-dft): chain butterfly twiddles instead of rebuilding each one

### DIFF
--- a/binary-dft/src/domain.rs
+++ b/binary-dft/src/domain.rs
@@ -1,5 +1,7 @@
 //! The additive NTT domain: `F_2`-linear subspaces spanned by the Cantor basis.
 
+use alloc::vec::Vec;
+
 use p3_binary_field::TowerLevel;
 
 /// The `index`-th point of the additive NTT domain, `Σ_r bit_r(index) · v_r`.
@@ -22,6 +24,26 @@ pub fn domain_point<F: TowerLevel>(index: usize) -> F {
         r += 1;
     }
     point
+}
+
+/// The increments of `domain_point(index << 1)` as `index` runs upwards from zero.
+///
+/// `domain_point` is `F_2`-linear in its index and `(index − 1) ^ index` is the mask of bits
+/// `0..=k` for `k = index.trailing_zeros()`, so consecutive points differ by
+/// `steps[k] = Σ_{r ≤ k} v_{r+1}`. The `count` entries returned cover every `index` below
+/// `2^count`.
+///
+/// # Panics
+/// Panics if `count` is at least the bit width of `F`.
+#[must_use]
+pub(crate) fn domain_point_steps<F: TowerLevel>(count: usize) -> Vec<F> {
+    let mut point = F::ZERO;
+    (0..count)
+        .map(|r| {
+            point += F::cantor_basis(r + 1);
+            point
+        })
+        .collect()
 }
 
 /// The subspace polynomial `W_j` of `S_j`, defined by `W_0(x) = x` and

--- a/binary-dft/src/domain.rs
+++ b/binary-dft/src/domain.rs
@@ -65,7 +65,18 @@ mod tests {
     use p3_binary_field::{BinaryField8, BinaryField16, BinaryField128, TowerLevel};
     use p3_field::PrimeCharacteristicRing;
 
-    use super::{domain_point, subspace_polynomial};
+    use super::{domain_point, domain_point_steps, subspace_polynomial};
+
+    /// Chaining the increments of a stage reproduces the points a full walk reaches.
+    fn check_steps_chain_to_the_walk<F: TowerLevel>(count: usize) {
+        let steps = domain_point_steps::<F>(count);
+        let mut point = F::ZERO;
+        assert_eq!(point, domain_point::<F>(0));
+        for index in 1..1usize << count {
+            point += steps[index.trailing_zeros() as usize];
+            assert_eq!(point, domain_point::<F>(index << 1), "index={index}");
+        }
+    }
 
     /// The image of every single-bit index is the matching Cantor basis vector, which pins the
     /// basis itself and not merely some graded `F_2`-linear reparametrisation of it.
@@ -105,6 +116,15 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The increments are what a transform adds to a twiddle in place of walking the block
+    /// index, so they have to agree with that walk at every index, not merely at the ends.
+    #[test]
+    fn domain_point_steps_chain_to_the_even_domain_points() {
+        check_steps_chain_to_the_walk::<BinaryField8>(7);
+        check_steps_chain_to_the_walk::<BinaryField16>(10);
+        check_steps_chain_to_the_walk::<BinaryField128>(12);
     }
 
     /// `W_j` vanishes exactly on `S_j`, the span of the first `j` basis vectors.

--- a/binary-dft/src/lch.rs
+++ b/binary-dft/src/lch.rs
@@ -8,14 +8,14 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
-use crate::domain::{domain_point, subspace_polynomial};
+use crate::domain::{domain_point, domain_point_steps, subspace_polynomial};
 use crate::traits::AdditiveNtt;
 
 /// The Lin–Chung–Han additive NTT over the Cantor-basis domain.
 ///
 /// Twiddles are index shifts (D8): at stage `j` and butterfly block `blk` the twiddle is
-/// `W_j(shift) + domain_point(blk << 1)`, so there is no twiddle table and no per-size
-/// precomputation.
+/// `W_j(shift) + domain_point(blk << 1)`, so the only per-size precomputation is the `ℓ − 1 − j`
+/// increments that consecutive blocks of a stage differ by.
 ///
 /// `W_j` is `F_2`-linear and `domain_point(0)` is zero, so over the subspace itself — the
 /// coset with `shift = 0` — the first block of every stage has a zero twiddle and its
@@ -32,7 +32,8 @@ pub struct LchNtt<F> {
 /// each side into pieces of this size leaves `n · width / (2 · BUTTERFLY_GRAIN)` pieces at
 /// every stage, independent of `j`: the wide stages, which have too few blocks to fill a
 /// machine, are split from within instead. Stages with `half ≤ BUTTERFLY_GRAIN` keep a single
-/// piece per side and pay nothing for the extra level.
+/// piece per side and instead gather `BUTTERFLY_GRAIN / half` whole blocks into one task, so a
+/// task is a piece of this size on either side of the crossover.
 ///
 /// At a few nanoseconds per butterfly a piece of this size is microseconds of work, well above
 /// the cost of handing a task to another thread, while still leaving hundreds of pieces per
@@ -49,35 +50,43 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
             // D8: the block starting at row `b` of the coset `shift + S_ℓ` has twiddle
             // `W_j(shift) + point(b >> j)`, and block `blk` starts at row `blk << (j + 1)`.
             let base = subspace_polynomial::<F>(j, shift);
+            let steps = domain_point_steps::<F>(log_n - 1 - j);
+            let per_task = (BUTTERFLY_GRAIN / half).max(1);
             mat.values
-                .par_chunks_mut(half << 1)
+                .par_chunks_mut(per_task * (half << 1))
                 .enumerate()
-                .for_each(|(blk, block)| {
-                    let t = base + domain_point::<F>(blk << 1);
-                    let zero = t.is_zero();
-                    let (lo, hi) = block.split_at_mut(half);
-                    let butterfly = |lo: &mut [F], hi: &mut [F]| {
-                        if zero {
-                            // (u, v) ↦ (u, u + v)
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v += *u;
-                            }
-                        } else {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                // (u, v) ↦ (u + t·v, u + t·v + v)
-                                *u += t * *v;
-                                *v += *u;
-                            }
+                .for_each(|(task, group)| {
+                    let first = task * per_task;
+                    let mut t = base + domain_point::<F>(first << 1);
+                    for (i, block) in group.chunks_mut(half << 1).enumerate() {
+                        if i != 0 {
+                            t += steps[(first + i).trailing_zeros() as usize];
                         }
-                    };
-                    // Pairs are independent across the block, so a block wider than the grain
-                    // is split further rather than run on a single thread.
-                    if half <= BUTTERFLY_GRAIN {
-                        butterfly(lo, hi);
-                    } else {
-                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                            .for_each(|(lo, hi)| butterfly(lo, hi));
+                        let zero = t.is_zero();
+                        let (lo, hi) = block.split_at_mut(half);
+                        let butterfly = |lo: &mut [F], hi: &mut [F]| {
+                            if zero {
+                                // (u, v) ↦ (u, u + v)
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    *v += *u;
+                                }
+                            } else {
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    // (u, v) ↦ (u + t·v, u + t·v + v)
+                                    *u += t * *v;
+                                    *v += *u;
+                                }
+                            }
+                        };
+                        // Pairs are independent across the block, so a block wider than the
+                        // grain is split further rather than run on a single thread.
+                        if half <= BUTTERFLY_GRAIN {
+                            butterfly(lo, hi);
+                        } else {
+                            lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                                .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                                .for_each(|(lo, hi)| butterfly(lo, hi));
+                        }
                     }
                 });
         }
@@ -92,35 +101,43 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
             let half = (1 << j) * width;
             // Twiddles as derived in `shifted_ntt_batch`, with the stages run in reverse.
             let base = subspace_polynomial::<F>(j, shift);
+            let steps = domain_point_steps::<F>(log_n - 1 - j);
+            let per_task = (BUTTERFLY_GRAIN / half).max(1);
             mat.values
-                .par_chunks_mut(half << 1)
+                .par_chunks_mut(per_task * (half << 1))
                 .enumerate()
-                .for_each(|(blk, block)| {
-                    let t = base + domain_point::<F>(blk << 1);
-                    let zero = t.is_zero();
-                    let (lo, hi) = block.split_at_mut(half);
-                    let butterfly = |lo: &mut [F], hi: &mut [F]| {
-                        if zero {
-                            // (u', v') ↦ (u = u', v = u' + v')
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v += *u;
-                            }
-                        } else {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                // (u', v') ↦ (u = u' + t·v, v = u' + v')
-                                *v += *u;
-                                *u += t * *v;
-                            }
+                .for_each(|(task, group)| {
+                    let first = task * per_task;
+                    let mut t = base + domain_point::<F>(first << 1);
+                    for (i, block) in group.chunks_mut(half << 1).enumerate() {
+                        if i != 0 {
+                            t += steps[(first + i).trailing_zeros() as usize];
                         }
-                    };
-                    // Pairs are independent across the block, so a block wider than the grain
-                    // is split further rather than run on a single thread.
-                    if half <= BUTTERFLY_GRAIN {
-                        butterfly(lo, hi);
-                    } else {
-                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                            .for_each(|(lo, hi)| butterfly(lo, hi));
+                        let zero = t.is_zero();
+                        let (lo, hi) = block.split_at_mut(half);
+                        let butterfly = |lo: &mut [F], hi: &mut [F]| {
+                            if zero {
+                                // (u', v') ↦ (u = u', v = u' + v')
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    *v += *u;
+                                }
+                            } else {
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    // (u', v') ↦ (u = u' + t·v, v = u' + v')
+                                    *v += *u;
+                                    *u += t * *v;
+                                }
+                            }
+                        };
+                        // Pairs are independent across the block, so a block wider than the
+                        // grain is split further rather than run on a single thread.
+                        if half <= BUTTERFLY_GRAIN {
+                            butterfly(lo, hi);
+                        } else {
+                            lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                                .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                                .for_each(|(lo, hi)| butterfly(lo, hi));
+                        }
                     }
                 });
         }

--- a/binary-dft/src/lch.rs
+++ b/binary-dft/src/lch.rs
@@ -152,10 +152,13 @@ mod tests {
     use p3_binary_field::{
         BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128, TowerLevel,
     };
+    use p3_matrix::Matrix;
     use p3_matrix::dense::RowMajorMatrix;
+    use p3_util::log2_strict_usize;
     use proptest::prelude::*;
 
     use super::LchNtt;
+    use crate::domain::{domain_point, subspace_polynomial};
     use crate::naive::NaiveAdditiveNtt;
     use crate::traits::AdditiveNtt;
 
@@ -177,6 +180,26 @@ mod tests {
                 .collect(),
             width,
         )
+    }
+
+    /// The forward transform with every twiddle walked out from its own block index, in one
+    /// serial pass and with no zero shortcut.
+    fn twiddle_walk_ntt<F: TowerLevel>(mut mat: RowMajorMatrix<F>, shift: F) -> RowMajorMatrix<F> {
+        let width = mat.width();
+        let log_n = log2_strict_usize(mat.height());
+        for j in (0..log_n).rev() {
+            let half = (1 << j) * width;
+            let base = subspace_polynomial::<F>(j, shift);
+            for (blk, block) in mat.values.chunks_mut(half << 1).enumerate() {
+                let t = base + domain_point::<F>(blk << 1);
+                let (lo, hi) = block.split_at_mut(half);
+                for (u, v) in lo.iter_mut().zip(hi) {
+                    *u += t * *v;
+                    *v += *u;
+                }
+            }
+        }
+        mat
     }
 
     /// `LchNtt` agrees with the oracle on a random matrix and a random coset.
@@ -275,6 +298,38 @@ mod tests {
                 .shifted_lde_batch(coeffs.clone(), added, shift);
             prop_assert_eq!(&lde, &naive);
             prop_assert_eq!(&lde.values[..coeffs.values.len()], &coeffs.values[..]);
+        }
+    }
+
+    /// A height whose stages take more than one butterfly task, so a task seeds its twiddle at
+    /// a block index of its own rather than at zero.
+    ///
+    /// The oracle tests all sit below that height, and `lch_round_trips` is blind to the
+    /// schedule: both directions read the same twiddles, so they invert each other whatever
+    /// those twiddles are. Only a comparison against an independent walk pins them.
+    #[test]
+    fn lch_matches_a_twiddle_walk_across_several_tasks() {
+        const LOG_N: usize = 12;
+        let ntt = LchNtt::<BinaryField128>::default();
+        for width in [1usize, 3] {
+            for shift_bits in [0u64, 0x1234_5678_9abc_def0] {
+                let coeffs = matrix::<BinaryField128>(LOG_N, width, 5);
+                let shift = sample::<BinaryField128>(shift_bits);
+
+                let walked = twiddle_walk_ntt::<BinaryField128>(coeffs.clone(), shift);
+                assert_eq!(
+                    ntt.shifted_ntt_batch(coeffs.clone(), shift),
+                    walked,
+                    "ntt width={width} shift={shift_bits:#x}"
+                );
+                // The inverse has its own copy of the schedule, and undoing a codeword the walk
+                // produced is what holds that copy to the same twiddles.
+                assert_eq!(
+                    ntt.shifted_intt_batch(walked, shift),
+                    coeffs,
+                    "intt width={width} shift={shift_bits:#x}"
+                );
+            }
         }
     }
 

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -190,6 +190,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::PolyBasisNtt;
+    use crate::lch::LchNtt;
     use crate::naive::NaiveAdditiveNtt;
     use crate::traits::AdditiveNtt;
 
@@ -266,6 +267,36 @@ mod tests {
                 .shifted_lde_batch(coeffs.clone(), added, shift);
             prop_assert_eq!(&lde, &naive);
             prop_assert_eq!(&lde.values[..coeffs.values.len()], &coeffs.values[..]);
+        }
+    }
+
+    /// A height whose stages take more than one butterfly task, so a task seeds its twiddle at
+    /// a block index of its own rather than at zero. The oracle tests all sit below that
+    /// height, so `LchNtt` stands in for the oracle here, itself held to an independent
+    /// twiddle walk at this same height by `lch_matches_a_twiddle_walk_across_several_tasks`.
+    #[test]
+    fn poly_basis_matches_the_tower_across_several_tasks() {
+        const LOG_N: usize = 12;
+        let poly = PolyBasisNtt::default();
+        let tower = LchNtt::<BinaryField128>::default();
+        for width in [1usize, 3] {
+            for shift_bits in [0u64, 0x1234_5678_9abc_def0] {
+                let coeffs = matrix(LOG_N, width, 5);
+                let shift =
+                    BinaryField128::from_le_byte_iter(shift_bits.to_le_bytes().into_iter().cycle());
+
+                let evals = tower.shifted_ntt_batch(coeffs.clone(), shift);
+                assert_eq!(
+                    poly.shifted_ntt_batch(coeffs.clone(), shift),
+                    evals,
+                    "ntt width={width} shift={shift_bits:#x}"
+                );
+                assert_eq!(
+                    poly.shifted_intt_batch(evals, shift),
+                    coeffs,
+                    "intt width={width} shift={shift_bits:#x}"
+                );
+            }
         }
     }
 

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -8,7 +8,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
-use crate::domain::{domain_point, subspace_polynomial};
+use crate::domain::{domain_point, domain_point_steps, subspace_polynomial};
 use crate::lch::{BUTTERFLY_GRAIN, LchNtt};
 use crate::traits::AdditiveNtt;
 
@@ -32,6 +32,17 @@ pub struct PolyBasisNtt {
 #[inline]
 fn twiddle(base: BinaryField128, blk: usize) -> u128 {
     poly_basis::from_tower(base + domain_point::<BinaryField128>(blk << 1))
+}
+
+/// [`domain_point_steps`] carried into the polynomial basis.
+///
+/// The change of basis is additive, so an increment converted here applies to a twiddle
+/// already in this basis by `XOR`.
+fn twiddle_steps(count: usize) -> Vec<u128> {
+    domain_point_steps::<BinaryField128>(count)
+        .into_iter()
+        .map(poly_basis::from_tower)
+        .collect()
 }
 
 impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
@@ -60,31 +71,39 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
         for j in (0..log_n).rev() {
             let half = (1 << j) * width;
             let base = subspace_polynomial::<BinaryField128>(j, shift);
+            let steps = twiddle_steps(log_n - 1 - j);
+            let per_task = (BUTTERFLY_GRAIN / half).max(1);
             values
-                .par_chunks_mut(half << 1)
+                .par_chunks_mut(per_task * (half << 1))
                 .enumerate()
-                .for_each(|(blk, block)| {
-                    let t = twiddle(base, blk);
-                    let zero = t == 0;
-                    let (lo, hi) = block.split_at_mut(half);
-                    let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                        if zero {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v ^= *u;
-                            }
-                        } else {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *u ^= poly_basis::mul(t, *v);
-                                *v ^= *u;
-                            }
+                .for_each(|(task, group)| {
+                    let first = task * per_task;
+                    let mut t = twiddle(base, first);
+                    for (i, block) in group.chunks_mut(half << 1).enumerate() {
+                        if i != 0 {
+                            t ^= steps[(first + i).trailing_zeros() as usize];
                         }
-                    };
-                    if half <= BUTTERFLY_GRAIN {
-                        butterfly(lo, hi);
-                    } else {
-                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                            .for_each(|(lo, hi)| butterfly(lo, hi));
+                        let zero = t == 0;
+                        let (lo, hi) = block.split_at_mut(half);
+                        let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
+                            if zero {
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    *v ^= *u;
+                                }
+                            } else {
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    *u ^= poly_basis::mul(t, *v);
+                                    *v ^= *u;
+                                }
+                            }
+                        };
+                        if half <= BUTTERFLY_GRAIN {
+                            butterfly(lo, hi);
+                        } else {
+                            lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                                .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                                .for_each(|(lo, hi)| butterfly(lo, hi));
+                        }
                     }
                 });
         }
@@ -119,31 +138,39 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
         for j in 0..log_n {
             let half = (1 << j) * width;
             let base = subspace_polynomial::<BinaryField128>(j, shift);
+            let steps = twiddle_steps(log_n - 1 - j);
+            let per_task = (BUTTERFLY_GRAIN / half).max(1);
             values
-                .par_chunks_mut(half << 1)
+                .par_chunks_mut(per_task * (half << 1))
                 .enumerate()
-                .for_each(|(blk, block)| {
-                    let t = twiddle(base, blk);
-                    let zero = t == 0;
-                    let (lo, hi) = block.split_at_mut(half);
-                    let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                        if zero {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v ^= *u;
-                            }
-                        } else {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v ^= *u;
-                                *u ^= poly_basis::mul(t, *v);
-                            }
+                .for_each(|(task, group)| {
+                    let first = task * per_task;
+                    let mut t = twiddle(base, first);
+                    for (i, block) in group.chunks_mut(half << 1).enumerate() {
+                        if i != 0 {
+                            t ^= steps[(first + i).trailing_zeros() as usize];
                         }
-                    };
-                    if half <= BUTTERFLY_GRAIN {
-                        butterfly(lo, hi);
-                    } else {
-                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                            .for_each(|(lo, hi)| butterfly(lo, hi));
+                        let zero = t == 0;
+                        let (lo, hi) = block.split_at_mut(half);
+                        let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
+                            if zero {
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    *v ^= *u;
+                                }
+                            } else {
+                                for (u, v) in lo.iter_mut().zip(hi) {
+                                    *v ^= *u;
+                                    *u ^= poly_basis::mul(t, *v);
+                                }
+                            }
+                        };
+                        if half <= BUTTERFLY_GRAIN {
+                            butterfly(lo, hi);
+                        } else {
+                            lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                                .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                                .for_each(|(lo, hi)| butterfly(lo, hi));
+                        }
                     }
                 });
         }


### PR DESCRIPTION
## Changes

- Chain each butterfly block's twiddle from the previous one via an XOR recurrence instead of recomputing it from scratch (the recomputation was a data-dependent bit-walk, the dominant per-twiddle cost). Applied to both the tower-basis (`LchNtt`) and polynomial-basis (`PolyBasisNtt`) transforms.
- Added a regression test covering the twiddle chain across multiple parallel butterfly tasks — a class of bug the pre-existing suite could not have caught (round-trip tests are structurally blind to a wrong twiddle schedule).

Verified bit-identical to `main` across ~4,700 (level, size, width, shift) shapes, including edge cases (height 1, height 2, domain at the full field bit width) and both serial and parallel builds.

## Benchmarks

`ntt`/`encode` bench, this machine, main vs branch (20 samples):

| benchmark | main | branch | Δ |
|---|---|---|---|
| ntt/32 (log_n 14–20) | 9.5 ms–898 ms | 9.2 ms–881 ms | −1.8% to −3.5% |
| ntt/64 (log_n 14–20) | 7.0 ms–673 ms | 6.6 ms–647 ms | −4.0% to −5.5% |
| ntt/128 (log_n 14–20) | 22.0 ms–2.11 s | 21.7 ms–2.09 s | −0.8% to −1.8% |
| encode/BinaryField128 (log_n 14–20) | 12.1 ms–1.01 s | 11.0 ms–923 ms | −7.9% to −9.5% |
