### PR TITLE
ci: fail on unused dependencies, and drop the ones already there

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
       # tools (and taplo's `time` dependency chain) from source every run.
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-sort,taplo
+          tool: cargo-machete,cargo-sort,taplo
 
       - uses: Swatinem/rust-cache@v2
 
@@ -275,6 +275,11 @@ jobs:
 
       - name: Check TOML formatting
         run: taplo fmt --check
+
+      # `--with-metadata` resolves each manifest through cargo.
+      # Only that resolution makes dev-dependencies visible to the scan.
+      - name: Unused dependencies
+        run: cargo machete --with-metadata
 
       - name: Clippy
         run: cargo +stable clippy --all-targets -- -D warnings

--- a/baby-bear/Cargo.toml
+++ b/baby-bear/Cargo.toml
@@ -29,7 +29,6 @@ num-bigint.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_xoshiro.workspace = true
-serde_json.workspace = true
 
 [[bench]]
 name = "bench_field"

--- a/binary-field/Cargo.toml
+++ b/binary-field/Cargo.toml
@@ -20,7 +20,6 @@ p3-maybe-rayon.workspace = true
 p3-symmetric.workspace = true
 
 num-bigint.workspace = true
-paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true

--- a/bn254/Cargo.toml
+++ b/bn254/Cargo.toml
@@ -16,7 +16,6 @@ p3-symmetric.workspace = true
 p3-util.workspace = true
 
 num-bigint.workspace = true
-paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 

--- a/commit/Cargo.toml
+++ b/commit/Cargo.toml
@@ -17,11 +17,11 @@ test-utils = ["p3-challenger"]
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true
-p3-multilinear-util.workspace = true
 p3-util.workspace = true
 
 itertools.workspace = true
-serde.workspace = true
+# The opening types derive their codecs, and they hold `Vec`s.
+serde = { workspace = true, features = ["derive", "alloc"] }
 
 # for testing
 p3-challenger = { workspace = true, optional = true }

