### PR TITLE
perf(whir): parallelize HVZK OOD evaluation and weight scaling, algebraic claim increment

### DIFF
--- a/sumcheck/src/constraints/statement/select.rs
+++ b/sumcheck/src/constraints/statement/select.rs
@@ -545,30 +545,38 @@ impl<F: Field, EF: ExtensionField<F>> SelectStatement<F, EF> {
         // Right half → scalar power table.
         let right = batch_pows(right);
 
-        // Broadcast challenge powers into packed form for dot products.
+        // Challenge powers weighting each constraint.
         let alphas = challenge
             .shifted_powers(challenge.exp_u64(shift as u64))
-            .collect_n(n)
-            .into_iter()
-            .map(EF::ExtensionPacking::from)
-            .collect::<Vec<_>>();
+            .collect_n(n);
 
         // For each right-half row, dot all left-half rows against it
         // (weighted by the challenge powers) and accumulate into the
-        // packed weight polynomial.
+        // packed weight polynomial. The right-half entry and its challenge
+        // power are constant across the left-half rows, so they are folded
+        // into a single broadcast coefficient per constraint first.
         weights
             .as_mut_slice()
             .par_chunks_mut(left.height())
             .zip(right.par_row_slices())
-            .for_each(|(out, right)| {
-                out.iter_mut().zip(left.rows()).for_each(|(out, left)| {
-                    *out += left
-                        .zip(right.iter())
-                        .zip(alphas.iter())
-                        .map(|((left, &right), &alpha)| alpha * (left * right))
-                        .sum::<EF::ExtensionPacking>();
-                });
-            });
+            .for_each_init(
+                || Vec::with_capacity(n),
+                |scaled, (out, right)| {
+                    scaled.clear();
+                    scaled.extend(
+                        right
+                            .iter()
+                            .zip(alphas.iter())
+                            .map(|(&right, &alpha)| EF::ExtensionPacking::from(alpha * right)),
+                    );
+                    out.iter_mut().zip(left.rows()).for_each(|(out, left)| {
+                        *out += left
+                            .zip(scaled.iter())
+                            .map(|(left, &scaled)| scaled * left)
+                            .sum::<EF::ExtensionPacking>();
+                    });
+                },
+            );
     }
 
     /// Batches expected evaluation values into a single target sum using challenge powers.

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -419,14 +419,16 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
     pub(crate) fn scale_weights(&mut self, scale: EF) {
         match &mut self.inner {
             MaybePacked::Packed { weights, .. } => {
-                for value in weights.as_mut_slice() {
-                    *value *= scale;
-                }
+                weights
+                    .as_mut_slice()
+                    .par_iter_mut()
+                    .for_each(|value| *value *= scale);
             }
             MaybePacked::Unpacked { weights, .. } => {
-                for value in weights.as_mut_slice() {
-                    *value *= scale;
-                }
+                weights
+                    .as_mut_slice()
+                    .par_iter_mut()
+                    .for_each(|value| *value *= scale);
             }
         }
     }

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -401,13 +401,6 @@ where
                     },
                 );
             }
-            let claim_delta = message
-                .as_slice()
-                .par_chunks(POW_CHUNK)
-                .zip(weight_delta.par_chunks(POW_CHUNK))
-                .map(|(m, w)| dot_product::<EF, _, _>(m.iter().copied(), w.iter().copied()))
-                .sum::<EF>();
-            sumcheck_prover.accumulate_claim(&weight_delta, claim_delta);
 
             // Mask side: the fresh mask enters the relation.
             let mask_covector = switch_mask_covector(
@@ -419,20 +412,21 @@ where
                 &query_points,
                 query_coeffs,
             );
+            // The batched-claim identity pins the source-side increment:
+            //
+            //     carried + claim_delta + <mask covector, mask message> = mu'
+            //
+            // `accumulate_claim` re-derives it from <evals, weights> in debug builds.
+            let claim_delta = joint
+                - carried
+                - dot_product::<EF, _, _>(
+                    mask_covector.iter().copied(),
+                    mask_message.iter().copied(),
+                );
+            sumcheck_prover.accumulate_claim(&weight_delta, claim_delta);
+
             // The running total must match a full re-evaluation.
             debug_assert_eq!(masks.aux, masks.claims.evaluate(&masks.messages));
