### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,55 +104,55 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 ] }
 
 # Local dependencies
-p3-air = { path = "air", version = "0.6.0" }
-p3-baby-bear = { path = "baby-bear", version = "0.6.0" }
-p3-binary-dft = { path = "binary-dft", version = "0.6.0" }
-p3-binary-field = { path = "binary-field", version = "0.6.0" }
-p3-blake3 = { path = "blake3", version = "0.6.0" }
-p3-blake3-air = { path = "blake3-air", version = "0.6.0" }
-p3-bn254 = { path = "bn254", version = "0.6.0" }
-p3-challenger = { path = "challenger", version = "0.6.0" }
-p3-circle = { path = "circle", version = "0.6.0" }
-p3-commit = { path = "commit", version = "0.6.0" }
-p3-dft = { path = "dft", version = "0.6.0" }
+p3-air = { path = "air", version = "0.7.0" }
+p3-baby-bear = { path = "baby-bear", version = "0.7.0" }
+p3-binary-dft = { path = "binary-dft", version = "0.7.0" }
+p3-binary-field = { path = "binary-field", version = "0.7.0" }
+p3-blake3 = { path = "blake3", version = "0.7.0" }
+p3-blake3-air = { path = "blake3-air", version = "0.7.0" }
+p3-bn254 = { path = "bn254", version = "0.7.0" }
+p3-challenger = { path = "challenger", version = "0.7.0" }
+p3-circle = { path = "circle", version = "0.7.0" }
+p3-commit = { path = "commit", version = "0.7.0" }
+p3-dft = { path = "dft", version = "0.7.0" }
 p3-examples = { path = "examples", version = "0.3.0" }
-p3-field = { path = "field", version = "0.6.0" }
-p3-field-testing = { path = "field-testing", version = "0.6.0" }
-p3-fri = { path = "fri", version = "0.6.0" }
-p3-goldilocks = { path = "goldilocks", version = "0.6.0" }
-p3-keccak = { path = "keccak", version = "0.6.0" }
-p3-keccak-air = { path = "keccak-air", version = "0.6.0" }
-p3-koala-bear = { path = "koala-bear", version = "0.6.0" }
-p3-lookup = { path = "lookup", version = "0.6.0" }
-p3-matrix = { path = "matrix", version = "0.6.0" }
-p3-maybe-rayon = { path = "maybe-rayon", version = "0.6.0" }
-p3-mds = { path = "mds", version = "0.6.0" }
-p3-merkle-tree = { path = "merkle-tree", version = "0.6.0" }
-p3-mersenne-31 = { path = "mersenne-31", version = "0.6.0" }
-p3-monolith = { path = "monolith", version = "0.6.0" }
-p3-monolith-air = { path = "monolith-air", version = "0.6.0" }
-p3-monty-31 = { path = "monty-31", version = "0.6.0" }
-p3-multilinear-util = { path = "multilinear-util", version = "0.6.0" }
-p3-poseidon1 = { path = "poseidon1", version = "0.6.0" }
-p3-poseidon1-air = { path = "poseidon1-air", version = "0.6.0" }
-p3-poseidon2 = { path = "poseidon2", version = "0.6.0" }
-p3-poseidon2-air = { path = "poseidon2-air", version = "0.6.0" }
-p3-rescue = { path = "rescue", version = "0.6.0" }
-p3-security = { path = "security", version = "0.6.0" }
-p3-sha256 = { path = "sha256", version = "0.6.0" }
-p3-sha256-air = { path = "sha256-air", version = "0.6.0" }
-p3-stir = { path = "stir", version = "0.6.0" }
-p3-sumcheck = { path = "sumcheck", version = "0.6.0" }
-p3-symmetric = { path = "symmetric", version = "0.6.0" }
-p3-uni-stark = { path = "uni-stark", version = "0.6.0" }
-p3-util = { path = "util", version = "0.6.0" }
-p3-whir = { path = "whir", version = "0.6.0" }
-p3-zk-codes = { path = "zk-codes", version = "0.6.0" }
+p3-field = { path = "field", version = "0.7.0" }
+p3-field-testing = { path = "field-testing", version = "0.7.0" }
+p3-fri = { path = "fri", version = "0.7.0" }
+p3-goldilocks = { path = "goldilocks", version = "0.7.0" }
+p3-keccak = { path = "keccak", version = "0.7.0" }
+p3-keccak-air = { path = "keccak-air", version = "0.7.0" }
+p3-koala-bear = { path = "koala-bear", version = "0.7.0" }
+p3-lookup = { path = "lookup", version = "0.7.0" }
+p3-matrix = { path = "matrix", version = "0.7.0" }
+p3-maybe-rayon = { path = "maybe-rayon", version = "0.7.0" }
+p3-mds = { path = "mds", version = "0.7.0" }
+p3-merkle-tree = { path = "merkle-tree", version = "0.7.0" }
+p3-mersenne-31 = { path = "mersenne-31", version = "0.7.0" }
+p3-monolith = { path = "monolith", version = "0.7.0" }
+p3-monolith-air = { path = "monolith-air", version = "0.7.0" }
+p3-monty-31 = { path = "monty-31", version = "0.7.0" }
+p3-multilinear-util = { path = "multilinear-util", version = "0.7.0" }
+p3-poseidon1 = { path = "poseidon1", version = "0.7.0" }
+p3-poseidon1-air = { path = "poseidon1-air", version = "0.7.0" }
+p3-poseidon2 = { path = "poseidon2", version = "0.7.0" }
+p3-poseidon2-air = { path = "poseidon2-air", version = "0.7.0" }
+p3-rescue = { path = "rescue", version = "0.7.0" }
+p3-security = { path = "security", version = "0.7.0" }
+p3-sha256 = { path = "sha256", version = "0.7.0" }
+p3-sha256-air = { path = "sha256-air", version = "0.7.0" }
+p3-stir = { path = "stir", version = "0.7.0" }
+p3-sumcheck = { path = "sumcheck", version = "0.7.0" }
+p3-symmetric = { path = "symmetric", version = "0.7.0" }
+p3-uni-stark = { path = "uni-stark", version = "0.7.0" }
+p3-util = { path = "util", version = "0.7.0" }
+p3-whir = { path = "whir", version = "0.7.0" }
+p3-zk-codes = { path = "zk-codes", version = "0.7.0" }
 
 [workspace.package]
 # General description field used for the sub-crates that are currently missing a description.
 description = "Plonky3 is a toolkit for implementing polynomial IOPs (PIOPs), such as PLONK and STARKs."
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Plonky3/Plonky3"

