### PR TITLE
fix(security,fri): accounting and guard hygiene fixes

### DIFF
--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -26,6 +26,25 @@ use crate::{BatchMultiOpening, FriParameters, FriProof, TwoAdicFriPcs};
 /// bounded by [`CryptoRng`]. That rules out generators known to be unsuitable for cryptographic
 /// use, but it does not replace proper seeding: a caller who seeds from a predictable source lets
 /// an observer reproduce the stream and strip the masks.
+///
+/// # Hiding requires a large enough trace relative to the query budget
+///
+/// [`Self::commit`] masks each committed column with exactly `N` uniform base-field values, where
+/// `N` is the trace height, independent of `num_queries` or `FriParameters::num_queries`. Every
+/// query opens each matrix in the base field, and every out-of-domain evaluation opens it in the
+/// extension field (`Challenge::DIMENSION` base-field functionals each). Hiding a matrix
+/// perfectly therefore requires
+///
+/// ```text
+/// N >= num_queries + 2 * Challenge::DIMENSION * (number of opening points)
+/// ```
+///
+/// where the query term is an upper bound on the number of distinct query indices landing on that
+/// matrix. Below that bound the mask is under-determined: the committed column is only partially
+/// hidden, and once `num_queries + 2 * Challenge::DIMENSION * (number of opening points) >= 2N`
+/// it is recoverable exactly. This is not checked or enforced anywhere in this type or in
+/// [`FriParameters`]; a small trace under a production-sized query count silently loses zero
+/// knowledge.
 #[derive(Debug)]
 pub struct HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R> {
     inner: TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs>,

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -68,6 +68,10 @@ where
         "num_queries must be at least 1 for FRI soundness"
     );
     assert!(
+        params.log_blowup > 0,
+        "log_blowup must be at least 1 for FRI soundness"
+    );
+    assert!(
         params.max_log_arity > 0,
         "max_log_arity must be at least 1 to guarantee folding progress"
     );

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -47,6 +47,13 @@ where
     /// - At least one query is required for the protocol to prove anything.
     #[error("FRI instance has zero queries; at least one is required for soundness")]
     ZeroQueries,
+    /// The instance is configured with `log_blowup == 0`.
+    ///
+    /// At rate 1 every length-N word is itself a degree-<N codeword, so the
+    /// folding chain and final-polynomial check are satisfied by an
+    /// arbitrary reduced-opening word: false claimed evaluations verify.
+    #[error("FRI instance has log_blowup = 0; a positive blowup is required for soundness")]
+    ZeroBlowup,
     #[error("missing initial reduced opening at log height {expected}")]
     MissingInitialReducedOpening { expected: usize },
     #[error("initial reduced opening height mismatch: expected {expected}, got {got}")]
@@ -185,6 +192,11 @@ where
     // Any final polynomial would then pass.
     if params.num_queries == 0 {
         return Err(FriError::ZeroQueries);
+    }
+    // Reject rate-1 FRI: every length-N word is a degree-<N codeword, so an
+    // arbitrary reduced-opening word would pass the folding chain unchecked.
+    if params.log_blowup == 0 {
+        return Err(FriError::ZeroBlowup);
     }
 
     // Generate the Batch combination challenge