-            // Cross-check the batched-claim identity:
-            //
-            //     residual + aux + <mask covector, mask message> = mu'
-            debug_assert_eq!(
-                sumcheck_prover.claimed_sum()
-                    + masks.aux
-                    + dot_product::<EF, _, _>(
-                        mask_covector.iter().copied(),
-                        mask_message.iter().copied(),
-                    ),
-                joint,
-            );
             masks.push_switch_mask(
                 mask_covector,
                 mask_message,

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -40,7 +40,7 @@ use crate::pcs::zk::code_switch::{ZkMaskClaim, switch_mask_covector};
 use crate::pcs::zk::committer::{FoldedRsCode, zk_padded_matrix};
 use crate::pcs::zk::config::ZkWhirConfig;
 use crate::pcs::zk::proof::{ZkRoundProof, ZkWhirProof};
-use crate::utils::eval_ze_star_n;
+use crate::utils::{eval_ze_star_n, par_add_scaled_powers, par_eval_ze_star_n};
 
 /// Chunk length for the parallel power runs over message-length vectors.
 ///
@@ -277,16 +277,7 @@ where
                 );
                 // ze*(rho) over (message || mask_message): the long message side
                 // runs as chunked parallel Horner, the short mask tail serially.
-                let message_eval = message
-                    .as_slice()
-                    .par_chunks(POW_CHUNK)
-                    .enumerate()
-                    .map(|(chunk_idx, chunk)| {
-                        chunk.iter().rev().fold(EF::ZERO, |acc, &m| acc * rho + m)
-                            * rho.exp_u64((chunk_idx * POW_CHUNK) as u64)
-                    })
-                    .sum::<EF>();
-                let answer = message_eval
+                let answer = par_eval_ze_star_n(rho, message.as_slice(), POW_CHUNK)
                     + eval_ze_star_n(rho, &mask_message) * rho.exp_u64(message_len as u64);
                 challenger.observe_algebra_element(answer);
                 rho_points.push(rho);
@@ -389,17 +380,9 @@ where
                 }
                 weight_delta
             };
-            // Chunked parallel power run: chunk `c` starts at coeff * rho^(c * CHUNK).
+            // OOD layers: delta[b] += c_j * rho_j^b.
             for (&rho, &coeff) in rho_points.iter().zip(ood_coeffs) {
-                weight_delta.par_chunks_mut(POW_CHUNK).enumerate().for_each(
-                    |(chunk_idx, chunk)| {
-                        let mut term = coeff * rho.exp_u64((chunk_idx * POW_CHUNK) as u64);
-                        for dst in chunk {
-                            *dst += term;
-                            term *= rho;
-                        }
-                    },
-                );
+                par_add_scaled_powers(&mut weight_delta, rho, coeff, POW_CHUNK);
             }
 
             // Mask side: the fresh mask enters the relation.

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -40,7 +40,13 @@ use crate::pcs::zk::code_switch::{ZkMaskClaim, switch_mask_covector};
 use crate::pcs::zk::committer::{FoldedRsCode, zk_padded_matrix};
 use crate::pcs::zk::config::ZkWhirConfig;
 use crate::pcs::zk::proof::{ZkRoundProof, ZkWhirProof};
-use crate::utils::padded_ood_t1;
+use crate::utils::eval_ze_star_n;
+
+/// Chunk length for the parallel power runs over message-length vectors.
+///
+/// Each chunk is evaluated independently and re-based by one `rho^{c · POW_CHUNK}`
+/// shift, trading a serial dependency chain for a parallel one per chunk.
+const POW_CHUNK: usize = 1 << 12;
 
 /// HVZK-WHIR prover.
 #[derive(Debug)]
@@ -269,7 +275,19 @@ where
                     !rho_points.contains(&rho),
                     "OOD points must be pairwise distinct",
                 );