--- a/air/CHANGELOG.md
+++ b/air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Air: some debugging improvements (#1431)

--- a/baby-bear/CHANGELOG.md
+++ b/baby-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Make batched_linear_combination chunk size per-impl tunable (#1451)

--- a/batch-stark/CHANGELOG.md
+++ b/batch-stark/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Perf: fixed-width binary serialization for field elements (#1988)
+- Chore: fix latest stable clippy (#1994)
+- Feat: adapt log levels of some inner functions (#1999)
+- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Uni-stark: richer verification errors (#1453)

--- a/binary-dft/CHANGELOG.md
+++ b/binary-dft/CHANGELOG.md
@@ -10,12 +10,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Merged PRs
 - Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
 
-## [0.6.0] - 2026-06-11
-### Merged PRs
-- Feat: extract ZK encoding traits to p3-zk-codes (#1601)
-- Chore: use T::zero_vec(n) instead of vec![T::ZERO; n] (#1633)
-- Fix: local refs for dev-deps (#1663)
-- Fix awkward specialization (#1675)
-- Feat(whir): HVZK sumcheck suffix-binding prover (#1665)
-- Whir: add HVZK-WHIR hiding polynomial commitment scheme (#1767)
-

--- a/binary-field/CHANGELOG.md
+++ b/binary-field/CHANGELOG.md
@@ -8,14 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ## [0.7.0] - 2026-09-04
 ### Merged PRs
+- Feat(binary-field): GF(2) through GF(2^128) tower fields (#2001)
 - Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
-
-## [0.6.0] - 2026-06-11
-### Merged PRs
-- Feat: extract ZK encoding traits to p3-zk-codes (#1601)
-- Chore: use T::zero_vec(n) instead of vec![T::ZERO; n] (#1633)
-- Fix: local refs for dev-deps (#1663)
-- Fix awkward specialization (#1675)
-- Feat(whir): HVZK sumcheck suffix-binding prover (#1665)
-- Whir: add HVZK-WHIR hiding polynomial commitment scheme (#1767)
+- Feat(sumcheck): ring switching over an arbitrary field extension (#2006)
 

--- a/blake3-air/CHANGELOG.md
+++ b/blake3-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Ci: tighten doc/release/TOML checks (#1689)

--- a/blake3/CHANGELOG.md
+++ b/blake3/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Ci: tighten doc/release/TOML checks (#1689)

--- a/bn254/CHANGELOG.md
+++ b/bn254/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Fix(bn254): add Poseidon2 round-number constants and fix benchmark (#1557)

--- a/challenger/CHANGELOG.md
+++ b/challenger/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat: adapt log levels of some inner functions (#1999)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Fix: use `u64` arithmetic in 64-bit challenger to avoid truncation (#1482)

--- a/circle/CHANGELOG.md
+++ b/circle/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat: adapt log levels of some inner functions (#1999)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add support for Periodic Columns at runtime (#1462)

--- a/commit/CHANGELOG.md
+++ b/commit/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
+- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add support for Periodic Columns at runtime (#1462)

--- a/dft/CHANGELOG.md
+++ b/dft/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+- Feat: adapt log levels of some inner functions (#1999)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Dft: testing for internals (#1494)

--- a/field-testing/CHANGELOG.md
+++ b/field-testing/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
+- Feat(binary-field): GF(2) through GF(2^128) tower fields (#2001)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Field: reinforcement of tests with edge cases and proptests (#1435)

--- a/field/CHANGELOG.md
+++ b/field/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
+- Feat(binary-field): GF(2) through GF(2^128) tower fields (#2001)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)

--- a/fri/CHANGELOG.md
+++ b/fri/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: add support for Periodic Columns at runtime (#1462)

--- a/goldilocks/CHANGELOG.md
+++ b/goldilocks/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Perf: fixed-width binary serialization for field elements (#1988)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore: more const assertions (#1441)

--- a/keccak-air/CHANGELOG.md
+++ b/keccak-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore(deps): update sha2 requirement from 0.10.9 to 0.11.0 (#1503)

--- a/keccak/CHANGELOG.md
+++ b/keccak/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore: remove needless_range_loop allows across the workspace (#1632)

--- a/koala-bear/CHANGELOG.md
+++ b/koala-bear/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Add broadcast, pack_columns, pack_columns_fn, and unpack_iter to PackedValue (#1450)

--- a/lookup/CHANGELOG.md
+++ b/lookup/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Fix(batch-stark): validate per-instance global lookup data count (#1458)

--- a/matrix/CHANGELOG.md
+++ b/matrix/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Matrix: add pad_to_min_power_of_two_height (#1448)

--- a/maybe-rayon/CHANGELOG.md
+++ b/maybe-rayon/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Batch-stark: more efficient prover (#1470)

--- a/mds/CHANGELOG.md
+++ b/mds/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Mds: small improvements and more testing (#1459)

--- a/merkle-tree/CHANGELOG.md
+++ b/merkle-tree/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Feat: expose arity schedule (#1433)

--- a/mersenne-31/CHANGELOG.md
+++ b/mersenne-31/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Perf: fixed-width binary serialization for field elements (#1988)
+- Chore: fix latest stable clippy (#1994)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Make batched_linear_combination chunk size per-impl tunable (#1451)

--- a/monolith/CHANGELOG.md
+++ b/monolith/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Monolith: implement Monolith for Mersenne31 and Goldilocks (#1478)

--- a/monty-31/CHANGELOG.md
+++ b/monty-31/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Perf: fixed-width binary serialization for field elements (#1988)
+- Chore: fix latest stable clippy (#1994)
+- Feat: adapt log levels of some inner functions (#1999)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Poseidon1: speedup monty-31 packed version on avx (#1420)

--- a/multi-stark/CHANGELOG.md
+++ b/multi-stark/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## [0.7.0] - 2026-09-04
-## [0.6.0] - 2026-06-11
 ### Merged PRs
-- Feat: add p3-monolith-air crate for Monolith permutation arithmetization (#1516)
-- Ci: tighten doc/release/TOML checks (#1689)
+- Test(multi-stark): add WHIR proof-serialization compat fixture (#1996)
+- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
+- Feat: adapt log levels of some inner functions (#1999)
 

--- a/multilinear-util/CHANGELOG.md
+++ b/multilinear-util/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762) (#1900)
+- Fix(sumcheck): unpack suffix-bound product polynomials (#2008)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Multilinear util: integrate poly utils (#1379)

--- a/poseidon1-air/CHANGELOG.md
+++ b/poseidon1-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Improved poseidon1 air (Karatsuba + Sparse partial rounds) (#1480)

--- a/poseidon1/CHANGELOG.md
+++ b/poseidon1/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Improved poseidon1 air (Karatsuba + Sparse partial rounds) (#1480)

--- a/poseidon2-air/CHANGELOG.md
+++ b/poseidon2-air/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Perf: abstract away Copy vs Clone (#1463)

--- a/poseidon2/CHANGELOG.md
+++ b/poseidon2/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore: more const assertions (#1441)

--- a/rescue/CHANGELOG.md
+++ b/rescue/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/security/CHANGELOG.md
+++ b/security/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## [0.7.0] - 2026-09-04
-## [0.6.0] - 2026-06-11
 ### Merged PRs
-- Feat: add p3-monolith-air crate for Monolith permutation arithmetization (#1516)
-- Ci: tighten doc/release/TOML checks (#1689)
+- Fix(stir): fallible config derivation & dedup eta-parameterized security formulas (#1998)
+- Fix(security): account for out-of-domain point count in budget's OOD round (#2007)
+- Feat(security): add legacy conjectured FRI soundness bound (#2018)
 

--- a/sha256-air/CHANGELOG.md
+++ b/sha256-air/CHANGELOG.md
@@ -7,8 +7,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## [0.7.0] - 2026-09-04
-## [0.6.0] - 2026-06-11
-### Merged PRs
-- Feat: add p3-monolith-air crate for Monolith permutation arithmetization (#1516)
-- Ci: tighten doc/release/TOML checks (#1689)
-

--- a/sha256/CHANGELOG.md
+++ b/sha256/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Chore(deps): update sha2 requirement from 0.10.9 to 0.11.0 (#1503)

--- a/stir/CHANGELOG.md
+++ b/stir/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+- Perf(stir): allow round 0's folding arity to differ from later rounds (#1989)
+- Feat: adapt log levels of some inner functions (#1999)
+- Perf(stir): commit height classes on a shared domain, merge via Combine (§7) (#1990)
+- Perf(stir): batch the OOD-sampling and degree-correction hot loops (#1992)
+- Fix(stir): fallible config derivation & dedup eta-parameterized security formulas (#1998)
+- Perf(stir): bucket committed heights into several bounded-spread shared domains (#2005)
+- Refactor(stir)!: replace the catch-all InvalidProofShape with typed variants (#2012)
+

--- a/sumcheck/CHANGELOG.md
+++ b/sumcheck/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Chore: fix latest stable clippy (#1994)
+- Feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762) (#1900)
+- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
+- Feat: adapt log levels of some inner functions (#1999)
+- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
+- Feat(sumcheck): ring switching over an arbitrary field extension (#2006)
+- Fix(sumcheck): unpack suffix-bound product polynomials (#2008)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Refactor: move sumcheck to an independent crate (#1672)

--- a/symmetric/CHANGELOG.md
+++ b/symmetric/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Core: couple more compile time assertions (#1525)

--- a/uni-stark/CHANGELOG.md
+++ b/uni-stark/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Perf: fixed-width binary serialization for field elements (#1988)
+- Chore: fix latest stable clippy (#1994)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Uni-stark: richer verification errors (#1453)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Utils: add `log3_strict_usize` (#1444)

--- a/whir/CHANGELOG.md
+++ b/whir/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [0.7.0] - 2026-09-04
+### Merged PRs
+- Feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762) (#1900)
+- Fix(whir): re-derive HVZK base case query/PoW budget from occupancy (#1995)
+- Feat: adapt log levels of some inner functions (#1999)
+
 ## [0.6.0] - 2026-06-11
 ### Merged PRs
 - Whir: integration of all the required primitives (#1477)


### PR DESCRIPTION



## 🤖 New release

* `p3-maybe-rayon`: 0.6.0 -> 0.7.0
* `p3-util`: 0.6.0 -> 0.7.0
* `p3-field`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-matrix`: 0.6.0 -> 0.7.0
* `p3-air`: 0.6.0 -> 0.7.0
* `p3-dft`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-symmetric`: 0.6.0 -> 0.7.0
* `p3-mds`: 0.6.0 -> 0.7.0
* `p3-poseidon1`: 0.6.0 -> 0.7.0
* `p3-poseidon2`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-monty-31`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-baby-bear`: 0.6.0 -> 0.7.0
* `p3-goldilocks`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-koala-bear`: 0.6.0 -> 0.7.0
* `p3-bn254`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-field-testing`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-mersenne-31`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-challenger`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-multilinear-util`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-commit`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-merkle-tree`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-blake3`: 0.6.0 -> 0.7.0
* `p3-keccak`: 0.6.0 -> 0.7.0
* `p3-rescue`: 0.6.0 -> 0.7.0
* `p3-security`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-uni-stark`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-lookup`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-batch-stark`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-fri`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-circle`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-binary-field`: 0.6.0 -> 0.7.0
* `p3-binary-dft`: 0.6.0 -> 0.7.0
* `p3-zk-codes`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-sumcheck`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-blake3-air`: 0.6.0 -> 0.7.0
* `p3-keccak-air`: 0.6.0 -> 0.7.0
* `p3-poseidon1-air`: 0.6.0 -> 0.7.0
* `p3-poseidon2-air`: 0.6.0 -> 0.7.0
* `p3-sha256`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-stir`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-whir`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-monolith`: 0.6.0 -> 0.7.0
* `p3-monolith-air`: 0.6.0 -> 0.7.0
* `p3-multi-stark`: 0.6.0 -> 0.7.0 (✓ API compatible changes)
* `p3-sha256-air`: 0.6.0 -> 0.7.0

<details><summary><i><b>Changelog</b></i></summary><p>



## `p3-field`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
- Feat(binary-field): GF(2) through GF(2^128) tower fields (#2001)
</blockquote>



## `p3-dft`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
- Feat: adapt log levels of some inner functions (#1999)
</blockquote>




## `p3-poseidon2`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
</blockquote>

## `p3-monty-31`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Perf: fixed-width binary serialization for field elements (#1988)
- Chore: fix latest stable clippy (#1994)
- Feat: adapt log levels of some inner functions (#1999)
</blockquote>


## `p3-goldilocks`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Perf: fixed-width binary serialization for field elements (#1988)
</blockquote>



## `p3-field-testing`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
- Feat(binary-field): GF(2) through GF(2^128) tower fields (#2001)
</blockquote>

## `p3-mersenne-31`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Perf: fixed-width binary serialization for field elements (#1988)
- Chore: fix latest stable clippy (#1994)
</blockquote>

## `p3-challenger`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat: adapt log levels of some inner functions (#1999)
</blockquote>

## `p3-multilinear-util`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762) (#1900)
- Fix(sumcheck): unpack suffix-bound product polynomials (#2008)
</blockquote>

## `p3-commit`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
</blockquote>

## `p3-merkle-tree`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
</blockquote>




## `p3-security`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Fix(stir): fallible config derivation & dedup eta-parameterized security formulas (#1998)
- Fix(security): account for out-of-domain point count in budget's OOD round (#2007)
- Feat(security): add legacy conjectured FRI soundness bound (#2018)
</blockquote>

## `p3-uni-stark`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Perf: fixed-width binary serialization for field elements (#1988)
- Chore: fix latest stable clippy (#1994)
</blockquote>

## `p3-lookup`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
</blockquote>

## `p3-batch-stark`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Perf: fixed-width binary serialization for field elements (#1988)
- Chore: fix latest stable clippy (#1994)
- Feat: adapt log levels of some inner functions (#1999)
- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
</blockquote>

## `p3-fri`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat: expose pruned-multiproof restoration and FRI/STARK opening internals (#2010)
</blockquote>

## `p3-circle`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat: adapt log levels of some inner functions (#1999)
</blockquote>

## `p3-binary-field`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(binary-field): GF(2) through GF(2^128) tower fields (#2001)
- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
- Feat(sumcheck): ring switching over an arbitrary field extension (#2006)
</blockquote>

## `p3-binary-dft`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
</blockquote>

## `p3-zk-codes`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
</blockquote>

## `p3-sumcheck`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
- Feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762) (#1900)
- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
- Feat: adapt log levels of some inner functions (#1999)
- Feat(binary-dft): additive NTT and the Encoder abstraction (#2003)
- Feat(sumcheck): ring switching over an arbitrary field extension (#2006)
- Fix(sumcheck): unpack suffix-bound product polynomials (#2008)
</blockquote>





## `p3-sha256`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
</blockquote>

## `p3-stir`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Chore: fix latest stable clippy (#1994)
- Perf(stir): allow round 0's folding arity to differ from later rounds (#1989)
- Feat: adapt log levels of some inner functions (#1999)
- Perf(stir): commit height classes on a shared domain, merge via Combine (§7) (#1990)
- Perf(stir): batch the OOD-sampling and degree-correction hot loops (#1992)
- Fix(stir): fallible config derivation & dedup eta-parameterized security formulas (#1998)
- Perf(stir): bucket committed heights into several bounded-spread shared domains (#2005)
- Refactor(stir)!: replace the catch-all InvalidProofShape with typed variants (#2012)
</blockquote>

## `p3-whir`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Feat(sumcheck): subtraction-free projective (monomial-basis) sum-check on the prover (eprint 2026/762) (#1900)
- Fix(whir): re-derive HVZK base case query/PoW budget from occupancy (#1995)
- Feat: adapt log levels of some inner functions (#1999)
</blockquote>



## `p3-multi-stark`

<blockquote>

## [0.7.0] - 2026-09-04

### Merged PRs
- Test(multi-stark): add WHIR proof-serialization compat fixture (#1996)
- Feat(field): characteristic-agnostic groundwork for binary fields (#2000)
- Feat: adapt log levels of some inner functions (#1999)
</blockquote>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).