### PR TITLE
refactor(merkle-tree): make the opening shape check self-contained

### DIFF
--- a/merkle-tree/src/mmcs/geometry.rs
+++ b/merkle-tree/src/mmcs/geometry.rs
@@ -7,16 +7,28 @@ use p3_util::log2_ceil_usize;
 use serde::{Deserialize, Serialize};
 
 use crate::MerkleTreeError;
-use crate::MerkleTreeError::{EmptyBatch, IncompatibleHeights, WrongWidth};
+use crate::MerkleTreeError::{EmptyBatch, IncompatibleHeights, WrongBatchSize, WrongWidth};
 
-/// Check that each opened row has exactly the width of its matrix.
+/// Check that the opened rows pair one-to-one with the committed matrices, each at its own width.
 ///
 /// The leaf hash flattens all rows at one height into a single element stream,
 /// so a digest match alone does not pin where one row ends and the next begins.
+///
+/// Both halves of the shape are needed to pin those boundaries:
+///
+/// - One row per committed matrix, so no matrix is skipped.
+/// - Each row exactly as wide as its matrix, so no boundary shifts.
+///
+/// Checking only the widths would leave a short opening to be read as a complete one, since
+/// the rows that are present can each still match the width of the matrix they are paired with.
 pub(crate) fn check_widths<T, R: AsRef<[T]>>(
     dimensions: &[Dimensions],
     opened_values: &[R],
 ) -> Result<(), MerkleTreeError> {
+    if opened_values.len() != dimensions.len() {
+        return Err(WrongBatchSize);
+    }
+
     for (matrix, (dims, row)) in dimensions.iter().zip(opened_values).enumerate() {
         let width = row.as_ref().len();
         if width != dims.width {
@@ -138,6 +150,52 @@ mod tests {
 
     use super::*;
     use crate::{MerkleTreeError, MerkleTreeMmcs};
+
+    #[test]
+    fn width_check_rejects_a_missing_row() {
+        // Invariant: the shape check accepts an opening only when it carries one row per
+        // committed matrix, each row exactly as wide as its matrix.
+        //
+        // Fixture state: two committed matrices, both 4 columns wide.
+        //
+        //     dimensions   : [ 4 wide, 4 wide ]
+        //     opened rows  : [ 4 wide ]
+        //     -> 1 row for 2 matrices
+        //
+        // Pairing the rows against the matrices left to right would walk only the first pair
+        // and find nothing wrong, so the row count has to be checked on its own.
+        let dims = vec![
+            Dimensions {
+                width: 4,
+                height: 8,
+            },
+            Dimensions {
+                width: 4,
+                height: 8,
+            },
+        ];
+        let one_row = vec![vec![BabyBear::ONE; 4]];
+
+        assert!(matches!(
+            check_widths(&dims, &one_row),
+            Err(MerkleTreeError::WrongBatchSize)
+        ));
+
+        // A second row of the right width completes the shape.
+        let both_rows = vec![vec![BabyBear::ONE; 4], vec![BabyBear::ONE; 4]];
+        assert!(check_widths(&dims, &both_rows).is_ok());
+
+        // Mutation: widen the second row to 5 values, leaving the count correct.
+        let wrong_width = vec![vec![BabyBear::ONE; 4], vec![BabyBear::ONE; 5]];
+        assert!(matches!(
+            check_widths(&dims, &wrong_width),
+            Err(MerkleTreeError::WrongWidth {
+                matrix: 1,
+                expected: 4,
+                got: 5,
+            })
+        ));
+    }
 
     type F = BabyBear;
 

--- a/merkle-tree/src/mmcs/mod.rs
+++ b/merkle-tree/src/mmcs/mod.rs
@@ -591,13 +591,9 @@ impl<P, PW, H, C, const N: usize, const DIGEST_ELEMS: usize>
         let mut restored =
             restore_paths(proof, &sorted_unique, &arity_schedule, full_sibling_count)?;
 
-        // Every representative opening must expose one row per committed matrix.
-        // Ascending, distinct leaf order already holds by construction.
+        // Every representative opening must expose one row per committed matrix, each at its
+        // matrix's width. Ascending, distinct leaf order already holds by construction.
         for &rep in &reps {
-            if opened_values[rep].len() != dimensions.len() {
-                return Err(WrongBatchSize);
-            }
-            // Row boundaries within a flattened leaf hash are only pinned by the widths.
             check_widths(dimensions, &opened_values[rep])?;
         }
 


### PR DESCRIPTION
Noticed while reviewing #2015. **This changes no behaviour and fixes no vulnerability** — it moves an invariant to where it is claimed to live.

## What is going on

`check_widths` is the helper documented as what pins row boundaries inside a flattened leaf hash, and `fri/src/verifier.rs` leans on exactly that reading:

```rust
//   - `check_widths` (in the MMCS) is the only authenticator of row boundaries
```

But it paired rows against dimensions with a plain `zip`, so it only checked the widths of the rows that happened to be present. An opening with fewer rows than committed matrices walked the shorter of the two, found every pair well-formed, and returned `Ok`.

## Why nothing was exposed

I checked all four call sites before writing this, and every one is already covered:

| call site | how the row count is pinned |
|---|---|
| `mmcs/batch.rs` (`verify_batch`) | its own check, ~20 lines earlier |
| `mmcs/mod.rs` (`verify_batch_pruned`) | its own check, immediately before |
| `hiding_mmcs.rs` (`verify_batch`) | the inner tree's check, one delegation down |
| `hiding_mmcs.rs` (`verify_multi_batch`) | the inner pruned verifier's check, one delegation down |

So there is no reachable false accept, and no test changes result. I would rather say that plainly than dress this up.

## Why do it anyway

The guarantee currently holds for every caller *that remembers* to add its own check, in a helper whose whole job is to be the one place that guarantee lives. Two of the four sites only get there by delegating to an inner tree that re-checks — meaning the shape check runs vacuously on a mis-shaped input first, and the helper's own doc overstates what it returns.

Folding the count into the helper makes it self-enforcing, corrects the doc to describe both halves of the shape it validates, and lets the duplicated check in the pruned batch verifier go.

Also adds a direct unit test on the helper, since it is `pub(crate)` and its contract is now the thing worth pinning: one row per matrix, each at its matrix's width, with the missing-row and wrong-width rejections covered separately.

## Verification

```
cargo test -p p3-merkle-tree --release   # 100 pass
cargo test -p p3-fri -p p3-uni-stark -p p3-batch-stark -p p3-multi-stark --release   # all pass
cargo clippy -p p3-merkle-tree --all-targets   # clean
cargo +nightly fmt   # clean
```

Happy to close this if you would rather keep the checks at the call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)