### PR TITLE
test(fri): pin the fused quotient LDE for the bit-reversed DFT backend

### DIFF
--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -224,6 +224,12 @@ where
                 // DFT is linear, so they share a single forward transform. Recovering the chunk's
                 // coefficients with `shift.inverse()` scales coefficient `j` by `shift^j`, placing
                 // them on the coset exactly as `coset_lde_batch(evals, log_blowup + 1, shift)` would.
+                //
+                // Why the coset LDE's own coefficient hook cannot host this:
+                //
+                // - That hook runs before the buffer is zero-extended, so the mask's upper half
+                //   has no room.
+                // - The coset scaling applied afterwards would scale the mask by `shift^j` too.
                 let mut lde_coeffs = self
                     .inner
                     .dft
@@ -503,7 +509,7 @@ mod tests {
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
     use p3_commit::ExtensionMmcs;
-    use p3_dft::{Radix2Bowers, Radix2DFTSmallBatch, Radix2Dit};
+    use p3_dft::{Radix2Bowers, Radix2DFTSmallBatch, Radix2Dit, Radix2DitParallel};
     use p3_field::extension::BinomialExtensionField;
     use p3_field::{Field, PrimeCharacteristicRing};
     use p3_merkle_tree::MerkleTreeMmcs;
@@ -814,9 +820,13 @@ mod tests {
             .collect()
     }
 
-    /// `get_quotient_ldes` shares one forward transform between a chunk and its mask. That relies
-    /// on backend conventions (natural-order coefficients through `coset_idft_batch`/`dft_batch`,
-    /// and `bit_reverse_rows` inverting the committed order), so pin it per backend.
+    /// Check one backend's quotient LDE against the same result built from two transforms.
+    ///
+    /// Sharing a single forward transform between a chunk and its mask relies on two backend
+    /// conventions, so every backend is pinned separately:
+    ///
+    /// - The inverse transform returns coefficients in natural order.
+    /// - Undoing the row permutation recovers the order the commitment expects.
     fn check_fused_quotient_ldes<D: TwoAdicSubgroupDft<Val> + Clone>(dft: &D) {
         for (log_h, width, num_chunks) in [(3, 4, 2), (4, 3, 4)] {
             let mut rng = SmallRng::seed_from_u64(11);
@@ -880,5 +890,18 @@ mod tests {
     #[test]
     fn fused_quotient_lde_matches_two_transforms_small_batch() {
         check_fused_quotient_ldes(&Radix2DFTSmallBatch::<Val>::default());
+    }
+
+    #[test]
+    fn fused_quotient_lde_matches_two_transforms_dit_parallel() {
+        // Why this backend earns its own case: it is the only one whose forward transform
+        // hands back a permuted view rather than natural order.
+        //
+        //     other backends : forward transform -> rows already in natural order
+        //     this backend   : forward transform -> rows in bit-reversed order, behind a view
+        //
+        // So it is the one place where the shared-transform rewrite could pick up the wrong
+        // row order without any other test noticing.
+        check_fused_quotient_ldes(&Radix2DitParallel::<Val>::default());
     }
 }


### PR DESCRIPTION
Follow-up to #2015.

That PR fuses the quotient chunk's LDE and its mask into a single forward transform, and correctly pins the result per DFT backend, since the rewrite leans on two backend conventions:

- the inverse transform returns coefficients in natural order,
- undoing the row permutation recovers the order the commitment expects.

The gap is which backends got pinned. All three covered — `Radix2Dit`, `Radix2Bowers`, `Radix2DFTSmallBatch` — declare `type Evaluations = RowMajorMatrix<F>`, i.e. evaluations already in natural order. `Radix2DitParallel` is the only backend with `type Evaluations = BitReversedMatrixView<RowMajorMatrix<F>>`, and it separately overrides `dft_batch`, `coset_idft_batch`, and `coset_lde_batch_with_transform`. So it is precisely the one place where the shared-transform rewrite could pick up the wrong row order with no other test noticing. It is also what `keccak-air`, `poseidon1-air`, and the `stir` benches actually use.

The fusion **is** correct for it — the new test passes as written, so this locks in behaviour rather than fixing a bug.

Also records why the fusion is hand-rolled instead of routed through `coset_lde_batch_with_transform`, which looks like the natural hook for it but cannot express it: the closure runs before the coefficient buffer is zero-extended, so the mask's upper half has nowhere to go, and the `coset_dft_batch` that follows would scale the mask by `shift^j` as well. Worth having written down, since the next reader will ask.

## Verification

```
cargo test -p p3-fri --release   # 4/4 fused_quotient_lde_* pass
cargo clippy -p p3-fri --all-targets   # clean
cargo +nightly fmt   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)