-                let answer = padded_ood_t1(rho, message.as_slice(), &mask_message);
+                // ze*(rho) over (message || mask_message): the long message side
+                // runs as chunked parallel Horner, the short mask tail serially.
+                let message_eval = message
+                    .as_slice()
+                    .par_chunks(POW_CHUNK)
+                    .enumerate()
+                    .map(|(chunk_idx, chunk)| {
+                        chunk.iter().rev().fold(EF::ZERO, |acc, &m| acc * rho + m)
+                            * rho.exp_u64((chunk_idx * POW_CHUNK) as u64)
+                    })
+                    .sum::<EF>();
+                let answer = message_eval
+                    + eval_ze_star_n(rho, &mask_message) * rho.exp_u64(message_len as u64);
                 challenger.observe_algebra_element(answer);
                 rho_points.push(rho);
                 ood_answers.push(answer);
@@ -372,7 +390,6 @@ where
                 weight_delta
             };
             // Chunked parallel power run: chunk `c` starts at coeff * rho^(c * CHUNK).
-            const POW_CHUNK: usize = 1 << 12;
             for (&rho, &coeff) in rho_points.iter().zip(ood_coeffs) {
                 weight_delta.par_chunks_mut(POW_CHUNK).enumerate().for_each(
                     |(chunk_idx, chunk)| {

--- a/whir/src/utils.rs
+++ b/whir/src/utils.rs
@@ -5,6 +5,7 @@
 //! - <https://eprint.iacr.org/2024/1586> (base WHIR).
 
 use p3_field::{ExtensionField, Field, HornerIter};
+use p3_maybe_rayon::prelude::*;
 
 /// Action of `ze*_n(ρ) := (1, ρ, …, ρ^{n-1})` on a coefficient vector,
 /// computed by Horner's method (Definition 6.1 of eprint 2026/391).
@@ -43,6 +44,75 @@ where
     // Mixed accumulator: extension coefficients fold against a base point,
     // so each step costs one cheap EF x F multiplication.
     coeffs.iter().copied().horner_acc(EF::ZERO, point)
+}
+
+/// Chunk-parallel form of [`eval_ze_star_n`].
+///
+/// # Math
+///
+/// The coefficients are cut into runs of `chunk_len`. Run `c` is folded by its
+/// own Horner pass and re-based by one `ρ^{c · chunk_len}` shift:
+///
+/// ```text
+///     Σ_i c_i · ρ^i = Σ_c ρ^{c · chunk_len} · Σ_j c_{c · chunk_len + j} · ρ^j
+/// ```
+///
+/// This is an exact-field reassociation, so the result equals
+/// [`eval_ze_star_n`] on the same inputs for every `chunk_len`.
+///
+/// # Cost
+///
+/// One serial dependency chain of length `chunk_len` per run instead of a
+/// single chain of length `coeffs.len()`, plus one `ρ^{c · chunk_len}` per run.
+///
+/// # Panics
+///
+/// Panics if `chunk_len` is zero.
+pub(crate) fn par_eval_ze_star_n<F, EF>(point: F, coeffs: &[EF], chunk_len: usize) -> EF
+where
+    F: Field,
+    EF: ExtensionField<F>,
+{
+    assert_ne!(chunk_len, 0, "chunk length must be positive");
+    coeffs
+        .par_chunks(chunk_len)
+        .enumerate()
+        .map(|(chunk_idx, chunk)| {
+            eval_ze_star_n(point, chunk) * point.exp_u64((chunk_idx * chunk_len) as u64)
+        })
+        .sum()
+}
+
+/// Adds the scaled power run `coeff · ρ^b` into slot `b` of `out`.
+///
+/// # Math
+///
+/// ```text
+///     out[b] += coeff · ρ^b        for b ∈ [0, out.len())
+/// ```
+///
+/// Each run of `chunk_len` slots restarts the running power from
+/// `coeff · ρ^{c · chunk_len}`, so the runs carry independent chains.
+///
+/// # Panics
+///
+/// Panics if `chunk_len` is zero.
+pub(crate) fn par_add_scaled_powers<EF: Field>(
+    out: &mut [EF],
+    point: EF,
+    coeff: EF,
+    chunk_len: usize,
+) {
+    assert_ne!(chunk_len, 0, "chunk length must be positive");
+    out.par_chunks_mut(chunk_len)
+        .enumerate()
+        .for_each(|(chunk_idx, chunk)| {
+            let mut term = coeff * point.exp_u64((chunk_idx * chunk_len) as u64);
+            for dst in chunk {
+                *dst += term;
+                term *= point;
+            }
+        });
 }
 
 /// Evaluate the polynomial `(msg ‖ rand)` (coefficients) at point `ρ`:
@@ -229,6 +299,68 @@ mod tests {
             }
 
             prop_assert_eq!(horner, expected);
+        }
+
+        #[test]
+        fn prop_par_eval_ze_star_n_matches_serial_basefield(
+            coeffs in prop::collection::vec(any::<u32>(), 0..40),
+            sigma_raw in any::<u32>(),
+            chunk_len in 1usize..5,
+        ) {
+            // Lengths reach ~10x the chunk length, so the chunk index runs well
+            // past 1 and the per-chunk rho^{c · chunk_len} rebase is exercised.
+            let coeffs: Vec<F> = coeffs.into_iter().map(F::from_u32).collect();
+            let sigma = F::from_u32(sigma_raw);
+
+            prop_assert_eq!(
+                par_eval_ze_star_n(sigma, &coeffs, chunk_len),
+                eval_ze_star_n(sigma, &coeffs),
+            );
+        }
+
+        #[test]
+        fn prop_par_eval_ze_star_n_matches_serial_extension(
+            seed in any::<u64>(),
+            n in 0usize..40,
+            chunk_len in 1usize..5,
+        ) {
+            // Same identity over an extension, where the Horner accumulator is
+            // a full EF x EF chain rather than the mixed EF x F one.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let coeffs: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let sigma: EF = rng.random();
+
+            prop_assert_eq!(
+                par_eval_ze_star_n(sigma, &coeffs, chunk_len),
+                eval_ze_star_n(sigma, &coeffs),
+            );
+        }
+
+        #[test]
+        fn prop_par_add_scaled_powers_matches_serial_run(
+            seed in any::<u64>(),
+            n in 0usize..40,
+            chunk_len in 1usize..5,
+        ) {
+            // Accumulates onto pre-existing content, so a chunk that overwrote
+            // instead of adding would be caught alongside a bad rebase exponent.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let initial: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let sigma: EF = rng.random();
+            let coeff: EF = rng.random();
+
+            let mut actual = initial.clone();
+            par_add_scaled_powers(&mut actual, sigma, coeff, chunk_len);
+
+            // Reference: one serial running-power chain across the whole slice.
+            let mut expected = initial;
+            let mut term = coeff;
+            for dst in &mut expected {
+                *dst += term;
+                term *= sigma;
+            }
+
+            prop_assert_eq!(actual, expected);
         }
 
         #[test]


### PR DESCRIPTION
## Changes

- Hoist a row-invariant scaling term out of `SelectStatement::combine_packed`'s per-row loop.
- Parallelize the HVZK OOD message evaluation (was a strictly serial, transcript-critical Horner fold).
- Parallelize `ProductPolynomial::scale_weights`.
- Derive the HVZK code-switch claim increment algebraically instead of a full-width dot product.
- Added proptests pinning the new chunked power-run rebase (the untested exponent case a wrong chunk-boundary fix could otherwise hide).

Two related findings were investigated and deliberately not pursued: fusing an unpack+transpose pass turned out to save nothing without a larger, riskier rewrite of surrounding code; rewiring the HVZK initial sumcheck batch onto an existing-but-unused prover path hit real transcript- and correctness-level blockers on inspection. All landed changes are bit-identical to `main` (verified via proof-byte hashing and exhaustive proptests).

## Benchmarks

`whir_zk_overhead` bench, this machine, main vs branch (20 samples). Note: this bench panics at n=20 on both `main` and the branch with an identical pre-existing config error unrelated to these changes, so only n=16/18 are shown.

| benchmark | main | branch | Δ |
|---|---|---|---|
| plain/16 | 33.01 ms | 32.67 ms | −1.0% |
| zk/16 | 47.93 ms | 47.17 ms | −1.6% |
| plain/18 | 111.20 ms | 110.44 ms | −0.7% |
| zk/18 | 128.54 ms | 127.45 ms | −0.8% |

End-to-end gains here are modest since this bench is dominated by DFT/Merkle cost, not the narrow HVZK kernels touched — the individual kernel-level wins (measured in isolation during review) are larger.
