### PR TITLE
refactor(binary-dft): hoist the twiddle increments out of the stage loop

### DIFF
--- a/binary-dft/src/lch.rs
+++ b/binary-dft/src/lch.rs
@@ -14,8 +14,11 @@ use crate::traits::AdditiveNtt;
 /// The Lin–Chung–Han additive NTT over the Cantor-basis domain.
 ///
 /// Twiddles are index shifts (D8): at stage `j` and butterfly block `blk` the twiddle is
-/// `W_j(shift) + domain_point(blk << 1)`, so the only per-size precomputation is the `ℓ − 1 − j`
-/// increments that consecutive blocks of a stage differ by.
+/// `W_j(shift) + domain_point(blk << 1)`, so there is no twiddle table.
+///
+/// Consecutive blocks differ by a fixed increment, so a block takes its twiddle from the one
+/// before it rather than walking its own index.
+/// The `ℓ - 1` increments are shared by every stage and are the only per-size precomputation.
 ///
 /// `W_j` is `F_2`-linear and `domain_point(0)` is zero, so over the subspace itself — the
 /// coset with `shift = 0` — the first block of every stage has a zero twiddle and its
@@ -45,12 +48,15 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
         let width = mat.width();
         let log_n = log2_strict_usize(mat.height());
 
+        // An increment depends only on a block index's trailing-zero count, never on the stage,
+        // so one table serves every stage and each stage uses the prefix it reaches.
+        // A height of one runs no stage and needs no table.
+        let steps = domain_point_steps::<F>(log_n.saturating_sub(1));
         for j in (0..log_n).rev() {
             let half = (1 << j) * width;
             // D8: the block starting at row `b` of the coset `shift + S_ℓ` has twiddle
             // `W_j(shift) + point(b >> j)`, and block `blk` starts at row `blk << (j + 1)`.
             let base = subspace_polynomial::<F>(j, shift);
-            let steps = domain_point_steps::<F>(log_n - 1 - j);
             let per_task = (BUTTERFLY_GRAIN / half).max(1);
             mat.values
                 .par_chunks_mut(per_task * (half << 1))
@@ -58,6 +64,8 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
                 .for_each(|(task, group)| {
                     let first = task * per_task;
                     let mut t = base + domain_point::<F>(first << 1);
+                    // Invariant: blocks are visited in ascending index order.
+                    // Carrying the twiddle from one block to the next relies on it.
                     for (i, block) in group.chunks_mut(half << 1).enumerate() {
                         if i != 0 {
                             t += steps[(first + i).trailing_zeros() as usize];
@@ -97,11 +105,14 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
         let width = mat.width();
         let log_n = log2_strict_usize(mat.height());
 
+        // An increment depends only on a block index's trailing-zero count, never on the stage,
+        // so one table serves every stage and each stage uses the prefix it reaches.
+        // A height of one runs no stage and needs no table.
+        let steps = domain_point_steps::<F>(log_n.saturating_sub(1));
         for j in 0..log_n {
             let half = (1 << j) * width;
             // Twiddles as derived in `shifted_ntt_batch`, with the stages run in reverse.
             let base = subspace_polynomial::<F>(j, shift);
-            let steps = domain_point_steps::<F>(log_n - 1 - j);
             let per_task = (BUTTERFLY_GRAIN / half).max(1);
             mat.values
                 .par_chunks_mut(per_task * (half << 1))
@@ -109,6 +120,8 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
                 .for_each(|(task, group)| {
                     let first = task * per_task;
                     let mut t = base + domain_point::<F>(first << 1);
+                    // Invariant: blocks are visited in ascending index order.
+                    // Carrying the twiddle from one block to the next relies on it.
                     for (i, block) in group.chunks_mut(half << 1).enumerate() {
                         if i != 0 {
                             t += steps[(first + i).trailing_zeros() as usize];

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -68,10 +68,13 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .par_iter_mut()
             .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
 
+        // An increment depends only on a block index's trailing-zero count, never on the stage,
+        // so one table serves every stage and each stage uses the prefix it reaches.
+        // A height of one runs no stage and needs no table.
+        let steps = twiddle_steps(log_n.saturating_sub(1));
         for j in (0..log_n).rev() {
             let half = (1 << j) * width;
             let base = subspace_polynomial::<BinaryField128>(j, shift);
-            let steps = twiddle_steps(log_n - 1 - j);
             let per_task = (BUTTERFLY_GRAIN / half).max(1);
             values
                 .par_chunks_mut(per_task * (half << 1))
@@ -79,6 +82,8 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
                 .for_each(|(task, group)| {
                     let first = task * per_task;
                     let mut t = twiddle(base, first);
+                    // Invariant: blocks are visited in ascending index order.
+                    // Carrying the twiddle from one block to the next relies on it.
                     for (i, block) in group.chunks_mut(half << 1).enumerate() {
                         if i != 0 {
                             t ^= steps[(first + i).trailing_zeros() as usize];
@@ -135,10 +140,13 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .par_iter_mut()
             .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
 
+        // An increment depends only on a block index's trailing-zero count, never on the stage,
+        // so one table serves every stage and each stage uses the prefix it reaches.
+        // A height of one runs no stage and needs no table.
+        let steps = twiddle_steps(log_n.saturating_sub(1));
         for j in 0..log_n {
             let half = (1 << j) * width;
             let base = subspace_polynomial::<BinaryField128>(j, shift);
-            let steps = twiddle_steps(log_n - 1 - j);
             let per_task = (BUTTERFLY_GRAIN / half).max(1);
             values
                 .par_chunks_mut(per_task * (half << 1))
@@ -146,6 +154,8 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
                 .for_each(|(task, group)| {
                     let first = task * per_task;
                     let mut t = twiddle(base, first);
+                    // Invariant: blocks are visited in ascending index order.
+                    // Carrying the twiddle from one block to the next relies on it.
                     for (i, block) in group.chunks_mut(half << 1).enumerate() {
                         if i != 0 {
                             t ^= steps[(first + i).trailing_zeros() as usize];


### PR DESCRIPTION
Follow-up to #2017. No behaviour change — three defensive/cosmetic items from reviewing that PR.

## 1. The increment table is stage-independent

`domain_point_steps` is a running sum with no parameter other than the count:

```rust
let mut point = F::ZERO;
(0..count).map(|r| { point += F::cantor_basis(r + 1); point }).collect()
```

So `steps[r] = sum_{s <= r} v_{s+1}` depends only on `r`. A table of `a` entries is therefore a **strict prefix** of a table of `b >= a` entries, and one table serves every stage.

It was being rebuilt per stage at size `ℓ - 1 - j`. The cost is nil (`O(ℓ^2)` field elements against `O(n·ℓ)` butterflies) — the reason to change it is that a per-stage construction actively suggests the table is stage-specific, which is exactly what a reader auditing an incremental twiddle chain must not believe.

Built once at `ℓ - 1`, the largest prefix any stage reaches.

**Why this cannot change any value:** stage `j` has exactly `2^(ℓ-1-j)` blocks, so `blk <= 2^m - 1` for `m = ℓ-1-j`, and the largest trailing-zero count over `blk` in `1..2^m` is `m-1`. The old table had `m` entries — exactly saturated. The new one has `ℓ-1 >= m` entries whose first `m` are bit-identical. Same values read, strictly more headroom.

`saturating_sub` covers height 1, where the stage loop never runs: it yields an empty table rather than underflowing. The largest basis index requested is still `ℓ - 1` (previously reached at stage 0), so the `ℓ <= bit width` panic precondition is unchanged.

## 2. The chain depends on ascending block order — now stated

Carrying `t += steps[trailing_zeros(first + i)]` from one block to the next is only meaningful if blocks are visited in ascending index order. `chunks_mut` guarantees that, but the neighbouring comment only covered the *inner* parallel split, so switching that loop to `par_chunks_mut` later would produce a wrong-but-plausible transform with no compile error.

This is the item I would not skip: it is precisely the failure mode #2017's own new cross-task test was written to catch.

## 3. Header doc

The amended sentence described the increments as belonging to a stage, and read as a concession against the previous "no per-size precomputation" claim. Reworded to say what is actually true: no twiddle table, blocks chain from their predecessor, and the `ℓ - 1` increments are shared by every stage.

## Verification

```
cargo test -p p3-binary-dft --release   # 32 + 2 pass
cargo clippy -p p3-binary-dft --all-targets   # clean
cargo +nightly fmt   # clean
```

The prefix property above makes this value-preserving by construction; the suite includes the differential-against-naive tests, the round-trips, and the cross-task twiddle test added in #2017.

Kept `ℓ` rather than switching to ASCII, since it is the crate-wide convention (36 uses across `traits.rs`, `domain.rs`, `lch.rs`, `poly.rs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)