@@ -2090,6 +2102,34 @@ mod tests {
         assert!(
             matches!(err, FriError::ZeroQueries),
             "expected ZeroQueries, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_with_zero_blowup() {
+        // Invariant: at log_blowup = 0 every length-N word is a degree-<N
+        // codeword, so the folding chain accepts an arbitrary word.
+        //
+        // Fixture state: an honest proof built with log_blowup >= 1.
+        //
+        // Mutation: verify it under params with log_blowup = 0.
+        let f = make_test_fixture();
+        let mut params = f.fri_params.clone();
+        params.log_blowup = 0;
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &params,
+            &f.proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect_err("zero-blowup instance must be rejected");
+
+        assert!(
+            matches!(err, FriError::ZeroBlowup),
+            "expected ZeroBlowup, got {err:?}"
         );
     }
 

--- a/security/src/assumption.rs
+++ b/security/src/assumption.rs
@@ -107,6 +107,12 @@ impl SecurityAssumption {
             Self::UniqueDecoding => 0.,
 
             // By the JB, RS codes are (1 - sqrt(rho) - eta, (2*eta*sqrt(rho))^-1)-list decodable.
+            //
+            // This is the classical Johnson list size, used to grade WHIR and STIR.
+            // `crate::proximity::list_size_ldr_m` grades FRI with the tighter [BCSS25]
+            // Theorem 4.2 bound instead. Both are valid theorems for the same code at a matched
+            // radius, and are never co-evaluated for the same regime; this one is the more
+            // conservative of the two, so the difference is intentional, not a defect to unify.
             Self::JohnsonBound => {
                 let log_inv_sqrt_rate: f64 = log_inv_rate as f64 / 2.;
                 log_inv_sqrt_rate - (1. + log_eta)

--- a/security/src/fixed.rs
+++ b/security/src/fixed.rs
@@ -18,10 +18,13 @@ pub const FRACTIONAL_BITS: u32 = 16;
 /// The value `1.0` in fixed point.
 pub const ONE: u64 = 1 << FRACTIONAL_BITS;
 
-/// `log2(e)` in fixed point, rounded down.
+/// `log2(e)` in fixed point, rounded up.
 ///
-/// Appears in the random-words cutoff of [2025/2010](https://eprint.iacr.org/2025/2010) section 1.5.
-pub const LOG2_E: u64 = 94_548;
+/// Appears in the random-words cutoff of [2025/2010](https://eprint.iacr.org/2025/2010) section
+/// 1.5, in [`bits_per_query`]'s `numerator`, whose `ceil_log2` is then subtracted from the
+/// uncorrected rate. Rounding this constant down would shrink that correction and overstate the
+/// reported per-query rate, contradicting this module's conservative-lower-bound invariant.
+pub const LOG2_E: u64 = 94_549;
 
 /// Converts a whole number of bits into fixed point.
 pub const fn from_bits(bits: u32) -> u64 {
@@ -132,7 +135,7 @@ mod tests {
                 let ceil = ceil_log2(candidate) as f64;
 
                 assert!(
-                    floor <= truth + 1.0,
+                    floor <= truth + 1e-3,
                     "floor_log2({candidate}) overstates log2"
                 );
                 assert!(
@@ -140,7 +143,7 @@ mod tests {
                     "floor_log2({candidate}) is more than 1 ulp low"
                 );
                 assert!(
-                    ceil + 1.0 >= truth,
+                    ceil + 1e-3 >= truth,
                     "ceil_log2({candidate}) understates log2"
                 );
                 assert!(
@@ -150,6 +153,17 @@ mod tests {
             }
             x *= 2;
         }
+    }
+
+    /// `LOG2_E` enters `bits_per_query`'s subtracted correction, so rounding it down would
+    /// shrink the correction and overstate the reported per-query rate.
+    #[test]
+    fn log2_e_rounds_up_not_down() {
+        let truth = core::f64::consts::LOG2_E * ONE as f64;
+        assert!(
+            LOG2_E as f64 >= truth,
+            "LOG2_E must round up, not down: {LOG2_E} < {truth}"
+        );
     }
 
     #[test]

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -277,7 +277,7 @@ pub fn best_ldr_m(
     shape: &InstanceShape,
 ) -> Option<(usize, ErrorBits)> {
     let trace_length = 1usize << shape.log_trace_length;
-    let m_max = core::cmp::min(compute_upper_m(trace_length), LDR_M_CAP);
+    let m_max = core::cmp::min(compute_upper_m(trace_length, air.max_combo), LDR_M_CAP);
     let m_min = 3usize;
     if m_max < m_min {
         return None;

--- a/security/src/proximity.rs
+++ b/security/src/proximity.rs
@@ -11,7 +11,7 @@
 //! - [2024/1553] On the Security of STARKs with FRI
 //! - [2025/2055] BCHKS25 Theorem 4.2
 
-use libm::{ceil, pow, sqrt};
+use libm::{floor, pow, sqrt};
 
 /// Performance cap on the proximity parameter `m` searched in LDR
 /// analyses. Matches Ethereum's `soundcalc`.
@@ -64,6 +64,11 @@ pub const fn list_size_conjectured() -> f64 {
 
 /// LDR list size: L⁺ = (m + 1/2)/√ρ. Matches `soundcalc`
 /// `johnson_bound::get_max_list_size` (explicit-m branch).
+///
+/// Uses the tighter [2025/2055] BCHKS25 Theorem 4.2 list size at the caller's
+/// explicit `m`, distinct from [`crate::assumption::SecurityAssumption::JohnsonBound`]'s
+/// classical Johnson bound at a fixed safety margin — the two are not
+/// interchangeable, see that variant's `list_size_bits_at_log_eta` doc.
 pub fn list_size_ldr_m(log_blowup: usize, m: usize) -> f64 {
     let rho = pow(2.0, -(log_blowup as f64));
     (m as f64 + 0.5) / sqrt(rho)
@@ -71,11 +76,23 @@ pub fn list_size_ldr_m(log_blowup: usize, m: usize) -> f64 {
 
 /// Largest proximity parameter `m` such that the η > 0 precondition of
 /// Theorem 1 in [2021/582] holds. Caller applies [`LDR_M_CAP`].
-pub fn compute_upper_m(trace_length: usize) -> usize {
+///
+/// `max_combo` accounts for the trace-side expansion from out-of-domain
+/// openings, matching [`alpha_udr`]'s `rho_plus`. The precondition is the
+/// strict inequality `m < X` where `X = 1 / (2 * (sqrt((h + max_combo) / h) - 1))`,
+/// so the admissible maximum is `floor(X)`, or `X - 1` on the non-generic
+/// chance that `X` is itself an integer.
+pub fn compute_upper_m(trace_length: usize, max_combo: usize) -> usize {
     if trace_length == 0 {
         return 0;
     }
     let h = trace_length as f64;
-    let ratio = (h + 2.0) / h;
-    ceil(1.0 / (2.0 * (sqrt(ratio) - 1.0))) as usize
+    let ratio = (h + max_combo as f64) / h;
+    let x = 1.0 / (2.0 * (sqrt(ratio) - 1.0));
+    let m = floor(x);
+    if m == x {
+        (m - 1.0) as usize
+    } else {
+        m as usize
+    }
 }


### PR DESCRIPTION
## Summary
- `compute_upper_m` now floors instead of ceils its admissible-`m` bound and takes the caller's `max_combo` instead of hardcoding `2`, both of which previously overstated reported security.
- `LOG2_E` now rounds up instead of down, keeping `bits_per_query`'s correction conservative.
- Documented why `SecurityAssumption::JohnsonBound`'s list size and `list_size_ldr_m` intentionally differ rather than being duplicate/disagreeing formulas.
- `p3-fri` now rejects `log_blowup == 0` in both `prove_fri` (assert) and `verify_fri` (new `FriError::ZeroBlowup`), a config that previously let arbitrary claimed evaluations verify.
- Documented `HidingFriPcs`'s trace-height-vs-query-budget requirement for its zero-knowledge guarantee to hold.

## Test plan
- [x] `cargo test -p p3-security -p p3-fri`
- [x] `cargo test -p p3-circle -p p3-uni-stark -p p3-batch-stark`
- [x] `cargo clippy -p p3-security -p p3-fri --all-targets -- -D warnings`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo fmt --check`