--- a/field/src/integers.rs
+++ b/field/src/integers.rs
@@ -22,7 +22,7 @@
 /// It considerably cuts down on the amount of copy/pasted code.
 macro_rules! from_integer_types {
     ($($type:ty),* $(,)? ) => {
-        $( paste::paste!{
+        $( $crate::paste::paste!{
             /// Given an integer `r`, return the sum of `r` copies of `ONE`:
             ///
             /// `r * Self::ONE =  Self::ONE + ... + Self::ONE (r times)`.
@@ -189,7 +189,7 @@ macro_rules! quotient_map_small_internals {
 macro_rules! quotient_map_small_int {
     ($field:ty, $field_size:ty, [$($small_int:ty),*] ) => {
         $(
-        paste::paste!{
+        $crate::paste::paste!{
             impl QuotientMap<$small_int> for $field {
                 $crate::quotient_map_small_internals!($field, $field_size, $small_int);
             }
@@ -199,7 +199,7 @@ macro_rules! quotient_map_small_int {
 
     ($field:ty, $field_size:ty, $field_param:ty, [$($small_int:ty),*] ) => {
         $(
-        paste::paste!{
+        $crate::paste::paste!{
             impl<FP: $field_param> QuotientMap<$small_int> for $field<FP> {
                 $crate::quotient_map_small_internals!($field, $field_size, $small_int);
             }

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -23,5 +23,10 @@ pub use dup::Dup;
 pub use field::*;
 pub use helpers::*;
 pub use packed::*;
+// Re-exported so the macros this crate exports can name the token-pasting helper through
+// `$crate`, which resolves at the definition site.
+// Without it every crate expanding one of those macros would need its own dependency on it.
+#[doc(hidden)]
+pub use paste;
 pub use sqrt::{tonelli_shanks, tonelli_shanks_two_adic};
 pub use vectorized::*;

--- a/field/src/op_assign_macros.rs
+++ b/field/src/op_assign_macros.rs
@@ -22,7 +22,7 @@
 #[macro_export]
 macro_rules! impl_add_assign {
     ($type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl<$($param_name: $type_param,)? T: Into<Self>> AddAssign<T> for $type$(<$param_name>)? {
                 #[inline]
                 fn add_assign(&mut self, rhs: T) {
@@ -39,7 +39,7 @@ macro_rules! impl_add_assign {
 #[macro_export]
 macro_rules! ring_sum {
     ($type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Sum for $type$(<$param_name>)? {
                 #[inline]
                 fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
@@ -58,7 +58,7 @@ macro_rules! ring_sum {
 #[macro_export]
 macro_rules! impl_sub_assign {
     ($type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl<$($param_name: $type_param,)? T: Into<Self>> SubAssign<T> for $type$(<$param_name>)? {
                 #[inline]
                 fn sub_assign(&mut self, rhs: T) {
@@ -78,7 +78,7 @@ macro_rules! impl_sub_assign {
 #[macro_export]
 macro_rules! impl_mul_methods {
     ($type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl<$($param_name: $type_param,)? T: Into<Self>> MulAssign<T> for $type$(<$param_name>)? {
                 #[inline]
                 fn mul_assign(&mut self, rhs: T) {
@@ -104,7 +104,7 @@ macro_rules! impl_mul_methods {
 #[macro_export]
 macro_rules! impl_add_base_field {
     ($alg_type:ty, $field_type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Add<$field_type$(<$param_name>)?> for $alg_type$(<$param_name>)? {
                 type Output = Self;
 
@@ -134,7 +134,7 @@ macro_rules! impl_add_base_field {
 #[macro_export]
 macro_rules! impl_sub_base_field {
     ($alg_type:ty, $field_type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Sub<$field_type$(<$param_name>)?> for $alg_type$(<$param_name>)? {
                 type Output = Self;
 
@@ -164,7 +164,7 @@ macro_rules! impl_sub_base_field {
 #[macro_export]
 macro_rules! impl_mul_base_field {
     ($alg_type:ty, $field_type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Mul<$field_type$(<$param_name>)?> for $alg_type$(<$param_name>)? {
                 type Output = Self;
 
@@ -197,7 +197,7 @@ macro_rules! impl_mul_base_field {
 #[macro_export]
 macro_rules! impl_div_methods {
     ($alg_type:ty, $field_type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Div<$field_type$(<$param_name>)?> for $alg_type$(<$param_name>)? {
                 type Output = Self;
 
@@ -228,7 +228,7 @@ macro_rules! impl_div_methods {
 #[macro_export]
 macro_rules! impl_packed_field_div {
     ($type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Div for $type$(<$param_name>)? {
                 type Output = Self;
 
@@ -265,7 +265,7 @@ macro_rules! impl_packed_field_div {
 #[macro_export]
 macro_rules! impl_sum_prod_base_field {
     ($alg_type:ty, $field_type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Sum<$field_type$(<$param_name>)?> for $alg_type$(<$param_name>)? {
                 #[inline]
                 fn sum<I>(iter: I) -> Self
@@ -298,7 +298,7 @@ macro_rules! impl_sum_prod_base_field {
 #[macro_export]
 macro_rules! impl_rng {
     ($type:ty $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             impl$(<$param_name: $type_param>)? Distribution<$type$(<$param_name>)?> for StandardUniform {
                 #[inline]
             fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> $type$(<$param_name>)? {
@@ -318,7 +318,7 @@ macro_rules! impl_rng {
 #[macro_export]
 macro_rules! impl_packed_value {
     ($alg_type:ty, $field_type:ty, $width:expr $(, ($type_param:ty, $param_name:ty))?) => {
-        paste::paste! {
+        $crate::paste::paste! {
             unsafe impl$(<$param_name: $type_param>)? PackedValue for $alg_type$(<$param_name>)? {
                 type Value = $field_type$(<$param_name>)?;
 

--- a/field/src/packed/interleaves.rs
+++ b/field/src/packed/interleaves.rs
@@ -393,7 +393,7 @@ macro_rules! impl_packed_field_pow_2 {
         ; [ $( ($block_len:expr, $func:ident) ),* $(,)? ],
         $width:expr
     ) => {
-        paste::paste! {
+        $crate::paste::paste! {
             unsafe impl$(<$param_name: $type_param>)? PackedFieldPow2 for $type$(<$param_name>)? {
                 #[inline]
                 fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {

--- a/goldilocks/Cargo.toml
+++ b/goldilocks/Cargo.toml
@@ -23,7 +23,6 @@ p3-symmetric.workspace = true
 p3-util.workspace = true
 
 num-bigint.workspace = true
-paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 spin.workspace = true

--- a/keccak-air/Cargo.toml
+++ b/keccak-air/Cargo.toml
@@ -33,7 +33,6 @@ p3-goldilocks = { path = "../goldilocks" }
 p3-keccak = { path = "../keccak" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-mersenne-31 = { path = "../mersenne-31" }
-p3-monty-31 = { path = "../monty-31" }
 p3-sha256 = { path = "../sha256" }
 p3-symmetric = { path = "../symmetric" }
 p3-uni-stark = { path = "../uni-stark" }

--- a/koala-bear/Cargo.toml
+++ b/koala-bear/Cargo.toml
@@ -29,7 +29,6 @@ num-bigint.workspace = true
 proptest.workspace = true
 rand.workspace = true
 rand_xoshiro.workspace = true
-serde_json.workspace = true
 
 [[bench]]
 name = "bench_field"

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -31,7 +31,6 @@ p3-challenger = { path = "../challenger" }
 p3-commit = { path = "../commit" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
-p3-goldilocks = { path = "../goldilocks" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-symmetric = { path = "../symmetric" }
 

--- a/mersenne-31/Cargo.toml
+++ b/mersenne-31/Cargo.toml
@@ -21,7 +21,6 @@ p3-util.workspace = true
 
 itertools.workspace = true
 num-bigint.workspace = true
-paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 

--- a/monolith-air/Cargo.toml
+++ b/monolith-air/Cargo.toml
@@ -34,15 +34,12 @@ p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-keccak = { path = "../keccak" }
-p3-koala-bear = { path = "../koala-bear" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-mersenne-31 = { path = "../mersenne-31" }
 p3-sha256 = { path = "../sha256" }
 p3-uni-stark = { path = "../uni-stark" }
 
 proptest.workspace = true
-tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
-tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 
 [[bench]]
 name = "monolith-air"

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -22,7 +22,6 @@ p3-util.workspace = true
 
 itertools.workspace = true
 num-bigint.workspace = true
-paste.workspace = true
 rand.workspace = true
 serde = { workspace = true, features = ["derive"] }
 spin.workspace = true

--- a/multilinear-util/Cargo.toml
+++ b/multilinear-util/Cargo.toml
@@ -19,7 +19,6 @@ p3-matrix.workspace = true
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
-tracing.workspace = true
 
 rand.workspace = true
 

--- a/security/Cargo.toml
+++ b/security/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 libm.workspace = true
 p3-air.workspace = true
 p3-field.workspace = true
-p3-util.workspace = true
 serde = { workspace = true, features = ["derive", "alloc"] }
 
 [dev-dependencies]

--- a/sha256-air/Cargo.toml
+++ b/sha256-air/Cargo.toml
@@ -22,16 +22,12 @@ p3-maybe-rayon.workspace = true
 rand.workspace = true
 tracing.workspace = true
 
-[target.'cfg(target_family = "unix")'.dev-dependencies]
-tikv-jemallocator = "0.7"
-
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-challenger = { path = "../challenger" }
 p3-commit = { path = "../commit" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
-p3-goldilocks = { path = "../goldilocks" }
 p3-keccak = { path = "../keccak" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-symmetric = { path = "../symmetric" }
@@ -40,8 +36,6 @@ p3-uni-stark = { path = "../uni-stark" }
 criterion = { version = "0.8", features = ["html_reports"] }
 proptest.workspace = true
 sha2.workspace = true
-tracing-forest = { workspace = true, features = ["ansi", "smallvec"] }
-tracing-subscriber = { workspace = true, features = ["std", "env-filter"] }
 
 [[bench]]
 name = "sha256-air"

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -36,7 +36,6 @@ p3-baby-bear = { path = "../baby-bear" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
 p3-goldilocks = { path = "../goldilocks" }
-p3-keccak = { path = "../keccak" }
 p3-koala-bear = { path = "../koala-bear" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-uni-stark = { path = "../uni-stark" }

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 parallel = ["p3-maybe-rayon/parallel"]
 
 [dependencies]
-libm.workspace = true
 p3-air.workspace = true
 p3-challenger.workspace = true
 p3-commit.workspace = true

--- a/whir/Cargo.toml
+++ b/whir/Cargo.toml
@@ -13,7 +13,6 @@ categories.workspace = true
 parallel = ["p3-maybe-rayon/parallel"]
 
 [dependencies]
-hashbrown.workspace = true
 itertools.workspace = true
 libm.workspace = true
 p3-challenger.workspace = true

--- a/zk-codes/Cargo.toml
+++ b/zk-codes/Cargo.toml
@@ -10,7 +10,6 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-itertools.workspace = true
 p3-dft.workspace = true
 p3-field.workspace = true
 p3-matrix.workspace = true


### PR DESCRIPTION
Adds `cargo machete` to the lint job so an unused dependency can't land again, and clears out the 23 already in the tree.

## The check

Two lines in the existing lint job. The repo already installs tooling through `taiki-e/install-action`, with a comment explaining why prebuilt binaries beat `cargo install`, so this reuses that along with the checkout, toolchain and cache rather than adding a job.

```yaml
tool: cargo-machete,cargo-sort,taplo
...
- name: Unused dependencies
  run: cargo machete --with-metadata
```

**`--with-metadata` is load-bearing, not decoration.** The default scan does not see dev-dependencies at all. Confirmed directly rather than read off the docs — putting an unused `serde_json` back into `baby-bear`'s dev-dependencies:

```
cargo machete                  -> "didn't find any unused dependencies", exit 0
cargo machete --with-metadata  -> p3-baby-bear: serde_json,            exit 1
```

On the unmodified tree the two modes find 11 and 20 findings, and every one of the 9 extras is a dev-dependency. A dev-dependency nothing uses still costs every contributor build time, so the flag is the point of the exercise.

## `paste`, and why there are no ignore lists

`paste` looks unused in five field crates. The only reference is inside `macro_rules!` bodies that `p3-field` exports:

```rust
// field/src/op_assign_macros.rs
#[macro_export]
macro_rules! ... {  paste::paste! { ... }  }
```

A path written in a `macro_rules!` body resolves **where the macro is expanded**, not where it is written. So every crate expanding one of these needed its own `paste` dependency for a helper it never names — drop it from `mersenne-31` and you get `error[E0433]: cannot find module or crate 'paste'`, five times over.

The scanner is right that the dependency is unused; the manifests were right that it was needed. Both point at the same defect, which is the macro reaching into the expanding crate's namespace.

So rather than teach five crates to ignore the finding, this fixes it at the source. `p3-field` re-exports the helper and its macros name it through `$crate`, which resolves at the definition site:

```rust
// field/src/lib.rs
#[doc(hidden)]
pub use paste;

// each of the 16 macro bodies
-        paste::paste! {
+        $crate::paste::paste! {
```

The five crates then drop the dependency outright, and **no crate in the workspace needs a `[package.metadata.cargo-machete]` ignore list** — the check runs with no escape hatches.

## What came out

23 dependencies across 17 crates — **11 regular** and **12 dev**:

| kind | crate -> dependency |
|---|---|
| regular | `whir -> hashbrown`, `commit -> p3-multilinear-util`, `zk-codes -> itertools`, `multilinear-util -> tracing`, `uni-stark -> libm`, `security -> p3-util`, and `paste` from `monty-31`, `binary-field`, `goldilocks`, `bn254`, `mersenne-31` |
| dev | `stir -> p3-keccak`, `keccak-air -> p3-monty-31`, `lookup -> p3-goldilocks`, `monolith-air -> p3-koala-bear, tracing-forest, tracing-subscriber`, `baby-bear -> serde_json`, `koala-bear -> serde_json`, `sha256-air -> p3-goldilocks, tikv-jemallocator, tracing-forest, tracing-subscriber` |

`sha256-air` is the clearest case: it has no `examples/`, only `src/` and `benches/`, but carried the tracing-subscriber and jemalloc setup an example-bearing crate needs.

## A latent bug the check surfaced

`p3-commit` needed `p3-multilinear-util` for a reason with nothing to do with that crate.

The workspace pins `serde = { version = "1.0", default-features = false }`. `p3-commit` declares plain `serde.workspace = true`, but `commit/src/mmcs.rs` derives codecs for types holding `Vec<Vec<T>>`, which needs both `derive` and `alloc`. It was getting them only because `p3-multilinear-util` declares `serde = { workspace = true, features = ["derive", "alloc"] }` and Cargo unifies features across the graph.

Removing the unused crate therefore broke the build — but only on a target where nothing else supplied the features:

```
cargo build --target thumbv7em-none-eabi -p p3-commit
  error[E0277]: the trait bound `Vec<Vec<T>>: serde::Serialize` is not satisfied
     --> commit/src/mmcs.rs:272:10
```

Host builds hid it because something else in the graph unified the features in. Fixed by declaring what `p3-commit` actually uses, which also makes the accidental dependency removable:

```toml
serde = { workspace = true, features = ["derive", "alloc"] }
```

## Verification

```
cargo machete --with-metadata                          # clean, exit 0
cargo check --workspace --all-targets --all-features   # ok
cargo clippy --all-targets -- -D warnings              # ok
cargo sort --workspace --grouped --check               # ok
taplo fmt --check                                      # ok
cargo doc --no-deps --workspace --document-private-items  # ok, with broken-intra-doc-links denied
```

Both other-target CI legs, since `libm`, `hashbrown` and the `paste` change were the ones most likely to matter there — the affected crates build for `thumbv7em-none-eabi`, and `p3-goldilocks` builds for `wasm32-unknown-unknown`. Tests pass for all 18 affected crates.

## One pre-existing thing, not touched here

Running the affected crates' suites turned up two failures in `p3-lookup` — `generate_permutation_exclusive_rejects_non_boolean_flag` and `..._rejects_two_active_flags`. They reproduce identically on `main`, so they are not from this change. They rest on `debug_assert`s, so they pass in debug (what CI runs via nextest) and fail under `--release`. Worth a separate look if you want the suite release-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
