### PR TITLE
feat(binary-field): Ghash128, GF(2^128) in the polynomial basis, with SIMD packings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,15 +48,28 @@ jobs:
           - os: ubuntu-latest
             features: "+pclmulqdq"
             parallel: true
+          # VPCLMULQDQ, the 256- and 512-bit carryless multiply, arrived with Ice Lake and
+          # Zen 3. GitHub's runner pool still includes older parts, so these legs compile the
+          # wide carryless-multiply paths rather than running them.
           - os: ubuntu-latest
-            features: "+avx512f"
+            features: "+avx2,+vpclmulqdq"
+            compile_only: true
+            target: x86_64-unknown-linux-gnu
+            parallel: false
+          - os: ubuntu-latest
+            features: "+avx2,+vpclmulqdq"
+            compile_only: true
+            target: x86_64-unknown-linux-gnu
+            parallel: true
+          - os: ubuntu-latest
+            features: "+avx512f,+vpclmulqdq"
             # GitHub-hosted runners aren't guaranteed to have AVX-512 hardware,
             # so this leg only verifies the AVX-512 paths compile.
             compile_only: true
             target: x86_64-unknown-linux-gnu
             parallel: false
           - os: ubuntu-latest
-            features: "+avx512f"
+            features: "+avx512f,+vpclmulqdq"
             compile_only: true
             target: x86_64-unknown-linux-gnu
             parallel: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,21 @@ jobs:
           - os: ubuntu-latest
             features: "+pclmulqdq"
             parallel: true
+          # A leg's job name embeds its `features`, and the two below are required status
+          # checks, so renaming either one leaves a required check that is never reported.
+          # New feature combinations go in legs of their own.
+          - os: ubuntu-latest
+            features: "+avx512f"
+            # GitHub-hosted runners aren't guaranteed to have AVX-512 hardware,
+            # so this leg only verifies the AVX-512 paths compile.
+            compile_only: true
+            target: x86_64-unknown-linux-gnu
+            parallel: false
+          - os: ubuntu-latest
+            features: "+avx512f"
+            compile_only: true
+            target: x86_64-unknown-linux-gnu
+            parallel: true
           # VPCLMULQDQ, the 256- and 512-bit carryless multiply, arrived with Ice Lake and
           # Zen 3. GitHub's runner pool still includes older parts, so these legs compile the
           # wide carryless-multiply paths rather than running them.
@@ -63,8 +78,6 @@ jobs:
             parallel: true
           - os: ubuntu-latest
             features: "+avx512f,+vpclmulqdq"
-            # GitHub-hosted runners aren't guaranteed to have AVX-512 hardware,
-            # so this leg only verifies the AVX-512 paths compile.
             compile_only: true
             target: x86_64-unknown-linux-gnu
             parallel: false

--- a/binary-dft/benches/ntt.rs
+++ b/binary-dft/benches/ntt.rs
@@ -2,8 +2,8 @@
 
 use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_baby_bear::BabyBear;
-use p3_binary_dft::{AdditiveNtt, AdditiveRsEncoder, LchNtt};
-use p3_binary_field::{BinaryField32, BinaryField64, BinaryField128, TowerLevel};
+use p3_binary_dft::{AdditiveNtt, AdditiveRsEncoder, LchNtt, PolyBasisNtt};
+use p3_binary_field::{BinaryField32, BinaryField64, BinaryField128, Ghash128, TowerLevel};
 use p3_commit::Encoder;
 use p3_dft::Radix2DFTSmallBatch;
 use p3_matrix::dense::RowMajorMatrix;
@@ -25,24 +25,31 @@ const LOG_INV_RATE: usize = 1;
 const BABY_BEAR_ROW_RATIO: usize = 4;
 
 fn bench_ntt(c: &mut Criterion) {
-    ntt::<BinaryField32>(c);
-    ntt::<BinaryField64>(c);
-    ntt::<BinaryField128>(c);
+    ntt(c, "32", &LchNtt::<BinaryField32>::default());
+    ntt(c, "64", &LchNtt::<BinaryField64>::default());
+
+    // The three routes to a `GF(2^128)` transform, in the order they cost.
+    //
+    //     128/tower  every twiddle multiply changes basis twice and back
+    //     128/hybrid the matrix changes basis once on the way in and once on the way out
+    //     128/ghash  the data is already in the basis the multiply wants
+    ntt(c, "128/tower", &LchNtt::<BinaryField128>::default());
+    ntt(c, "128/hybrid", &PolyBasisNtt::default());
+    ntt(c, "128/ghash", &LchNtt::<Ghash128>::default());
 }
 
 /// The forward transform of a width-[`WIDTH`] matrix over `S_ℓ`, across [`LOG_HEIGHTS`].
-fn ntt<F: TowerLevel>(c: &mut Criterion)
+fn ntt<F: TowerLevel, N: AdditiveNtt<F>>(c: &mut Criterion, name: &str, ntt: &N)
 where
     StandardUniform: Distribution<F>,
 {
-    let mut group = c.benchmark_group(format!("ntt/{}", 1usize << F::LOG_BITS));
+    let mut group = c.benchmark_group(format!("ntt/{name}"));
     group.sample_size(10);
 
     let mut rng = SmallRng::seed_from_u64(1);
-    let ntt = LchNtt::<F>::default();
     for log_height in LOG_HEIGHTS {
         let coeffs = RowMajorMatrix::<F>::rand(&mut rng, 1 << log_height, WIDTH);
-        group.bench_with_input(BenchmarkId::from_parameter(log_height), &ntt, |b, ntt| {
+        group.bench_with_input(BenchmarkId::from_parameter(log_height), ntt, |b, ntt| {
             b.iter_batched(
                 || coeffs.clone(),
                 |m| ntt.ntt_batch(m),

--- a/binary-dft/src/lch.rs
+++ b/binary-dft/src/lch.rs
@@ -12,24 +12,36 @@ use p3_util::log2_strict_usize;
 use crate::domain::{domain_point, domain_point_steps, subspace_polynomial};
 use crate::traits::AdditiveNtt;
 
-/// The Lin–Chung–Han additive NTT over a Cantor-basis domain.
+/// The Lin–Chung–Han additive NTT over the Cantor-basis domain.
 ///
-/// At stage `j`, block `blk` has twiddle `W_j(shift) + domain_point(blk << 1)`.
-/// There is no twiddle table.
+/// Twiddles are index shifts (D8): at stage `j` and butterfly block `blk` the twiddle is
+/// `W_j(shift) + domain_point(blk << 1)`, so there is no twiddle table.
 ///
-/// Consecutive blocks differ by a fixed increment, shared by every stage.
+/// Consecutive blocks differ by a fixed increment, so a block takes its twiddle from the one
+/// before it rather than walking its own index.
+/// The `ℓ - 1` increments are shared by every stage and are the only per-size precomputation.
 ///
-/// Butterflies run on SIMD packings, and drop the multiply where the twiddle is zero.
+/// `W_j` is `F_2`-linear and `domain_point(0)` is zero, so over the subspace itself — the
+/// coset with `shift = 0` — the first block of every stage has a zero twiddle and its
+/// butterfly collapses to a single addition. The inner loop takes that as a separate case,
+/// which removes one multiply in `2/ℓ` of them.
 #[derive(Clone, Debug, Default)]
 pub struct LchNtt<F> {
     _marker: PhantomData<F>,
 }
 
-/// Elements per side of a butterfly task.
+/// The number of field elements one butterfly task covers on each side of a block.
 ///
-/// Narrow blocks share a task.
-/// Wide blocks split into pieces of this size, which have too few blocks to fill a machine.
-/// Either way a stage leaves enough independent tasks to be worth handing to other threads.
+/// Stage `j` has `2^(ℓ − 1 − j)` blocks of `half = 2^j · width` elements per side, so cutting
+/// each side into pieces of this size leaves `n · width / (2 · BUTTERFLY_GRAIN)` pieces at
+/// every stage, independent of `j`: the wide stages, which have too few blocks to fill a
+/// machine, are split from within instead. Stages with `half ≤ BUTTERFLY_GRAIN` keep a single
+/// piece per side and instead gather `BUTTERFLY_GRAIN / half` whole blocks into one task, so a
+/// task is a piece of this size on either side of the crossover.
+///
+/// At a few nanoseconds per butterfly a piece of this size is microseconds of work, well above
+/// the cost of handing a task to another thread, while still leaving hundreds of pieces per
+/// stage at the smallest useful heights.
 pub(crate) const BUTTERFLY_GRAIN: usize = 1 << 10;
 
 impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
@@ -314,8 +326,8 @@ mod tests {
             prop_assert_eq!(ntt.shifted_intt_batch(evals, shift), coeffs);
         }
 
-        /// The low-degree extension agrees with the oracle, on a coset too.
-        /// The input rows reappear as the prefix of the output.
+        /// `LchNtt`'s low-degree extension agrees with the oracle's, on a coset too, and the
+        /// input rows reappear as the prefix: the correspondence Phase 3 folds along.
         #[test]
         fn lch_lde_matches_naive(
             log_n in 0usize..=6,
@@ -339,8 +351,9 @@ mod tests {
     /// A height whose stages take more than one butterfly task, so a task seeds its twiddle at
     /// a block index of its own rather than at zero.
     ///
-    /// The round-trip test is blind to the schedule.
-    /// Both directions read the same twiddles, so they invert each other regardless.
+    /// The oracle tests all sit below that height, and `lch_round_trips` is blind to the
+    /// schedule: both directions read the same twiddles, so they invert each other whatever
+    /// those twiddles are. Only a comparison against an independent walk pins them.
     #[test]
     fn lch_matches_a_twiddle_walk_across_several_tasks() {
         const LOG_N: usize = 12;
@@ -367,7 +380,8 @@ mod tests {
         }
     }
 
-    /// An index past the field's bit width needs a Cantor vector it does not have.
+    /// An index of `S_ℓ` past the bit width of `F` calls for a Cantor basis vector this level
+    /// does not have.
     #[test]
     #[should_panic]
     fn shifted_ntt_batch_rejects_l_past_the_bit_width() {
@@ -376,7 +390,7 @@ mod tests {
         let _ = LchNtt::<BinaryField8>::default().ntt_batch(coeffs);
     }
 
-    /// A height that is not a power of two has no well-defined `l`.
+    /// A height that is not a power of two has no well-defined `ℓ`.
     #[test]
     #[should_panic]
     fn shifted_ntt_batch_rejects_a_non_power_of_two_height() {
@@ -407,7 +421,8 @@ mod tests {
         }
     }
 
-    /// The domain does not depend on the level, so neither does the transform.
+    /// The same data transformed at two levels agrees after embedding: the domain does not
+    /// depend on the level, so neither does the transform.
     #[test]
     fn levels_agree_after_embedding() {
         const LOG_N: usize = 6;

--- a/binary-dft/src/lch.rs
+++ b/binary-dft/src/lch.rs
@@ -3,6 +3,7 @@
 use core::marker::PhantomData;
 
 use p3_binary_field::TowerLevel;
+use p3_field::{PackedValue, PrimeCharacteristicRing};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
@@ -11,36 +12,24 @@ use p3_util::log2_strict_usize;
 use crate::domain::{domain_point, domain_point_steps, subspace_polynomial};
 use crate::traits::AdditiveNtt;
 
-/// The Lin–Chung–Han additive NTT over the Cantor-basis domain.
+/// The Lin–Chung–Han additive NTT over a Cantor-basis domain.
 ///
-/// Twiddles are index shifts (D8): at stage `j` and butterfly block `blk` the twiddle is
-/// `W_j(shift) + domain_point(blk << 1)`, so there is no twiddle table.
+/// At stage `j`, block `blk` has twiddle `W_j(shift) + domain_point(blk << 1)`.
+/// There is no twiddle table.
 ///
-/// Consecutive blocks differ by a fixed increment, so a block takes its twiddle from the one
-/// before it rather than walking its own index.
-/// The `ℓ - 1` increments are shared by every stage and are the only per-size precomputation.
+/// Consecutive blocks differ by a fixed increment, shared by every stage.
 ///
-/// `W_j` is `F_2`-linear and `domain_point(0)` is zero, so over the subspace itself — the
-/// coset with `shift = 0` — the first block of every stage has a zero twiddle and its
-/// butterfly collapses to a single addition. The inner loop takes that as a separate case,
-/// which removes one multiply in `2/ℓ` of them.
+/// Butterflies run on SIMD packings, and drop the multiply where the twiddle is zero.
 #[derive(Clone, Debug, Default)]
 pub struct LchNtt<F> {
     _marker: PhantomData<F>,
 }
 
-/// The number of field elements one butterfly task covers on each side of a block.
+/// Elements per side of a butterfly task.
 ///
-/// Stage `j` has `2^(ℓ − 1 − j)` blocks of `half = 2^j · width` elements per side, so cutting
-/// each side into pieces of this size leaves `n · width / (2 · BUTTERFLY_GRAIN)` pieces at
-/// every stage, independent of `j`: the wide stages, which have too few blocks to fill a
-/// machine, are split from within instead. Stages with `half ≤ BUTTERFLY_GRAIN` keep a single
-/// piece per side and instead gather `BUTTERFLY_GRAIN / half` whole blocks into one task, so a
-/// task is a piece of this size on either side of the crossover.
-///
-/// At a few nanoseconds per butterfly a piece of this size is microseconds of work, well above
-/// the cost of handing a task to another thread, while still leaving hundreds of pieces per
-/// stage at the smallest useful heights.
+/// Narrow blocks share a task.
+/// Wide blocks split into pieces of this size, which have too few blocks to fill a machine.
+/// Either way a stage leaves enough independent tasks to be worth handing to other threads.
 pub(crate) const BUTTERFLY_GRAIN: usize = 1 << 10;
 
 impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
@@ -70,21 +59,9 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
                         if i != 0 {
                             t += steps[(first + i).trailing_zeros() as usize];
                         }
-                        let zero = t.is_zero();
                         let (lo, hi) = block.split_at_mut(half);
                         let butterfly = |lo: &mut [F], hi: &mut [F]| {
-                            if zero {
-                                // (u, v) ↦ (u, u + v)
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    *v += *u;
-                                }
-                            } else {
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    // (u, v) ↦ (u + t·v, u + t·v + v)
-                                    *u += t * *v;
-                                    *v += *u;
-                                }
-                            }
+                            packed_butterfly::<F, false>(lo, hi, t);
                         };
                         // Pairs are independent across the block, so a block wider than the
                         // grain is split further rather than run on a single thread.
@@ -126,21 +103,9 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
                         if i != 0 {
                             t += steps[(first + i).trailing_zeros() as usize];
                         }
-                        let zero = t.is_zero();
                         let (lo, hi) = block.split_at_mut(half);
                         let butterfly = |lo: &mut [F], hi: &mut [F]| {
-                            if zero {
-                                // (u', v') ↦ (u = u', v = u' + v')
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    *v += *u;
-                                }
-                            } else {
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    // (u', v') ↦ (u = u' + t·v, v = u' + v')
-                                    *v += *u;
-                                    *u += t * *v;
-                                }
-                            }
+                            packed_butterfly::<F, true>(lo, hi, t);
                         };
                         // Pairs are independent across the block, so a block wider than the
                         // grain is split further rather than run on a single thread.
@@ -158,13 +123,54 @@ impl<F: TowerLevel> AdditiveNtt<F> for LchNtt<F> {
     }
 }
 
+/// Apply a butterfly to full SIMD vectors and any remaining scalar elements.
+#[inline]
+fn packed_butterfly<F: TowerLevel, const INVERSE: bool>(lo: &mut [F], hi: &mut [F], t: F) {
+    // Both sides have equal length, so their packed prefixes and tails pair exactly.
+    let (lo, lo_tail) = F::Packing::pack_slice_with_suffix_mut(lo);
+    let (hi, hi_tail) = F::Packing::pack_slice_with_suffix_mut(hi);
+    let zero = t.is_zero();
+    butterfly_values::<_, INVERSE>(lo, hi, t.into(), zero);
+    butterfly_values::<_, INVERSE>(lo_tail, hi_tail, t, zero);
+}
+
+/// Apply the same field identities to scalar or packed values.
+#[inline]
+fn butterfly_values<R: PrimeCharacteristicRing + Copy, const INVERSE: bool>(
+    lo: &mut [R],
+    hi: &mut [R],
+    t: R,
+    zero: bool,
+) {
+    if zero {
+        // A zero twiddle reduces both transform directions to (u, u + v).
+        for (u, v) in lo.iter_mut().zip(hi) {
+            *v += *u;
+        }
+    } else if INVERSE {
+        // Recover v first, then remove its twiddle contribution from u.
+        for (u, v) in lo.iter_mut().zip(hi) {
+            *v += *u;
+            *u += t * *v;
+        }
+    } else {
+        // Evaluate the pair as (u + t*v, u + t*v + v).
+        for (u, v) in lo.iter_mut().zip(hi) {
+            *u += t * *v;
+            *v += *u;
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec;
 
     use p3_binary_field::{
-        BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128, TowerLevel,
+        BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128, Ghash128,
+        TowerLevel,
     };
+    use p3_field::PrimeCharacteristicRing;
     use p3_matrix::Matrix;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_util::log2_strict_usize;
@@ -227,6 +233,22 @@ mod tests {
 
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]
+
+        #[test]
+        fn ghash_packing_matches_naive_and_round_trips(
+            log_n in 0usize..=7,
+            width in 1usize..=9,
+            seed: u64,
+            shift: u64,
+        ) {
+            // Odd widths force scalar tails alongside SIMD prefixes.
+            check_matches_naive::<Ghash128>(log_n, width, seed, shift);
+            let coeffs = matrix::<Ghash128>(log_n, width, seed);
+            let shift = sample::<Ghash128>(shift);
+            let ntt = LchNtt::<Ghash128>::default();
+            let transformed = ntt.shifted_ntt_batch(coeffs.clone(), shift);
+            prop_assert_eq!(ntt.shifted_intt_batch(transformed, shift), coeffs);
+        }
 
         #[test]
         fn lch_matches_naive_at_8_bits(
@@ -292,8 +314,8 @@ mod tests {
             prop_assert_eq!(ntt.shifted_intt_batch(evals, shift), coeffs);
         }
 
-        /// `LchNtt`'s low-degree extension agrees with the oracle's, on a coset too, and the
-        /// input rows reappear as the prefix: the correspondence Phase 3 folds along.
+        /// The low-degree extension agrees with the oracle, on a coset too.
+        /// The input rows reappear as the prefix of the output.
         #[test]
         fn lch_lde_matches_naive(
             log_n in 0usize..=6,
@@ -317,9 +339,8 @@ mod tests {
     /// A height whose stages take more than one butterfly task, so a task seeds its twiddle at
     /// a block index of its own rather than at zero.
     ///
-    /// The oracle tests all sit below that height, and `lch_round_trips` is blind to the
-    /// schedule: both directions read the same twiddles, so they invert each other whatever
-    /// those twiddles are. Only a comparison against an independent walk pins them.
+    /// The round-trip test is blind to the schedule.
+    /// Both directions read the same twiddles, so they invert each other regardless.
     #[test]
     fn lch_matches_a_twiddle_walk_across_several_tasks() {
         const LOG_N: usize = 12;
@@ -346,8 +367,7 @@ mod tests {
         }
     }
 
-    /// An index of `S_ℓ` past the bit width of `F` calls for a Cantor basis vector this level
-    /// does not have.
+    /// An index past the field's bit width needs a Cantor vector it does not have.
     #[test]
     #[should_panic]
     fn shifted_ntt_batch_rejects_l_past_the_bit_width() {
@@ -356,7 +376,7 @@ mod tests {
         let _ = LchNtt::<BinaryField8>::default().ntt_batch(coeffs);
     }
 
-    /// A height that is not a power of two has no well-defined `ℓ`.
+    /// A height that is not a power of two has no well-defined `l`.
     #[test]
     #[should_panic]
     fn shifted_ntt_batch_rejects_a_non_power_of_two_height() {
@@ -387,8 +407,7 @@ mod tests {
         }
     }
 
-    /// The same data transformed at two levels agrees after embedding: the domain does not
-    /// depend on the level, so neither does the transform.
+    /// The domain does not depend on the level, so neither does the transform.
     #[test]
     fn levels_agree_after_embedding() {
         const LOG_N: usize = 6;
@@ -406,6 +425,54 @@ mod tests {
         let large = LchNtt::<BinaryField128>::default().ntt_batch(coeffs128);
         for (s, l) in small.values.iter().zip(&large.values) {
             assert_eq!(u128::from(s.to_repr()), l.to_repr());
+        }
+    }
+
+    #[test]
+    fn ghash_packing_matches_scalar_across_tasks() {
+        // These blocks cross the task-size boundary and leave scalar tails at narrow stages.
+        for width in [3, 5] {
+            for shift in [Ghash128::ZERO, sample::<Ghash128>(17)] {
+                let coeffs = matrix::<Ghash128>(11, width, 29);
+                let ntt = LchNtt::<Ghash128>::default();
+                let actual = ntt.shifted_ntt_batch(coeffs.clone(), shift);
+                // The serial oracle uses scalar products and recomputes every twiddle.
+                assert_eq!(actual, twiddle_walk_ntt(coeffs.clone(), shift));
+                assert_eq!(ntt.shifted_intt_batch(actual, shift), coeffs);
+            }
+        }
+    }
+
+    /// The transform must commute with the change of basis between the two representations.
+    ///
+    /// It is built from twiddle multiplies.
+    /// Only a field isomorphism preserves multiplication, so this pins that too.
+    #[test]
+    fn the_two_representations_of_the_widest_level_transform_alike() {
+        const LOG_N: usize = 7;
+        const WIDTH: usize = 3;
+
+        // Express one matrix in both field bases.
+        let tower_coeffs = matrix::<BinaryField128>(LOG_N, WIDTH, 11);
+        let ghash_coeffs = RowMajorMatrix::new(
+            tower_coeffs
+                .values
+                .iter()
+                .copied()
+                .map(Ghash128::from)
+                .collect(),
+            WIDTH,
+        );
+
+        let shift = sample::<BinaryField128>(0x0123_4567_89ab_cdef);
+
+        let tower = LchNtt::<BinaryField128>::default().shifted_ntt_batch(tower_coeffs, shift);
+        let ghash =
+            LchNtt::<Ghash128>::default().shifted_ntt_batch(ghash_coeffs, Ghash128::from(shift));
+
+        // Converting before or after the transform must give the same values.
+        for (t, g) in tower.values.iter().zip(&ghash.values) {
+            assert_eq!(Ghash128::from(*t), *g);
         }
     }
 }

--- a/binary-field/README.md
+++ b/binary-field/README.md
@@ -1,15 +1,42 @@
 # p3-binary-field
 
-The Wiedemann binary tower `GF(2) ⊂ GF(4) ⊂ … ⊂ GF(2^128)`, providing characteristic-2
-field arithmetic as a building block toward binary-field SNARKs.
+Characteristic-2 field arithmetic as a building block toward binary-field SNARKs.
+
+The crate carries two representations of `GF(2^128)`, which are the same field seen in two
+bases:
+
+- the Wiedemann tower `GF(2) ⊂ GF(4) ⊂ … ⊂ GF(2^128)`, whose levels are subfields of one
+  another;
+- the polynomial basis of `x^128 + x^7 + x^2 + x + 1`, the GHASH modulus.
 
 Key items:
 
 - `Gf2` — the base field `GF(2)`
 - `BinaryField2`, `BinaryField4`, `BinaryField8`, `BinaryField16`, `BinaryField32`, `BinaryField64`, `BinaryField128` — the tower levels, each a quadratic extension of the one below
-- `BasedVectorSpace` / `ExtensionField` between every pair of byte-aligned levels, in the tower basis
+- `Ghash128` — `GF(2^128)` in the GHASH polynomial basis, with `From` conversions to and from the widest tower level
+- `PackedGhash128` — the SIMD packing, holding two elements per register under `AVX2` and four under `AVX-512`
+- `BasedVectorSpace` / `ExtensionField` between every pair of byte-aligned tower levels, in the tower basis
 - `BinaryChallenger` — Fiat–Shamir over a byte challenger; every bit pattern is a field element, so no rejection sampling is needed
-- Carryless-multiply fast paths for `BinaryField64` and `BinaryField128` on x86-64 (`pclmulqdq`) and AArch64 (`aes`)
+- Carryless-multiply fast paths on x86-64 (`pclmulqdq`, `vpclmulqdq`) and AArch64 (`aes`), with a software backend everywhere else
+
+## Which representation to use
+
+With hardware carryless multiplication, a 128-bit tower product converts both operands into
+polynomial coordinates and converts the result back.
+Each conversion reads sixteen operand-indexed table entries.
+
+`Ghash128` works directly in polynomial coordinates and avoids those conversions.
+Its SIMD packings process two or four independent elements per register.
+Dot products accumulate unreduced polynomials and reduce the sum once.
+
+What it gives up is the subfield structure: `GF(2^8)`, `GF(2^16)`, `GF(2^32)` and `GF(2^64)`
+are byte-aligned inside the tower representation and are not inside this one.
+
+Code that needs the subfield structure — ring switching, small-field witnesses — wants the
+tower. Code that only needs a large binary field — challenges, folding, transforms — wants
+`Ghash128`.
+
+## Conventions
 
 Little-endian targets only. The tower-basis coefficients of an element are borrowed in place
 as a slice of the level below, which is sound only where the byte layout coincides with the
@@ -20,12 +47,31 @@ subfield `GF(2)`, so they carry the parity of their argument rather than its bit
 `from_u64(2)` is zero. `from_le_bytes` and `interpolation_node` are the bit-pattern
 constructors.
 
-Two deliberate scope boundaries:
+The tower levels are unpacked: `Packing` is `Self` at every one of them, because a tower
+product is table lookups that no vector unit widens. Only `Ghash128` has a packing.
 
-- `TowerLevel` — the trait carrying `LOG_BITS`, `from_repr`, `to_repr` and `mul_alpha` — is
-  `pub(crate)`, keeping the public surface minimal. Downstream crates work through the
-  `p3-field` traits instead; exporting it later is an additive change.
-- Arithmetic is unpacked: `Packing` is `Self` at every level, so elements are never bit-packed
-  into SIMD lanes. A packed representation is a separate design.
+GHASH coordinates assign the coefficient of `x^i` to bit `i` of the backing integer.
+NIST GCM blocks assign `x^0` to the leftmost bit instead.
+For a block written as a big-endian integer, reverse all 128 bits before constructing an element.
+The field arithmetic alone is not an AES-GCM implementation.
+
+## Timing and backend selection
+
+GHASH multiplication, squaring, square roots, and dot products use no operand-indexed tables.
+Their software multiplication assumes constant-time integer multiplication on the target CPU.
+
+GHASH inversion, tower arithmetic, and conversions between the two bases use operand-indexed tables.
+These operations are not constant-time and should not process secrets when cache or timing leakage matters.
+Hardware GHASH inversion uses five precomputed maps, totaling 320 KiB of read-only tables.
+Software GHASH inversion uses the tower norm instead, and does not compile those tables.
+
+Backends are selected at compile time.
+For a binary intended for the build machine, enable its instructions with:
+
+```sh
+RUSTFLAGS="-C target-cpu=native" cargo test -p p3-binary-field -p p3-binary-dft
+```
+
+A baseline build uses the software backend.
 
 Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.

--- a/binary-field/README.md
+++ b/binary-field/README.md
@@ -14,7 +14,8 @@ Key items:
 - `Gf2` — the base field `GF(2)`
 - `BinaryField2`, `BinaryField4`, `BinaryField8`, `BinaryField16`, `BinaryField32`, `BinaryField64`, `BinaryField128` — the tower levels, each a quadratic extension of the one below
 - `Ghash128` — `GF(2^128)` in the GHASH polynomial basis, with `From` conversions to and from the widest tower level
-- `PackedGhash128` — the SIMD packing, holding two elements per register under `AVX2` and four under `AVX-512`
+- `PackedGhash128` — the SIMD packing, two elements per register on `avx2` and four on `avx512f`,
+  in both cases only when `vpclmulqdq` is also enabled, so it is absent from the rendered docs
 - `BasedVectorSpace` / `ExtensionField` between every pair of byte-aligned tower levels, in the tower basis
 - `BinaryChallenger` — Fiat–Shamir over a byte challenger; every bit pattern is a field element, so no rejection sampling is needed
 - Carryless-multiply fast paths on x86-64 (`pclmulqdq`, `vpclmulqdq`) and AArch64 (`aes`), with a software backend everywhere else

--- a/binary-field/benches/arithmetic.rs
+++ b/binary-field/benches/arithmetic.rs
@@ -341,7 +341,9 @@ fn bench_representation_square(c: &mut Criterion) {
     group.finish();
 }
 
-/// Inversion in the polynomial basis, which routes through the tower and pays two conversions.
+/// Inversion in the polynomial basis, against converting to the tower and inverting there.
+///
+/// Both arms see the same operands, none of them zero, so neither can panic.
 fn bench_representation_inverse(c: &mut Criterion) {
     let (_, ghash) = representation_operands();
     let nonzero: Vec<Ghash128> = ghash
@@ -353,7 +355,7 @@ fn bench_representation_inverse(c: &mut Criterion) {
     group.bench_function("through tower", |b| {
         // Include both basis conversions in the comparison.
         b.iter(|| {
-            black_box(&ghash).iter().fold(Ghash128::ZERO, |acc, &y| {
+            black_box(&nonzero).iter().fold(Ghash128::ZERO, |acc, &y| {
                 acc + Ghash128::from(BinaryField128::from(y).inverse())
             })
         });

--- a/binary-field/benches/arithmetic.rs
+++ b/binary-field/benches/arithmetic.rs
@@ -9,8 +9,11 @@
 use std::hint::black_box;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
-use p3_binary_field::{BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128};
-use p3_field::{BasedVectorSpace, Field, PrimeCharacteristicRing};
+use p3_binary_field::{
+    BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128, Ghash128,
+};
+use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing};
+use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
@@ -238,12 +241,278 @@ fn bench_flatten_to_base(c: &mut Criterion) {
     group.finish();
 }
 
+/// Random operands in both representations of `GF(2^128)`, lane for lane.
+fn representation_operands() -> (Vec<BinaryField128>, Vec<Ghash128>) {
+    let mut rng = SmallRng::seed_from_u64(1);
+    let tower: Vec<BinaryField128> = (0..REPS).map(|_| rng.random()).collect();
+    let ghash = tower.iter().map(|&x| Ghash128::from(x)).collect();
+    (tower, ghash)
+}
+
+/// Multiplication in the two representations, on a dependent chain.
+///
+/// Both are the same field.
+///
+/// A tower product converts both operands and the result, sixteen lookups apiece.
+/// A polynomial-basis product is already in the basis the instruction wants.
+fn bench_representation_mul_latency(c: &mut Criterion) {
+    let (tower, ghash) = representation_operands();
+
+    let mut group = c.benchmark_group("representations/mul/latency");
+    group.bench_function("tower", |b| {
+        b.iter(|| {
+            black_box(&tower)
+                .iter()
+                .fold(BinaryField128::ONE, |acc, &y| acc * y)
+        });
+    });
+    group.bench_function("ghash", |b| {
+        b.iter(|| {
+            black_box(&ghash)
+                .iter()
+                .fold(Ghash128::ONE, |acc, &y| acc * y)
+        });
+    });
+    group.finish();
+}
+
+/// Multiplication in the two representations, on independent chains the core can overlap.
+fn bench_representation_mul_throughput(c: &mut Criterion) {
+    let (tower, ghash) = representation_operands();
+
+    let mut group = c.benchmark_group("representations/mul/throughput");
+    group.bench_function("tower", |b| {
+        b.iter(|| {
+            let mut acc = [BinaryField128::ONE; LANES];
+            let (chunks, _) = black_box(&tower).as_chunks::<LANES>();
+            for chunk in chunks {
+                for (lane, &y) in acc.iter_mut().zip(chunk) {
+                    *lane *= y;
+                }
+            }
+            acc
+        });
+    });
+    group.bench_function("ghash", |b| {
+        b.iter(|| {
+            let mut acc = [Ghash128::ONE; LANES];
+            let (chunks, _) = black_box(&ghash).as_chunks::<LANES>();
+            for chunk in chunks {
+                for (lane, &y) in acc.iter_mut().zip(chunk) {
+                    *lane *= y;
+                }
+            }
+            acc
+        });
+    });
+    group.finish();
+}
+
+/// Squaring in the two representations.
+///
+/// Each step mixes in the next operand, so the chain cannot fold away at compile time.
+fn bench_representation_square(c: &mut Criterion) {
+    let (tower, ghash) = representation_operands();
+
+    let mut group = c.benchmark_group("representations/square");
+    group.bench_function("tower", |b| {
+        b.iter(|| {
+            black_box(&tower)
+                .iter()
+                .fold(BinaryField128::ONE, |acc, &y| (acc + y).square())
+        });
+    });
+    group.bench_function("ghash", |b| {
+        b.iter(|| {
+            black_box(&ghash)
+                .iter()
+                .fold(Ghash128::ONE, |acc, &y| (acc + y).square())
+        });
+    });
+    // The dedicated squaring drops the two cross products a general multiply pays for.
+    group.bench_function("ghash, through multiplication", |b| {
+        b.iter(|| {
+            black_box(&ghash).iter().fold(Ghash128::ONE, |acc, &y| {
+                let x = acc + y;
+                x * x
+            })
+        });
+    });
+    group.finish();
+}
+
+/// Inversion in the polynomial basis, which routes through the tower and pays two conversions.
+fn bench_representation_inverse(c: &mut Criterion) {
+    let (_, ghash) = representation_operands();
+    let nonzero: Vec<Ghash128> = ghash
+        .iter()
+        .map(|&x| if x.is_zero() { Ghash128::ONE } else { x })
+        .collect();
+
+    let mut group = c.benchmark_group("representations/inverse");
+    group.bench_function("through tower", |b| {
+        // Include both basis conversions in the comparison.
+        b.iter(|| {
+            black_box(&ghash).iter().fold(Ghash128::ZERO, |acc, &y| {
+                acc + Ghash128::from(BinaryField128::from(y).inverse())
+            })
+        });
+    });
+
+    group.bench_function("ghash", |b| {
+        b.iter(|| {
+            black_box(&nonzero)
+                .iter()
+                .fold(Ghash128::ZERO, |acc, &y| acc + y.inverse())
+        });
+    });
+    group.finish();
+}
+
+/// What the change of basis costs on its own, in both directions.
+fn bench_representation_convert(c: &mut Criterion) {
+    let (tower, ghash) = representation_operands();
+
+    let mut group = c.benchmark_group("representations/convert");
+    group.bench_function("tower to ghash", |b| {
+        b.iter(|| {
+            black_box(&tower)
+                .iter()
+                .fold(Ghash128::ZERO, |acc, &y| acc + Ghash128::from(y))
+        });
+    });
+    group.bench_function("ghash to tower", |b| {
+        b.iter(|| {
+            black_box(&ghash)
+                .iter()
+                .fold(BinaryField128::ZERO, |acc, &y| {
+                    acc + BinaryField128::from(y)
+                })
+        });
+    });
+    group.finish();
+}
+
+/// The packing of the polynomial-basis field against its scalar.
+///
+/// One element fills one 128-bit lane.
+/// A packed product is the scalar kernel applied to every lane at once.
+/// Both arms multiply the same number of field elements.
+fn bench_packing(c: &mut Criterion) {
+    type Packing = <Ghash128 as Field>::Packing;
+
+    let width = Packing::WIDTH;
+    let mut rng = SmallRng::seed_from_u64(1);
+
+    // A whole number of packed vectors, so neither arm has a remainder to handle.
+    let scalars: Vec<Ghash128> = (0..REPS.next_multiple_of(width))
+        .map(|_| rng.random())
+        .collect();
+    let packed: Vec<Packing> = Packing::pack_slice(&scalars).to_vec();
+
+    let mut group = c.benchmark_group("packing/mul/throughput");
+    group.throughput(criterion::Throughput::Elements(scalars.len() as u64));
+
+    group.bench_function("scalar", |b| {
+        b.iter(|| {
+            let mut acc = [Ghash128::ONE; LANES];
+            let (chunks, _) = black_box(&scalars).as_chunks::<LANES>();
+            for chunk in chunks {
+                for (lane, &y) in acc.iter_mut().zip(chunk) {
+                    *lane *= y;
+                }
+            }
+            acc
+        });
+    });
+    group.bench_function("packed", |b| {
+        b.iter(|| {
+            let mut acc = [Packing::ONE; LANES];
+            let (chunks, _) = black_box(&packed).as_chunks::<LANES>();
+            for chunk in chunks {
+                for (lane, &y) in acc.iter_mut().zip(chunk) {
+                    *lane *= y;
+                }
+            }
+            acc
+        });
+    });
+    group.finish();
+}
+
+/// Compare direct square roots with the repeated-squaring definition.
+fn bench_ghash_sqrt(c: &mut Criterion) {
+    let (_, operands) = representation_operands();
+    let mut group = c.benchmark_group("ghash/sqrt");
+    for direct in [false, true] {
+        group.bench_function(if direct { "direct" } else { "127 squares" }, |b| {
+            // Mix fresh data into the chain to keep every square root observable.
+            b.iter(|| {
+                black_box(&operands).iter().fold(Ghash128::ONE, |acc, &x| {
+                    let value = acc + x;
+                    if direct {
+                        value.try_sqrt().unwrap()
+                    } else {
+                        value.exp_power_of_2(127)
+                    }
+                })
+            });
+        });
+    }
+    group.finish();
+}
+
+/// Compare deferred reduction with a sum of separately reduced products.
+fn bench_dot_width<P: PackedValue + PrimeCharacteristicRing + Copy, const N: usize>(
+    c: &mut Criterion,
+    label: &str,
+) where
+    StandardUniform: Distribution<P>,
+{
+    let mut rng = SmallRng::seed_from_u64(1);
+    // Both algorithms consume identical full-width random inputs.
+    let a: [P; N] = core::array::from_fn(|_| rng.random());
+    let b: [P; N] = core::array::from_fn(|_| rng.random());
+    let mut group = c.benchmark_group(format!("ghash/dot/{label}/{N}"));
+    group.bench_function("separate", |bencher| {
+        bencher.iter(|| {
+            black_box(&a)
+                .iter()
+                .zip(black_box(&b))
+                .map(|(&x, &y)| x * y)
+                .sum::<P>()
+        });
+    });
+    group.bench_function("deferred", |bencher| {
+        bencher.iter(|| P::dot_product(black_box(&a), black_box(&b)));
+    });
+    group.finish();
+}
+
+/// Exercise small and long dot products at scalar and native packed widths.
+fn bench_ghash_dot(c: &mut Criterion) {
+    bench_dot_width::<Ghash128, 4>(c, "scalar");
+    bench_dot_width::<Ghash128, 16>(c, "scalar");
+    bench_dot_width::<Ghash128, 64>(c, "scalar");
+    bench_dot_width::<<Ghash128 as Field>::Packing, 4>(c, "packed");
+    bench_dot_width::<<Ghash128 as Field>::Packing, 16>(c, "packed");
+    bench_dot_width::<<Ghash128 as Field>::Packing, 64>(c, "packed");
+}
+
 criterion_group!(
     benches,
     bench_mul,
     bench_square,
     bench_inverse,
     bench_mul_alpha,
-    bench_flatten_to_base
+    bench_flatten_to_base,
+    bench_representation_mul_latency,
+    bench_representation_mul_throughput,
+    bench_representation_square,
+    bench_representation_inverse,
+    bench_representation_convert,
+    bench_packing,
+    bench_ghash_sqrt,
+    bench_ghash_dot
 );
 criterion_main!(benches);

--- a/binary-field/src/challenger.rs
+++ b/binary-field/src/challenger.rs
@@ -33,9 +33,10 @@ const GRIND_MARGIN_BITS: usize = 8;
 
 /// A challenger for a binary tower field, driven by a challenger over bytes.
 ///
-/// A level of the Wiedemann tower is an exact number of bytes wide and every bit pattern of
-/// that width is a field element, so a transcript over the field is a transcript over its
-/// bytes: no encoding, decoding or rejection sampling is needed in either direction.
+/// A tower level is a whole number of bytes wide, and every bit pattern is an element.
+///
+/// A transcript over the field is therefore a transcript over its bytes.
+/// Nothing is encoded, decoded or rejection-sampled in either direction.
 ///
 /// **Observing**: absorbs the little-endian bytes of the element into the inner challenger.
 ///
@@ -260,7 +261,7 @@ mod tests {
     use p3_symmetric::{Hash, MerkleCap};
 
     use crate::challenger::{BITS_SAMPLE_BYTES, BinaryChallenger};
-    use crate::{BinaryField8, BinaryField32, BinaryField128, Gf2};
+    use crate::{BinaryField8, BinaryField32, BinaryField128, Gf2, Ghash128};
 
     type Inner = HashChallenger<u8, Keccak256Hash, 32>;
 
@@ -280,6 +281,34 @@ mod tests {
             0x21, 0x43, 0x65, 0x87, 0xa9, 0xcb, 0xed, 0x0f, 0xf0, 0xde, 0xbc, 0x9a, 0x78, 0x56,
             0x34, 0x12,
         ])
+    }
+
+    #[test]
+    fn the_polynomial_basis_field_shares_the_transcript_with_the_tower() {
+        // Both representations are 16 bytes wide with every pattern a valid element, so a
+        // transcript over one is byte-for-byte the transcript over the other.
+        //
+        //     observe tower element -> same bytes absorbed -> same bytes drawn
+        //
+        // What differs is only how those bytes are read as a field element.
+        let element = a128();
+
+        let mut tower = mk::<BinaryField128>();
+        tower.observe(element);
+        let drawn: BinaryField128 = tower.sample();
+
+        let mut ghash = mk::<Ghash128>();
+        ghash.observe(Ghash128::from_le_bytes(
+            element.into_bytes().into_iter().collect::<Vec<_>>()[..]
+                .try_into()
+                .unwrap(),
+        ));
+        let mirrored: Ghash128 = ghash.sample();
+
+        assert_eq!(
+            drawn.into_bytes().into_iter().collect::<Vec<_>>(),
+            mirrored.into_bytes().into_iter().collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/binary-field/src/challenger.rs
+++ b/binary-field/src/challenger.rs
@@ -261,6 +261,7 @@ mod tests {
     use p3_symmetric::{Hash, MerkleCap};
 
     use crate::challenger::{BITS_SAMPLE_BYTES, BinaryChallenger};
+    use crate::tower::TowerLevel;
     use crate::{BinaryField8, BinaryField32, BinaryField128, Gf2, Ghash128};
 
     type Inner = HashChallenger<u8, Keccak256Hash, 32>;
@@ -298,10 +299,8 @@ mod tests {
         let drawn: BinaryField128 = tower.sample();
 
         let mut ghash = mk::<Ghash128>();
-        ghash.observe(Ghash128::from_le_bytes(
-            element.into_bytes().into_iter().collect::<Vec<_>>()[..]
-                .try_into()
-                .unwrap(),
+        ghash.observe(Ghash128::from_le_byte_iter(
+            element.into_bytes().into_iter(),
         ));
         let mirrored: Ghash128 = ghash.sample();
 

--- a/binary-field/src/clmul/aarch64.rs
+++ b/binary-field/src/clmul/aarch64.rs
@@ -8,23 +8,25 @@ use core::mem::transmute;
 
 /// The carryless product of two 64-bit polynomials over `GF(2)`.
 ///
-/// `PMULL` accumulates `b << i` for every set bit `i` of `a`, so bit `j` of the result is the
-/// coefficient of `x^j` exactly as the rest of this module assumes.
+/// `PMULL` accumulates `b << i` for every set bit `i` of `a`.
+/// Bit `j` of the result is therefore the coefficient of `x^j`.
 #[inline]
 pub(super) fn clmul_64x64(a: u64, b: u64) -> u128 {
     // SAFETY: this module is compiled only when `target_feature = "aes"` is enabled for the
-    // crate, and `aes` implies `neon`; together those are what `vmull_p64` requires.
+    // crate, and `aes` implies `neon`.
+    // Together those are what the carryless multiply requires.
     unsafe { vmull_p64(a, b) }
 }
 
-/// The carryless product of the low halves of `a` and `b`.
+/// The carryless product of the low halves of two vectors.
 ///
 /// # Safety
+///
 /// The caller must be compiled with the `aes` target feature.
 #[inline]
 unsafe fn clmul_low(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
-    // SAFETY: guaranteed by the caller. The lane extractions feed `PMULL` directly, so the
-    // operands stay in vector registers.
+    // SAFETY: guaranteed by the caller.
+    // The lane extractions feed the multiply directly, so the operands stay in vector registers.
     unsafe {
         transmute(vmull_p64(
             vgetq_lane_u64::<0>(vreinterpretq_u64_u8(a)),
@@ -33,9 +35,10 @@ unsafe fn clmul_low(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     }
 }
 
-/// The carryless product of the high halves of `a` and `b`.
+/// The carryless product of the high halves of two vectors.
 ///
 /// # Safety
+///
 /// The caller must be compiled with the `aes` target feature.
 #[inline]
 unsafe fn clmul_high(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
@@ -48,23 +51,61 @@ unsafe fn clmul_high(a: uint8x16_t, b: uint8x16_t) -> uint8x16_t {
     }
 }
 
-/// Multiplication in `GF(2^128) = GF(2)[x] / (x^128 + x^7 + x^2 + x + 1)`, both operands and the
-/// result in the polynomial basis.
+/// Reduces the 256-bit product `low + high x^128` modulo the field polynomial.
 ///
-/// Schoolbook over the 64-bit halves, then the two-round fold of the modulus, with every 128-bit
-/// intermediate held in a vector register: the halves are selected by `PMULL`'s own lane choice
-/// and by `EXT`, and the fold multiplies by the modulus tail with `PMULL` rather than shifting.
+/// # Algorithm
 ///
-/// The fold is the identity `x^128 ≡ x^7 + x^2 + x + 1`. Writing the high half of the product as
-/// `h0 + h1·x^64` and the tail as `T`, the first round gives `h1·T = e0 + e1·x^64` with `e1` of
-/// degree at most 6, and the second folds `e1·x^128 ≡ e1·T` back down. Collecting the two terms
-/// that are multiplied by `T` leaves `(h0 + e1)·T + e0·x^64`, of degree at most 127, so a single
-/// further product finishes the reduction.
+/// The modulus rewrites `x^128` as its tail.
+/// Writing the top limb as `h0 + h1 x^64`:
+///
+/// ```text
+///     T          = x^7 + x^2 + x + 1
+///     high x^128 = h0 T + h1 T x^64
+///     h1 T       = e0 + e1 x^64                degree at most 63 + 7
+///     e1 x^128   = e1 T                        fold the spill back down
+///     total      = (h0 + e1) T + e0 x^64
+/// ```
+///
+/// One carryless product raises the spill, one more finishes the reduction.
+///
+/// # Safety
+///
+/// The caller must be compiled with the `aes` target feature.
 #[inline]
-pub(super) fn poly_mul_128(a: u128, b: u128) -> u128 {
+unsafe fn fold_high(low: uint8x16_t, high: uint8x16_t) -> uint8x16_t {
+    // SAFETY: guaranteed by the caller.
+    unsafe {
+        let zero = vdupq_n_u8(0);
+
+        // The tail in both lanes, so the multiply can take it against either half.
+        let tail = vreinterpretq_u8_u64(vdupq_n_u64(super::basis::TAIL_128 as u64));
+
+        // The top half of the limb, scaled by the tail.
+        let folded = clmul_high(high, tail);
+
+        // `EXT` against zero is a 128-bit shift by 64 in either direction.
+        let spill = vextq_u8::<8>(folded, zero);
+        let carried = vextq_u8::<8>(zero, folded);
+
+        let reduced = veorq_u8(low, clmul_low(veorq_u8(high, spill), tail));
+        veorq_u8(reduced, carried)
+    }
+}
+
+/// Multiplication in `GF(2^128) = GF(2)[x] / (x^128 + x^7 + x^2 + x + 1)`.
+///
+/// Both operands and the result are in the polynomial basis.
+///
+/// # Algorithm
+///
+/// Schoolbook over the 64-bit halves, then the fold of the modulus.
+/// Halves are selected by the multiply's own lane choice and by `EXT`.
+/// Every 128-bit intermediate therefore stays in a vector register.
+#[inline]
+pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
     const {
-        // `target_arch = "aarch64"` covers the big-endian AArch64 targets too, where the halves
-        // of a `u128` and the lanes of a vector run in opposite orders.
+        // `target_arch = "aarch64"` covers the big-endian AArch64 targets too.
+        // There the halves of a `u128` and the lanes of a vector run in opposite orders.
         assert!(
             cfg!(target_endian = "little"),
             "the halves of a `u128` are its vector lanes only on little-endian targets"
@@ -72,29 +113,93 @@ pub(super) fn poly_mul_128(a: u128, b: u128) -> u128 {
     }
 
     // SAFETY: this module is compiled only when `target_feature = "aes"` is enabled for the
-    // crate, and `aes` implies `neon`; together those are what every intrinsic below requires.
+    // crate, and `aes` implies `neon`.
+    // Together those are what every intrinsic below requires.
     unsafe {
         let a = transmute::<u128, uint8x16_t>(a);
         let b = transmute::<u128, uint8x16_t>(b);
         let zero = vdupq_n_u8(0);
-        // The tail `x^7 + x^2 + x + 1` of the modulus, in both lanes so `PMULL` can take it
-        // against either half.
-        let tail = vreinterpretq_u8_u64(vdupq_n_u64(super::basis::TAIL_128 as u64));
 
-        // `EXT #8` swaps the halves, so the two cross products come from the same lane choices
-        // as the two diagonal ones.
+        // Swapping the halves of one operand puts the two cross products on the same lane
+        // choices as the two diagonal ones.
         let swapped = vextq_u8::<8>(b, b);
         let middle = veorq_u8(clmul_low(a, swapped), clmul_high(a, swapped));
 
-        // `EXT` against zero is a 128-bit shift by 64 in either direction.
+        // Split the middle coefficient across the two limbs it straddles.
         let low = veorq_u8(clmul_low(a, b), vextq_u8::<8>(zero, middle));
         let high = veorq_u8(clmul_high(a, b), vextq_u8::<8>(middle, zero));
 
-        let folded = clmul_high(high, tail);
-        let spill = vextq_u8::<8>(folded, zero);
-        let carried = vextq_u8::<8>(zero, folded);
+        transmute::<uint8x16_t, u128>(fold_high(low, high))
+    }
+}
 
-        let reduced = veorq_u8(low, clmul_low(veorq_u8(high, spill), tail));
-        transmute::<uint8x16_t, u128>(veorq_u8(reduced, carried))
+/// Squaring in `GF(2^128)`, taking and returning the polynomial representation.
+///
+/// The cross term of `(p0 + p1 x^64)^2` is `2 p0 p1`, which vanishes in characteristic 2.
+/// The 256-bit square is therefore `p0^2 + p1^2 x^128`, with nothing between the halves.
+#[inline]
+pub(crate) fn poly_square_128(a: u128) -> u128 {
+    const {
+        assert!(
+            cfg!(target_endian = "little"),
+            "the halves of a `u128` are its vector lanes only on little-endian targets"
+        );
+    }
+
+    // SAFETY: as in the multiplication above.
+    unsafe {
+        let a = transmute::<u128, uint8x16_t>(a);
+        transmute::<uint8x16_t, u128>(fold_high(clmul_low(a, a), clmul_high(a, a)))
+    }
+}
+
+/// Sum unreduced products before folding the GHASH modulus once.
+#[inline]
+pub(crate) fn poly_dot_128(pairs: impl Iterator<Item = (u128, u128)>) -> u128 {
+    const {
+        assert!(cfg!(target_endian = "little"));
+    }
+    // SAFETY: this module requires AES and NEON.
+    // Every bit pattern is valid in both the integer and vector representations.
+    unsafe {
+        let zero = vdupq_n_u8(0);
+        let (mut low, mut high, mut middle) = (zero, zero, zero);
+        for (a, b) in pairs {
+            let a = transmute::<u128, uint8x16_t>(a);
+            let b = transmute::<u128, uint8x16_t>(b);
+            // Swapping halves aligns the cross terms with the diagonal multiply instructions.
+            let swapped = vextq_u8::<8>(b, b);
+            low = veorq_u8(low, clmul_low(a, b));
+            high = veorq_u8(high, clmul_high(a, b));
+            middle = veorq_u8(
+                middle,
+                veorq_u8(clmul_low(a, swapped), clmul_high(a, swapped)),
+            );
+        }
+        // Place the cross terms across the two halves of the 256-bit sum.
+        low = veorq_u8(low, vextq_u8::<8>(zero, middle));
+        high = veorq_u8(high, vextq_u8::<8>(middle, zero));
+        transmute::<uint8x16_t, u128>(fold_high(low, high))
+    }
+}
+
+/// Multiply by a polynomial of degree below 64 using three carryless products.
+#[inline]
+pub(crate) fn poly_mul_128_by_64(a: u128, b: u64) -> u128 {
+    const {
+        assert!(cfg!(target_endian = "little"));
+    }
+    // SAFETY: this module requires AES and NEON.
+    unsafe {
+        let a = transmute::<u128, uint8x16_t>(a);
+        let b = vreinterpretq_u8_u64(vdupq_n_u64(b));
+        let zero = vdupq_n_u8(0);
+        // Invariant: a*b = a0*b + x^64*(a1*b).
+        let low = clmul_low(a, b);
+        let middle = clmul_high(a, b);
+        let tail = vreinterpretq_u8_u64(vdupq_n_u64(super::basis::TAIL_128 as u64));
+        // Raise the low half and replace the overflowing high half using x^128 = 0x87.
+        let folded = veorq_u8(vextq_u8::<8>(zero, middle), clmul_high(middle, tail));
+        transmute::<uint8x16_t, u128>(veorq_u8(low, folded))
     }
 }

--- a/binary-field/src/clmul/basis.rs
+++ b/binary-field/src/clmul/basis.rs
@@ -23,7 +23,7 @@
 pub(super) const TAIL_64: u128 = 0b1_1011;
 
 /// `GF(2^128)` as `GF(2)[x] / (x^128 + x^7 + x^2 + x + 1)`.
-pub(super) const TAIL_128: u128 = 0b1000_0111;
+pub(crate) const TAIL_128: u128 = 0b1000_0111;
 
 /// The images of the tower generators `X_0, …, X_5` in `GF(2)[x]/(x^64 + x^4 + x^3 + x + 1)`.
 const XI_64: [u128; 6] = [
@@ -237,6 +237,25 @@ static SQUARE_64: [[u64; 256]; 8] =
     narrow(&byte_tables(&square_columns(64, TAIL_64, &COLUMNS_64), 64));
 static TOWER_TO_POLY_128: [[u128; 256]; 16] = byte_tables(&COLUMNS_128, 128);
 static POLY_TO_TOWER_128: [[u128; 256]; 16] = byte_tables(&invert(&COLUMNS_128, 128), 128);
+
+/// The polynomial-basis coordinates of a tower-basis bit pattern, at compile time.
+///
+/// The change of basis is `GF(2)`-linear.
+/// An element's image is therefore the sum of the columns its set bits select.
+///
+/// The table-driven route sums a byte at a time, which constant evaluation cannot index into.
+/// This walks the bits instead.
+pub(crate) const fn tower_image_128(v: u128) -> u128 {
+    let mut acc = 0;
+    let mut i = 0;
+    while i < 128 {
+        if (v >> i) & 1 == 1 {
+            acc ^= COLUMNS_128[i];
+        }
+        i += 1;
+    }
+    acc
+}
 
 /// Applies the eight-table form of a `64 × 64` matrix over `GF(2)`.
 #[inline]

--- a/binary-field/src/clmul/inverse.rs
+++ b/binary-field/src/clmul/inverse.rs
@@ -1,0 +1,136 @@
+//! Itoh–Tsujii inversion with precomputed Frobenius maps.
+//!
+//! The inverse of a nonzero `x` is `x^(2^128 - 2)`.
+//! An addition chain reaches that exponent in ten products, once squaring is cheap.
+//!
+//! Squaring `2^k` times is `GF(2)`-linear, so each such step is one fixed matrix.
+//! The five the chain needs are tabulated a byte at a time, at compile time.
+
+use super::{poly_mul_128, poly_square_128, portable};
+
+/// One byte-indexed linear map occupies 64 KiB.
+type PowerMap = [[u128; 256]; 16];
+
+/// Build a linear map for a fixed number of squarings at compile time.
+const fn power_map(squarings: usize) -> PowerMap {
+    let mut table = [[0; 256]; 16];
+    let mut byte = 0;
+    while byte < 16 {
+        // A linear map is determined by the images of the eight bits of this byte.
+        let mut bit = 0;
+        while bit < 8 {
+            let mut image = 1u128 << (8 * byte + bit);
+            let mut step = 0;
+            while step < squarings {
+                image = portable::poly_square_128(image);
+                step += 1;
+            }
+            table[byte][1 << bit] = image;
+            bit += 1;
+        }
+
+        // Every remaining byte is the XOR of one bit and a smaller byte.
+        let mut value = 1usize;
+        while value < 256 {
+            let low = 1 << value.trailing_zeros();
+            table[byte][value] = table[byte][low] ^ table[byte][value ^ low];
+            value += 1;
+        }
+        byte += 1;
+    }
+    table
+}
+
+/// Three squarings advance the exponent index from 3 to 6.
+static POW_3: PowerMap = power_map(3);
+/// Seven squarings serve both the 7-to-14 and 56-to-63 steps.
+static POW_7: PowerMap = power_map(7);
+/// Fourteen squarings advance the exponent index from 14 to 28.
+static POW_14: PowerMap = power_map(14);
+/// Twenty-eight squarings advance the exponent index from 28 to 56.
+static POW_28: PowerMap = power_map(28);
+/// Sixty-three squarings advance the exponent index from 63 to 126.
+static POW_63: PowerMap = power_map(63);
+
+/// Apply a Frobenius map through operand-indexed lookups.
+#[inline]
+fn apply(table: &PowerMap, value: u128) -> u128 {
+    // Each byte contributes independently because squaring is GF(2)-linear.
+    table
+        .iter()
+        .zip(value.to_le_bytes())
+        .fold(0, |acc, (row, byte)| acc ^ row[usize::from(byte)])
+}
+
+/// Invert a nonzero polynomial-basis element, mapping zero to zero.
+///
+/// Operand-indexed tables make this unsuitable for secret inputs requiring constant-time access.
+#[inline]
+pub(crate) fn poly_inverse_128(x: u128) -> u128 {
+    // Invariant:
+    //     beta_k = x^(2^k - 1)
+    //     beta_(a+b) = beta_a^(2^b) * beta_b
+    let b2 = poly_mul_128(poly_square_128(x), x);
+    let b3 = poly_mul_128(poly_square_128(b2), x);
+    let b6 = poly_mul_128(apply(&POW_3, b3), b3);
+    let b7 = poly_mul_128(poly_square_128(b6), x);
+
+    // Doubling the exponent index reuses the same intermediate on both sides.
+    let b14 = poly_mul_128(apply(&POW_7, b7), b7);
+    let b28 = poly_mul_128(apply(&POW_14, b14), b14);
+    let b56 = poly_mul_128(apply(&POW_28, b28), b28);
+
+    // Finish 56 + 7 = 63, then 2 * 63 + 1 = 127.
+    let b63 = poly_mul_128(apply(&POW_7, b56), b7);
+    let b126 = poly_mul_128(apply(&POW_63, b63), b63);
+    let b127 = poly_mul_128(poly_square_128(b126), x);
+
+    // Squaring gives x^(2^128 - 2), the multiplicative inverse for nonzero x.
+    poly_square_128(b127)
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::clmul::basis::{TAIL_128, poly_mul};
+
+    #[test]
+    fn power_maps_match_the_modulus_on_every_basis_vector() {
+        // Linearity reduces equality of the maps to all 128 input basis vectors.
+        for (count, table) in [
+            (3, &POW_3),
+            (7, &POW_7),
+            (14, &POW_14),
+            (28, &POW_28),
+            (63, &POW_63),
+        ] {
+            for bit in 0..128 {
+                let input = 1u128 << bit;
+                let mut expected = input;
+                // Use bit-serial modular multiplication as an independent oracle.
+                for _ in 0..count {
+                    expected = poly_mul(expected, expected, 128, TAIL_128);
+                }
+                assert_eq!(apply(table, input), expected);
+            }
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn inversion_matches_the_multiplicative_identity(x: u128) {
+            // The bit-serial product characterizes the inverse independently of every backend.
+            let inverse = poly_inverse_128(x);
+            prop_assert_eq!(poly_mul(x, inverse, 128, TAIL_128), u128::from(x != 0));
+        }
+    }
+
+    #[test]
+    fn inversion_handles_zero_and_one() {
+        // Every step maps zero to zero; the public field API rejects it before inversion.
+        assert_eq!(poly_inverse_128(0), 0);
+        assert_eq!(poly_inverse_128(1), 1);
+    }
+}

--- a/binary-field/src/clmul/mod.rs
+++ b/binary-field/src/clmul/mod.rs
@@ -1,18 +1,55 @@
-//! Carryless multiplication for the 64- and 128-bit levels of the tower.
+//! Carryless multiplication, and the polynomial-basis arithmetic built on it.
 //!
-//! Hardware carryless multiply computes products in `GF(2)[x]`, which is not the tower's own
-//! representation. [`basis`] supplies the change of basis between the two, leaving three steps:
-//! map both operands into the polynomial basis, multiply and reduce there, and map back.
+//! The instruction works in `GF(2)[x]`, which is not the tower's representation.
+//! A tower product therefore costs three steps that a polynomial-basis product does not:
 //!
-//! Architecture-specific code is confined to the backends: the `64 × 64 → 128` carryless
-//! product, and on some targets a whole `GF(2^128)` product that never leaves the vector unit.
-//! Composing the wider product from the half products and folding the modulus are plain shifts
-//! and `XOR`s, so the definition of every routine here is portable code that the tests exercise
-//! on every target, and each backend is checked against it.
+//! ```text
+//!     map both operands into the polynomial basis
+//!     multiply and reduce there
+//!     map the result back
+//! ```
+//!
+//! Each backend supplies the same routines, and each has a portable definition to test against.
 
 mod basis;
+mod sqrt;
 
-pub(crate) use basis::{poly_to_tower_128, tower_to_poly_128};
+pub(crate) use sqrt::poly_sqrt_128;
+
+// The addition chain pays for its 320 KiB of Frobenius maps only where a product is a single
+// instruction.
+// Without one the tower norm wins, so the maps are not compiled at all.
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+    all(target_arch = "aarch64", target_feature = "aes"),
+))]
+mod inverse;
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+    all(target_arch = "aarch64", target_feature = "aes"),
+))]
+pub(crate) use inverse::poly_inverse_128;
+
+// Compiled on every target, even where a backend supersedes it.
+// Its tests then run everywhere.
+// No instruction guarantees the carry argument the software multiply rests on.
+#[cfg_attr(
+    any(
+        all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+        all(target_arch = "aarch64", target_feature = "aes"),
+    ),
+    allow(dead_code)
+)]
+mod portable;
+
+// The modulus tail, which only a packed backend folds with directly.
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "vpclmulqdq",
+    any(target_feature = "avx2", target_feature = "avx512f")
+))]
+pub(crate) use basis::TAIL_128;
+pub(crate) use basis::{poly_to_tower_128, tower_image_128, tower_to_poly_128};
 
 use crate::BinaryField64;
 use crate::tower::TowerLevel;
@@ -24,13 +61,9 @@ mod x86_64;
 
 /// Whether the target has a carryless-multiply instruction.
 ///
-/// The bit-serial fallback below keeps every routine in this module correct everywhere, but it
-/// is far slower than the recursive tower arithmetic, so `Mul` and `square` only route through
-/// this module when the instruction is really there.
-///
-/// This is a compile-time decision, and neither feature is in the baseline of most targets:
-/// `aarch64-apple-darwin` has `aes`, but generic AArch64 Linux and every `x86_64` target need
-/// `-C target-feature=+aes` / `+pclmulqdq` (or `-C target-cpu=native`) for the fast path.
+/// - The tower routes here only when it does, since its own recursion beats the software path.
+/// - The polynomial-basis field has no such alternative and always routes here.
+/// - Most targets need `+pclmulqdq` / `+aes` asked for, or `-C target-cpu=native`.
 pub(crate) const HAS_HARDWARE_CLMUL: bool = cfg!(any(
     all(target_arch = "x86_64", target_feature = "pclmulqdq"),
     all(target_arch = "aarch64", target_feature = "aes"),
@@ -38,17 +71,11 @@ pub(crate) const HAS_HARDWARE_CLMUL: bool = cfg!(any(
 
 /// The carryless product of two 64-bit polynomials over `GF(2)`, one bit of `b` at a time.
 ///
-/// The portable definition of the operation the hardware instruction performs. It is compiled
-/// on every target: where there is no instruction it is the fallback, and where there is one it
-/// is what the tests check that instruction against.
-#[cfg_attr(
-    any(
-        all(target_arch = "x86_64", target_feature = "pclmulqdq"),
-        all(target_arch = "aarch64", target_feature = "aes"),
-    ),
-    // Superseded by a backend, but still the reference the tests compare against.
-    allow(dead_code)
-)]
+/// The plainest possible statement of what every backend computes.
+///
+/// Far too slow to dispatch to.
+/// It exists as the reference the tests check each backend against.
+#[cfg(test)]
 #[inline]
 const fn scalar_clmul_64x64(a: u64, b: u64) -> u128 {
     let a = a as u128;
@@ -65,30 +92,22 @@ const fn scalar_clmul_64x64(a: u64, b: u64) -> u128 {
 
 #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
 use aarch64::clmul_64x64;
-#[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
-use x86_64::clmul_64x64;
-
 #[cfg(not(any(
     all(target_arch = "x86_64", target_feature = "pclmulqdq"),
     all(target_arch = "aarch64", target_feature = "aes"),
 )))]
-// The backends this stands in for wrap an intrinsic and so cannot be `const`; keeping the
-// signatures uniform stops constness from leaking into everything built on top.
-#[allow(clippy::missing_const_for_fn)]
-#[inline]
-fn clmul_64x64(a: u64, b: u64) -> u128 {
-    scalar_clmul_64x64(a, b)
-}
+use portable::clmul_64x64;
+#[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
+use x86_64::clmul_64x64;
 
 /// The `256`-bit carryless product of two 128-bit polynomials, as `(low, high)`.
 ///
-/// Schoolbook over the 64-bit halves: with `a = a0 + a1·x^64` and `b = b0 + b1·x^64`, the four
-/// half products give the low, middle and high coefficients directly.
-///
-/// Karatsuba writes the middle coefficient as `(a0 + a1)·(b0 + b1) + a0·b0 + a1·b1` and so
-/// needs only three products, but it pays four extra `XOR`s for them and puts two of those on
-/// the critical path ahead of the product they feed. A hardware carryless multiply is cheap
-/// enough that the trade goes the other way.
+/// Schoolbook over the 64-bit halves: four independent products, no dependency between them.
+/// Karatsuba saves one product, at the price of two exclusive ors ahead of it.
+/// A hardware multiply is too cheap for that trade to pay.
+// The software backend is `const` and the hardware ones wrap intrinsics, so they cannot be.
+// Keeping this uniform stops constness from leaking into callers on some targets only.
+#[allow(clippy::missing_const_for_fn)]
 #[inline]
 fn clmul_128x128(a: u128, b: u128) -> (u128, u128) {
     let (a0, a1) = (a as u64, (a >> 64) as u64);
@@ -101,9 +120,9 @@ fn clmul_128x128(a: u128, b: u128) -> (u128, u128) {
 
 /// Reduces a 128-bit carryless product modulo `x^64 + x^4 + x^3 + x + 1`.
 ///
-/// `x^64 ≡ x^4 + x^3 + x + 1`, so the high half is folded down by multiplying it by that tail.
-/// The tail has degree 4, so the fold spills 4 bits back above `x^64`; folding those in turn
-/// reaches degree at most `3 + 4`, well inside the low half, and two rounds are enough.
+/// The modulus rewrites `x^64` as the tail `x^4 + x^3 + x + 1`.
+/// The high half therefore folds down by that tail.
+/// Degree 4 spills 4 bits back over the top; a second fold lands at degree `3 + 4`.
 #[inline]
 const fn reduce_64(product: u128) -> u64 {
     let low = product as u64;
@@ -117,8 +136,8 @@ const fn reduce_64(product: u128) -> u64 {
 
 /// Reduces a 256-bit carryless product modulo `x^128 + x^7 + x^2 + x + 1`.
 ///
-/// The same two-round fold as [`reduce_64`], with a tail of degree 7: the first round spills
-/// 7 bits above `x^128` and the second lands at degree at most `6 + 7`.
+/// The same two-round fold as at 64 bits, with a tail of degree 7.
+/// The first round spills 7 bits over the top; the second lands at degree `6 + 7`.
 #[inline]
 const fn reduce_128(low: u128, high: u128) -> u128 {
     let folded = (high << 7) ^ (high << 2) ^ (high << 1) ^ high;
@@ -134,40 +153,33 @@ pub(crate) fn mul_64(a: u64, b: u64) -> u64 {
     basis::poly_to_tower_64(reduce_64(product))
 }
 
-/// Multiplication in `GF(2^128)`, taking and returning the polynomial representation.
+/// Multiplication in `GF(2^128)`, in the polynomial representation.
 ///
-/// The 256-bit product is assembled and folded in general-purpose registers, so the whole
-/// operation is a short dependency chain and nothing waits on a wider one.
+/// Assembled and folded in general-purpose registers, so the dependency chain stays short.
 #[inline]
 fn composed_poly_mul_128(a: u128, b: u128) -> u128 {
     let (low, high) = clmul_128x128(a, b);
     reduce_128(low, high)
 }
 
-/// Multiplication in `GF(2^128)`, taking and returning the polynomial representation.
-///
-/// Where the target has one, this is a kernel that keeps both operands in vector registers from
-/// end to end. It issues more instructions than [`composed_poly_mul_128`] but none that leave
-/// the vector unit, which is the better trade only for a caller with several products in
-/// flight at once; [`composed_poly_mul_128`] is the one to reach for on a dependency chain.
+// The polynomial-basis arithmetic, chosen at compile time.
+//
+// A backend keeps every intermediate in a vector register and folds the modulus with a
+// carryless product, where the integer file would need several instructions per shift.
 #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
-#[inline]
-pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
-    aarch64::poly_mul_128(a, b)
-}
-
-/// Multiplication in `GF(2^128)`, taking and returning the polynomial representation.
-#[cfg(not(all(target_arch = "aarch64", target_feature = "aes")))]
-#[inline]
-pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
-    composed_poly_mul_128(a, b)
-}
+pub(crate) use aarch64::{poly_dot_128, poly_mul_128, poly_mul_128_by_64, poly_square_128};
+#[cfg(not(any(
+    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+    all(target_arch = "aarch64", target_feature = "aes"),
+)))]
+pub(crate) use portable::{poly_dot_128, poly_mul_128, poly_mul_128_by_64, poly_square_128};
+#[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
+pub(crate) use x86_64::{poly_dot_128, poly_mul_128, poly_mul_128_by_64, poly_square_128};
 
 /// Multiplication in `GF(2^128)`, taking and returning the tower representation.
 ///
-/// The three changes of basis around the product are sixteen dependent lookups each, so this
-/// takes the composition rather than the vector kernel: there is no throughput to win behind a
-/// chain of loads that long.
+/// The three changes of basis are sixteen dependent lookups each.
+/// Behind a chain of loads that long there is no throughput for a vector kernel to win.
 #[inline]
 pub(crate) fn mul_128(a: u128, b: u128) -> u128 {
     let product = composed_poly_mul_128(basis::tower_to_poly_128(a), basis::tower_to_poly_128(b));
@@ -176,36 +188,23 @@ pub(crate) fn mul_128(a: u128, b: u128) -> u128 {
 
 /// Squaring in `GF(2^64)`, taking and returning the tower representation.
 ///
-/// Squaring is `GF(2)`-linear in characteristic 2, so in the tower basis it is a fixed matrix,
-/// tabulated a byte of the input at a time exactly as the changes of basis are. That is eight
-/// lookups, against the two conversions and a carryless product a route through the polynomial
-/// basis would cost.
+/// Squaring is `GF(2)`-linear, so in the tower basis it is a fixed matrix.
+/// Tabulated a byte at a time: eight lookups, against two conversions and a product.
 #[inline]
 pub(crate) fn square_64(a: u64) -> u64 {
     basis::tower_square_64(a)
 }
 
-/// Squaring in `GF(2^128)`, taking and returning the polynomial representation.
-///
-/// With `p = p0 + p1·x^64`, the middle coefficient of `p²` is `2·p0·p1`, which vanishes in
-/// characteristic 2. So `p² = p0² + p1²·x^128` exactly: two carryless products with nothing to
-/// fold between them, where [`clmul_128x128`] needs four and a middle term.
-#[inline]
-pub(crate) fn poly_square_128(a: u128) -> u128 {
-    let (p0, p1) = (a as u64, (a >> 64) as u64);
-    reduce_128(clmul_64x64(p0, p0), clmul_64x64(p1, p1))
-}
-
 /// Squaring in `GF(2^128)`, taking and returning the tower representation.
 ///
-/// The tower basis of this level is the tower basis of the level below, twice over, so the two
-/// halves square through [`square_64`]: with `a = a0 + a1·X` and `X² = αX + 1`, the cross term
-/// vanishes in characteristic 2 and `a² = (a0² + a1²) + α·a1²·X`.
-///
-/// Tabulating this level directly would take a table four times the size for the same sixteen
-/// lookups, so the level below's is used twice instead.
+/// This level's basis is the level below's twice over.
+/// Both halves therefore square through the narrower table.
+/// Tabulating this level directly would cost four times the space for the same lookups.
 #[inline]
 pub(crate) fn square_128(a: u128) -> u128 {
+    // Invariant: with a = a0 + a1*X and X^2 = alpha*X + 1, the cross term doubles to zero.
+    //
+    //     a^2 = (a0^2 + a1^2) + alpha*a1^2*X
     let low = square_64(a as u64);
     let high = square_64((a >> 64) as u64);
     let scaled = BinaryField64::from_repr(high).mul_alpha().to_repr();
@@ -314,28 +313,29 @@ mod tests {
         }
     }
 
-    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     proptest! {
-        // The kernel below is the one routine here with no portable definition standing behind
-        // it, so it is checked over many more pairs than the rest of the module.
+        // The selected backend is the one routine here written per target rather than once, so
+        // it is checked over many more pairs than the rest of the module.
         #![proptest_config(ProptestConfig::with_cases(20_000))]
 
-        /// The vector-native kernel must agree bit for bit with the composition it stands in for.
         #[test]
-        fn the_vector_kernel_matches_the_composition(a: u128, b: u128) {
-            prop_assert_eq!(
-                super::aarch64::poly_mul_128(a, b),
-                super::composed_poly_mul_128(a, b),
-            );
+        fn the_selected_backend_matches_multiplication_from_the_modulus(a: u128, b: u128) {
+            // Bit-serial reduction straight from the modulus, independent of every backend.
+            prop_assert_eq!(super::poly_mul_128(a, b), poly_mul(a, b, 128, TAIL_128));
+            prop_assert_eq!(super::poly_square_128(a), poly_mul(a, a, 128, TAIL_128));
+            prop_assert_eq!(super::poly_mul_128_by_64(a, b as u64), poly_mul(a, b as u64 as u128, 128, TAIL_128));
         }
     }
 
-    /// The edge cases a random search is unlikely to reach: the identities, and the operands
-    /// whose half products and reduction spill are maximal.
-    #[cfg(all(target_arch = "aarch64", target_feature = "aes"))]
     #[test]
-    fn the_vector_kernel_matches_the_composition_on_extremes() {
-        let corners = [
+    fn the_selected_backend_is_exact_on_the_extremes() {
+        // Invariant: the fold of the modulus is exact however far the product overflows.
+        //
+        // The corners a random search is unlikely to reach:
+        //   - the additive and multiplicative identities,
+        //   - the operands whose half products are maximal,
+        //   - the operands whose reduction spill is maximal.
+        const CORNERS: [u128; 8] = [
             0,
             1,
             u128::MAX,
@@ -345,19 +345,25 @@ mod tests {
             u128::MAX << 64,
             0x8000_0000_0000_0001_8000_0000_0000_0001,
         ];
-        for a in corners {
-            for b in corners {
+
+        for a in CORNERS {
+            assert_eq!(
+                super::poly_square_128(a),
+                poly_mul(a, a, 128, TAIL_128),
+                "{a:#x} squared"
+            );
+            for b in CORNERS {
                 assert_eq!(
-                    super::aarch64::poly_mul_128(a, b),
-                    super::composed_poly_mul_128(a, b),
+                    super::poly_mul_128(a, b),
+                    poly_mul(a, b, 128, TAIL_128),
                     "{a:#x} * {b:#x}"
                 );
             }
         }
     }
 
-    /// A worked example small enough to check by hand: in the tower `X_0² = X_0 + 1`, so bit
-    /// pattern `0b10` squares to `0b11` at both levels, and `ONE` is a two-sided identity.
+    /// A worked example small enough to check by hand.
+    /// In the tower `X_0^2 = X_0 + 1`, so `0b10` squares to `0b11` at both levels.
     #[test]
     fn hand_checkable_products() {
         assert_eq!(super::mul_128(0b10, 0b10), 0b11);

--- a/binary-field/src/clmul/mod.rs
+++ b/binary-field/src/clmul/mod.rs
@@ -16,18 +16,15 @@ mod sqrt;
 
 pub(crate) use sqrt::poly_sqrt_128;
 
-// The addition chain pays for its 320 KiB of Frobenius maps only where a product is a single
-// instruction.
-// Without one the tower norm wins, so the maps are not compiled at all.
-#[cfg(any(
-    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
-    all(target_arch = "aarch64", target_feature = "aes"),
-))]
+// The addition chain pays for its 320 KiB of Frobenius maps only where a product is fast
+// enough for ten of them to beat a change of basis.
+//
+// That is the carryless-multiply x86 path.
+// AArch64 measures the two routes level, and the software path loses outright, so neither
+// compiles the maps.
+#[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
 mod inverse;
-#[cfg(any(
-    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
-    all(target_arch = "aarch64", target_feature = "aes"),
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
 pub(crate) use inverse::poly_inverse_128;
 
 // Compiled on every target, even where a backend supersedes it.
@@ -61,7 +58,7 @@ mod x86_64;
 
 /// Whether the target has a carryless-multiply instruction.
 ///
-/// - The tower routes here only when it does, since its own recursion beats the software path.
+/// - The tower routes here only when it does, and takes its own recursion otherwise.
 /// - The polynomial-basis field has no such alternative and always routes here.
 /// - Most targets need `+pclmulqdq` / `+aes` asked for, or `-C target-cpu=native`.
 pub(crate) const HAS_HARDWARE_CLMUL: bool = cfg!(any(

--- a/binary-field/src/clmul/portable.rs
+++ b/binary-field/src/clmul/portable.rs
@@ -29,10 +29,10 @@ const NIBBLE_3: u64 = NIBBLE_0 << 3;
 /// # Why the carries never escape
 ///
 /// Bit `p` counts the pairs `(i, j)` with `i + j = p` drawn from the two masks.
-/// A 64-bit word holds at most 16 positions in one residue class.
+/// Writing `p = 4k + r + s`, that count is `k + 1`, and `k` is at most 15.
 ///
-/// At most 15 pairs reach any `p <= 56`, which fits the three free bits above `p`.
-/// Only `p = 60` reaches 16, and its carry leaves the word entirely.
+/// So every `p <= 59` sees at most 15 pairs, which fit the three free bits above `p`.
+/// Positions 60 to 63 reach 16, and a fifth bit there lands outside the word.
 #[inline]
 pub(super) const fn bmul64(x: u64, y: u64) -> u64 {
     // Bits of the first operand, one residue class per word.

--- a/binary-field/src/clmul/portable.rs
+++ b/binary-field/src/clmul/portable.rs
@@ -1,0 +1,272 @@
+//! The software backend, for targets with no carryless-multiply instruction.
+//!
+//! An integer multiply is a carryless multiply plus carries.
+//!
+//! Masking an operand down to every fourth bit spaces its partial products four apart.
+//! The three positions in between are then free for carries to land in.
+//! Masking the result again discards them.
+//!
+//! Four masked operands per side cover every bit of the input.
+//! This is the routine BearSSL's constant-time GHASH is built on.
+
+/// Every fourth bit, starting at bit 0.
+const NIBBLE_0: u64 = 0x1111_1111_1111_1111;
+/// Every fourth bit, starting at bit 1.
+const NIBBLE_1: u64 = NIBBLE_0 << 1;
+/// Every fourth bit, starting at bit 2.
+const NIBBLE_2: u64 = NIBBLE_0 << 2;
+/// Every fourth bit, starting at bit 3.
+const NIBBLE_3: u64 = NIBBLE_0 << 3;
+
+/// The low 64 bits of the carryless product of two 64-bit polynomials over `GF(2)`.
+///
+/// # Algorithm
+///
+/// Split each operand by the residue of its bit positions modulo 4.
+/// A product of residue `r` by residue `s` lands entirely in residue `r + s`.
+/// Sixteen integer products cover the four residues of the output.
+///
+/// # Why the carries never escape
+///
+/// Bit `p` counts the pairs `(i, j)` with `i + j = p` drawn from the two masks.
+/// A 64-bit word holds at most 16 positions in one residue class.
+///
+/// At most 15 pairs reach any `p <= 56`, which fits the three free bits above `p`.
+/// Only `p = 60` reaches 16, and its carry leaves the word entirely.
+#[inline]
+pub(super) const fn bmul64(x: u64, y: u64) -> u64 {
+    // Bits of the first operand, one residue class per word.
+    let (x0, x1) = (x & NIBBLE_0, x & NIBBLE_1);
+    let (x2, x3) = (x & NIBBLE_2, x & NIBBLE_3);
+
+    // Bits of the second operand, likewise.
+    let (y0, y1) = (y & NIBBLE_0, y & NIBBLE_1);
+    let (y2, y3) = (y & NIBBLE_2, y & NIBBLE_3);
+
+    // Each line gathers the four products belonging to one output residue.
+    //
+    //     residue 0 <- (0,0) (1,3) (2,2) (3,1)
+    //     residue 1 <- (0,1) (1,0) (2,3) (3,2)
+    //     residue 2 <- (0,2) (1,1) (2,0) (3,3)
+    //     residue 3 <- (0,3) (1,2) (2,1) (3,0)
+    let z0 = x0.wrapping_mul(y0) ^ x1.wrapping_mul(y3) ^ x2.wrapping_mul(y2) ^ x3.wrapping_mul(y1);
+    let z1 = x0.wrapping_mul(y1) ^ x1.wrapping_mul(y0) ^ x2.wrapping_mul(y3) ^ x3.wrapping_mul(y2);
+    let z2 = x0.wrapping_mul(y2) ^ x1.wrapping_mul(y1) ^ x2.wrapping_mul(y0) ^ x3.wrapping_mul(y3);
+    let z3 = x0.wrapping_mul(y3) ^ x1.wrapping_mul(y2) ^ x2.wrapping_mul(y1) ^ x3.wrapping_mul(y0);
+
+    // Keep only the positions each line is exact at, dropping the carries in between.
+    (z0 & NIBBLE_0) | (z1 & NIBBLE_1) | (z2 & NIBBLE_2) | (z3 & NIBBLE_3)
+}
+
+/// The carryless product of two 64-bit polynomials over `GF(2)`, as its two 64-bit halves.
+///
+/// # Algorithm
+///
+/// Reversing both operands reverses their product.
+/// Running the masked multiply on the reversed operands therefore returns the top half.
+///
+/// ```text
+///     a * b            = p_0 + p_1 x + ... + p_126 x^126
+///     rev(a) * rev(b)  = p_126 + p_125 x + ... + p_0 x^126
+///
+///     its low 64 bits  = p_126 down to p_63
+///     reversed again   = p_63, p_64, ..., p_126
+///     shifted by one   = p_64, ..., p_126          the high half
+/// ```
+#[inline]
+const fn clmul_64x64_halves(a: u64, b: u64) -> (u64, u64) {
+    // Coefficients 0 through 63, straight from the masked multiply.
+    let low = bmul64(a, b);
+
+    // Coefficients 64 through 126, from the reversed operands.
+    // The shift drops coefficient 63, which the low half already carries.
+    let high = bmul64(a.reverse_bits(), b.reverse_bits()).reverse_bits() >> 1;
+
+    (low, high)
+}
+
+/// The carryless product of two 64-bit polynomials over `GF(2)`.
+#[inline]
+pub(super) const fn clmul_64x64(a: u64, b: u64) -> u128 {
+    let (low, high) = clmul_64x64_halves(a, b);
+    (low as u128) | ((high as u128) << 64)
+}
+
+/// Multiplication in `GF(2^128) = GF(2)[x] / (x^128 + x^7 + x^2 + x + 1)`.
+///
+/// Both operands and the result are in the polynomial basis.
+///
+/// # Algorithm
+///
+/// Karatsuba over the 64-bit halves.
+/// Writing `a = a0 + a1 x^64` and `b = b0 + b1 x^64`:
+///
+/// ```text
+///     middle = (a0 + a1)(b0 + b1) + a0 b0 + a1 b1
+/// ```
+///
+/// # Why Karatsuba here
+///
+/// A half product costs sixteen integer multiplies.
+/// Saving one is worth the four extra exclusive ors it costs.
+/// A hardware carryless multiply is cheap enough that the trade goes the other way.
+#[inline]
+pub(crate) const fn poly_mul_128(a: u128, b: u128) -> u128 {
+    // Reduce the full polynomial product once.
+    let (low, high) = wide_mul_128(a, b);
+    super::reduce_128(low, high)
+}
+
+/// Compute the two halves of an unreduced 128-bit polynomial product.
+#[inline]
+const fn wide_mul_128(a: u128, b: u128) -> (u128, u128) {
+    let (a0, a1) = (a as u64, (a >> 64) as u64);
+    let (b0, b1) = (b as u64, (b >> 64) as u64);
+
+    // The two diagonal half products.
+    let (l0, l1) = clmul_64x64_halves(a0, b0);
+    let (h0, h1) = clmul_64x64_halves(a1, b1);
+
+    // The third product, less the two above, is the sum of the cross terms.
+    let (m0, m1) = clmul_64x64_halves(a0 ^ a1, b0 ^ b1);
+    let (m0, m1) = (m0 ^ l0 ^ h0, m1 ^ l1 ^ h1);
+
+    // Place the middle coefficient at x^64 and split the 256-bit product in two.
+    //
+    //     low  = l0 + (l1 + m0) x^64
+    //     high = (h0 + m1) + h1 x^64          weighted by x^128
+    let low = (l0 as u128) | (((l1 ^ m0) as u128) << 64);
+    let high = ((h0 ^ m1) as u128) | ((h1 as u128) << 64);
+
+    (low, high)
+}
+
+/// Sum polynomial products before reducing modulo the GHASH polynomial.
+#[inline]
+pub(crate) fn poly_dot_128(pairs: impl Iterator<Item = (u128, u128)>) -> u128 {
+    // Reduction is linear over GF(2), so XOR accumulation needs no carry space.
+    let (low, high) = pairs.fold((0, 0), |(low, high), (a, b)| {
+        let (l, h) = wide_mul_128(a, b);
+        (low ^ l, high ^ h)
+    });
+    super::reduce_128(low, high)
+}
+
+/// Interleaves the bits of a 64-bit word with zeros, widening it to 128 bits.
+///
+/// Each round doubles the gap between neighbouring bits.
+/// After six rounds every original bit sits at twice its index.
+#[inline]
+const fn spread_bits_64(v: u64) -> u128 {
+    let mut x = v as u128;
+
+    // Separate into groups of 32 bits, then 16, 8, 4, 2, and finally single bits.
+    x = (x | (x << 32)) & 0x0000_0000_ffff_ffff_0000_0000_ffff_ffff;
+    x = (x | (x << 16)) & 0x0000_ffff_0000_ffff_0000_ffff_0000_ffff;
+    x = (x | (x << 8)) & 0x00ff_00ff_00ff_00ff_00ff_00ff_00ff_00ff;
+    x = (x | (x << 4)) & 0x0f0f_0f0f_0f0f_0f0f_0f0f_0f0f_0f0f_0f0f;
+    x = (x | (x << 2)) & 0x3333_3333_3333_3333_3333_3333_3333_3333;
+    x = (x | (x << 1)) & 0x5555_5555_5555_5555_5555_5555_5555_5555;
+
+    x
+}
+
+/// Squaring in `GF(2^128)`, taking and returning the polynomial representation.
+///
+/// Squaring is the Frobenius map, so in characteristic 2 the coefficients simply spread out:
+///
+/// ```text
+///     (sum_i c_i x^i)^2 = sum_i c_i x^(2i)
+/// ```
+///
+/// Only shifts and masks are involved.
+/// This backend therefore squares far faster than it multiplies.
+#[inline]
+pub(crate) const fn poly_square_128(a: u128) -> u128 {
+    // Spreading each half gives the 256-bit square directly, with no middle term.
+    super::reduce_128(spread_bits_64(a as u64), spread_bits_64((a >> 64) as u64))
+}
+
+/// Multiply by a polynomial of degree below 64 with two unreduced half products.
+#[inline]
+pub(crate) const fn poly_mul_128_by_64(a: u128, b: u64) -> u128 {
+    // The high half of the second operand is zero, leaving just two coefficients.
+    let low = clmul_64x64(a as u64, b);
+    let middle = clmul_64x64((a >> 64) as u64, b);
+    super::reduce_128(low ^ (middle << 64), middle >> 64)
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::{bmul64, clmul_64x64, spread_bits_64};
+    use crate::clmul::basis::{TAIL_128, poly_mul};
+
+    /// Bit `i` of the input, moved to position `2i`, one bit at a time.
+    fn spread_bits_64_reference(v: u64) -> u128 {
+        (0..64)
+            .filter(|i| (v >> i) & 1 == 1)
+            .fold(0u128, |acc, i| acc | (1u128 << (2 * i)))
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(4000))]
+
+        #[test]
+        fn the_masked_multiply_matches_the_bit_serial_product(a: u64, b: u64) {
+            // The bit-serial loop is the definition of a carryless product.
+            let expected = super::super::scalar_clmul_64x64(a, b);
+
+            // Both halves, recovered through the bit reversal.
+            prop_assert_eq!(clmul_64x64(a, b), expected);
+
+            // The low half alone, which is all the masked multiply promises.
+            prop_assert_eq!(bmul64(a, b), expected as u64);
+        }
+
+        #[test]
+        fn the_bit_spread_matches_a_bit_at_a_time(v: u64) {
+            prop_assert_eq!(spread_bits_64(v), spread_bits_64_reference(v));
+        }
+
+        #[test]
+        fn the_software_product_matches_bit_serial_modular_multiplication(a: u128, b: u128) {
+            // Karatsuba plus the fold, against multiplication straight from the modulus.
+            prop_assert_eq!(super::poly_mul_128(a, b), poly_mul(a, b, 128, TAIL_128));
+        }
+
+        #[test]
+        fn the_software_square_matches_the_software_product(a: u128) {
+            prop_assert_eq!(super::poly_square_128(a), super::poly_mul_128(a, a));
+        }
+    }
+
+    #[test]
+    fn the_masked_multiply_is_exact_where_the_carries_are_worst() {
+        // Invariant: the carries stay inside the holes for every operand pair.
+        //
+        // Worst cases: the operands packing the most set bits into one residue class.
+        //
+        //     0xffff...  every position in every class
+        //     0x8888...  every position in class 3
+        //     0x1111...  every position in class 0
+        //     1 << 63    the single highest position, where the carry leaves the word
+        const WORST: [u64; 4] = [
+            u64::MAX,
+            0x8888_8888_8888_8888,
+            0x1111_1111_1111_1111,
+            1 << 63,
+        ];
+
+        for a in WORST {
+            for b in WORST {
+                assert_eq!(
+                    clmul_64x64(a, b),
+                    super::super::scalar_clmul_64x64(a, b),
+                    "{a:#x} * {b:#x}"
+                );
+            }
+        }
+    }
+}

--- a/binary-field/src/clmul/sqrt.rs
+++ b/binary-field/src/clmul/sqrt.rs
@@ -1,8 +1,5 @@
 //! Square roots by separating even and odd polynomial coefficients.
 
-#[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
-use core::arch::x86_64::_pext_u64;
-
 use super::basis::{TAIL_128, poly_mul};
 
 /// The unique square root of the polynomial variable modulo the GHASH polynomial.
@@ -11,27 +8,14 @@ const ROOT_X: u128 = 0x2492_4924_9249_2492_6db6_db6d_b6db_6da4;
 // Pin the constant to the modulus, independently of the selected arithmetic backend.
 const _: () = assert!(poly_mul(ROOT_X, ROOT_X, 128, TAIL_128) == 2);
 
-/// Gather the even-numbered bits into the low half of a word.
-// The shift-and-mask fallback is `const` and the bit-extract instruction is not, so leaving
-// this one out keeps the signature the same on every target.
-#[allow(clippy::missing_const_for_fn)]
+/// Gather the even-numbered coefficients into the low half of a word.
+///
+/// A bit-extract instruction does this in one step on recent x86.
+/// On Zen 1 and Zen 2 it is microcoded, at around eighteen cycles.
+///
+/// Square roots are rare enough not to be worth that cliff, so the six shifts run everywhere.
 #[inline]
-fn compact_even(x: u64) -> u64 {
-    #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
-    {
-        // SAFETY: the crate is compiled with BMI2 enabled.
-        unsafe { _pext_u64(x, 0x5555_5555_5555_5555) }
-    }
-    #[cfg(not(all(target_arch = "x86_64", target_feature = "bmi2")))]
-    {
-        compact_even_portable(x)
-    }
-}
-
-/// Gather even-numbered coefficients using only shifts and masks.
-#[cfg_attr(all(target_arch = "x86_64", target_feature = "bmi2"), allow(dead_code))]
-#[inline]
-const fn compact_even_portable(mut x: u64) -> u64 {
+const fn compact_even(mut x: u64) -> u64 {
     // Separate coefficients at positions 0, 2, ..., 62 from the odd coefficients.
     x &= 0x5555_5555_5555_5555;
     // Merge adjacent groups until the 32 selected bits are contiguous.
@@ -44,7 +28,7 @@ const fn compact_even_portable(mut x: u64) -> u64 {
 
 /// Separate the coefficients of even and odd degree into two 64-bit polynomials.
 #[inline]
-fn unshuffle(a: u128) -> (u64, u64) {
+const fn unshuffle(a: u128) -> (u64, u64) {
     // Each half supplies 32 coefficients to each output polynomial.
     let (lo, hi) = (a as u64, (a >> 64) as u64);
     (
@@ -74,7 +58,6 @@ mod tests {
         fn unshuffle_matches_individual_coefficients(a: u128) {
             // Trace each input bit to its position in the two output polynomials.
             let (even, odd) = unshuffle(a);
-            prop_assert_eq!(compact_even(a as u64), compact_even_portable(a as u64));
             for i in 0..64 {
                 prop_assert_eq!((even >> i) & 1, ((a >> (2 * i)) & 1) as u64);
                 prop_assert_eq!((odd >> i) & 1, ((a >> (2 * i + 1)) & 1) as u64);

--- a/binary-field/src/clmul/sqrt.rs
+++ b/binary-field/src/clmul/sqrt.rs
@@ -1,0 +1,98 @@
+//! Square roots by separating even and odd polynomial coefficients.
+
+#[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
+use core::arch::x86_64::_pext_u64;
+
+use super::basis::{TAIL_128, poly_mul};
+
+/// The unique square root of the polynomial variable modulo the GHASH polynomial.
+const ROOT_X: u128 = 0x2492_4924_9249_2492_6db6_db6d_b6db_6da4;
+
+// Pin the constant to the modulus, independently of the selected arithmetic backend.
+const _: () = assert!(poly_mul(ROOT_X, ROOT_X, 128, TAIL_128) == 2);
+
+/// Gather the even-numbered bits into the low half of a word.
+// The shift-and-mask fallback is `const` and the bit-extract instruction is not, so leaving
+// this one out keeps the signature the same on every target.
+#[allow(clippy::missing_const_for_fn)]
+#[inline]
+fn compact_even(x: u64) -> u64 {
+    #[cfg(all(target_arch = "x86_64", target_feature = "bmi2"))]
+    {
+        // SAFETY: the crate is compiled with BMI2 enabled.
+        unsafe { _pext_u64(x, 0x5555_5555_5555_5555) }
+    }
+    #[cfg(not(all(target_arch = "x86_64", target_feature = "bmi2")))]
+    {
+        compact_even_portable(x)
+    }
+}
+
+/// Gather even-numbered coefficients using only shifts and masks.
+#[cfg_attr(all(target_arch = "x86_64", target_feature = "bmi2"), allow(dead_code))]
+#[inline]
+const fn compact_even_portable(mut x: u64) -> u64 {
+    // Separate coefficients at positions 0, 2, ..., 62 from the odd coefficients.
+    x &= 0x5555_5555_5555_5555;
+    // Merge adjacent groups until the 32 selected bits are contiguous.
+    x = (x | (x >> 1)) & 0x3333_3333_3333_3333;
+    x = (x | (x >> 2)) & 0x0f0f_0f0f_0f0f_0f0f;
+    x = (x | (x >> 4)) & 0x00ff_00ff_00ff_00ff;
+    x = (x | (x >> 8)) & 0x0000_ffff_0000_ffff;
+    (x | (x >> 16)) & 0xffff_ffff
+}
+
+/// Separate the coefficients of even and odd degree into two 64-bit polynomials.
+#[inline]
+fn unshuffle(a: u128) -> (u64, u64) {
+    // Each half supplies 32 coefficients to each output polynomial.
+    let (lo, hi) = (a as u64, (a >> 64) as u64);
+    (
+        compact_even(lo) | (compact_even(hi) << 32),
+        compact_even(lo >> 1) | (compact_even(hi >> 1) << 32),
+    )
+}
+
+/// Compute a square root with one field product and no operand-indexed tables.
+#[inline]
+pub(crate) fn poly_sqrt_128(a: u128) -> u128 {
+    // Invariant:
+    //     a = even(x)^2 + x * odd(x)^2
+    //     sqrt(a) = even(x) + sqrt(x) * odd(x)
+    let (even, odd) = unshuffle(a);
+    u128::from(even) ^ super::poly_mul_128_by_64(ROOT_X, odd)
+}
+
+#[cfg(test)]
+mod tests {
+    use proptest::prelude::*;
+
+    use super::*;
+
+    proptest! {
+        #[test]
+        fn unshuffle_matches_individual_coefficients(a: u128) {
+            // Trace each input bit to its position in the two output polynomials.
+            let (even, odd) = unshuffle(a);
+            prop_assert_eq!(compact_even(a as u64), compact_even_portable(a as u64));
+            for i in 0..64 {
+                prop_assert_eq!((even >> i) & 1, ((a >> (2 * i)) & 1) as u64);
+                prop_assert_eq!((odd >> i) & 1, ((a >> (2 * i + 1)) & 1) as u64);
+            }
+        }
+    }
+
+    #[test]
+    fn every_basis_vector_squares_back() {
+        // A linear map is determined by its action on all 128 basis vectors.
+        for i in 0..128 {
+            let a = 1u128 << i;
+            let root = poly_sqrt_128(a);
+            assert_eq!(poly_mul(root, root, 128, TAIL_128), a);
+        }
+        // Include both additive extremes explicitly.
+        assert_eq!(poly_sqrt_128(0), 0);
+        let root = poly_sqrt_128(u128::MAX);
+        assert_eq!(poly_mul(root, root, 128, TAIL_128), u128::MAX);
+    }
+}

--- a/binary-field/src/clmul/x86_64.rs
+++ b/binary-field/src/clmul/x86_64.rs
@@ -1,32 +1,189 @@
 //! The `PCLMULQDQ` backend.
 
 use core::arch::x86_64::{
-    _mm_clmulepi64_si128, _mm_cvtsi128_si64, _mm_set_epi64x, _mm_unpackhi_epi64,
+    __m128i, _mm_clmulepi64_si128, _mm_cvtsi128_si64, _mm_set_epi64x, _mm_setzero_si128,
+    _mm_shuffle_epi32, _mm_slli_si128, _mm_unpackhi_epi64, _mm_xor_si128,
 };
+use core::mem::transmute;
 
-/// Selects the low quadword of both operands: bit 0 picks the half of the first argument and
-/// bit 4 the half of the second, so `0x00` is `a.low × b.low`.
+use super::basis::TAIL_128;
+
+/// Selects the low quadword of both operands.
+///
+/// Bit 0 picks the half of the first argument, bit 4 the half of the second.
 const LOW_BY_LOW: i32 = 0x00;
+
+/// Selects the high quadword of both operands.
+const HIGH_BY_HIGH: i32 = 0x11;
+
+/// Selects the high quadword of the first operand and the low quadword of the second.
+const HIGH_BY_LOW: i32 = 0x01;
+
+/// Selects the low quadword of the first operand and the high quadword of the second.
+const LOW_BY_HIGH: i32 = 0x10;
 
 /// The carryless product of two 64-bit polynomials over `GF(2)`.
 ///
-/// `PCLMULQDQ` accumulates `b << i` for every set bit `i` of `a`, so bit `j` of the result is
-/// the coefficient of `x^j` exactly as the rest of this module assumes.
+/// The instruction accumulates `b << i` for every set bit `i` of `a`.
+/// Bit `j` of the result is therefore the coefficient of `x^j`.
 #[inline]
 pub(super) fn clmul_64x64(a: u64, b: u64) -> u128 {
     // SAFETY: this module is compiled only when `target_feature = "pclmulqdq"` is enabled for
-    // the crate, which is what `_mm_clmulepi64_si128` requires; the remaining intrinsics are
-    // `sse2`, which is unconditionally available on `x86_64`.
+    // the crate, which is what the carryless multiply requires.
+    // The remaining intrinsics are `sse2`, always available on `x86_64`.
     unsafe {
-        // `_mm_set_epi64x` takes its arguments from highest lane to lowest, so the operand goes
-        // in the second position and the unused high lane in the first.
+        // Arguments run from the highest lane down.
+        // The operand goes second and the unused high lane first.
         let a = _mm_set_epi64x(0, a as i64);
         let b = _mm_set_epi64x(0, b as i64);
         let product = _mm_clmulepi64_si128::<LOW_BY_LOW>(a, b);
 
-        // `_mm_extract_epi64` would need `sse4.1`, so the high lane is moved down instead.
+        // Extracting the high lane directly would need `sse4.1`, so it is moved down instead.
         let low = _mm_cvtsi128_si64(product) as u64;
         let high = _mm_cvtsi128_si64(_mm_unpackhi_epi64(product, product)) as u64;
         u128::from(low) | (u128::from(high) << 64)
+    }
+}
+
+/// One Horner step of the reduction: `t0 + t1 x^64` modulo the field polynomial.
+///
+/// # Algorithm
+///
+/// Split the second argument into its 64-bit halves and rewrite the part that overflows.
+///
+/// ```text
+///     T  = x^7 + x^2 + x + 1                       the modulus tail, since x^128 = T
+///     t1 = t1_lo + t1_hi x^64
+///
+///     t1 x^64 = t1_lo x^64 + t1_hi x^128
+///             = t1_lo x^64 + t1_hi T
+/// ```
+///
+/// The first term is a byte-wise shift by eight.
+/// The second has degree at most `63 + 7`, so nothing overflows again.
+///
+/// # Safety
+///
+/// The caller must be compiled with the `pclmulqdq` target feature.
+#[inline]
+unsafe fn fold_shifted(t0: __m128i, t1: __m128i) -> __m128i {
+    // SAFETY: guaranteed by the caller.
+    unsafe {
+        // The tail sits in the low lane, which is where the multiply below reads it from.
+        let tail = _mm_set_epi64x(0, TAIL_128 as i64);
+
+        // t0 + t1_lo x^64.
+        let shifted = _mm_xor_si128(t0, _mm_slli_si128::<8>(t1));
+
+        // ... + t1_hi T.
+        _mm_xor_si128(shifted, _mm_clmulepi64_si128::<HIGH_BY_LOW>(t1, tail))
+    }
+}
+
+/// Multiplication in `GF(2^128) = GF(2)[x] / (x^128 + x^7 + x^2 + x + 1)`.
+///
+/// Both operands and the result are in the polynomial basis.
+///
+/// # Algorithm
+///
+/// Schoolbook over the 64-bit halves, then Horner in `x^64`.
+///
+/// ```text
+///     a b = lo + mid x^64 + hi x^128
+///         = lo + x^64 (mid + x^64 hi)
+/// ```
+///
+/// Six carryless products in all: four for the halves, two for the fold.
+///
+/// # Performance
+///
+/// Every intermediate stays in a vector register.
+/// The general-purpose file has no 128-bit shift.
+/// Folding there costs several instructions per step instead of one.
+#[inline]
+pub(crate) fn poly_mul_128(a: u128, b: u128) -> u128 {
+    // SAFETY: this module is compiled only when `target_feature = "pclmulqdq"` is enabled for
+    // the crate.
+    // The remaining intrinsics are `sse2`, always available on `x86_64`.
+    unsafe {
+        let x = transmute::<u128, __m128i>(a);
+        let y = transmute::<u128, __m128i>(b);
+
+        // The two diagonal half products.
+        let low = _mm_clmulepi64_si128::<LOW_BY_LOW>(x, y);
+        let high = _mm_clmulepi64_si128::<HIGH_BY_HIGH>(x, y);
+
+        // The two cross products, which share the weight x^64.
+        let middle = _mm_xor_si128(
+            _mm_clmulepi64_si128::<HIGH_BY_LOW>(x, y),
+            _mm_clmulepi64_si128::<LOW_BY_HIGH>(x, y),
+        );
+
+        // Inner fold brings the top limb down, outer fold finishes the reduction.
+        transmute::<__m128i, u128>(fold_shifted(low, fold_shifted(middle, high)))
+    }
+}
+
+/// Squaring in `GF(2^128)`, taking and returning the polynomial representation.
+///
+/// The cross term of `(p0 + p1 x^64)^2` is `2 p0 p1`, which vanishes in characteristic 2.
+/// The 256-bit square is therefore `p0^2 + p1^2 x^128`, with nothing between the halves.
+#[inline]
+pub(crate) fn poly_square_128(a: u128) -> u128 {
+    // SAFETY: as in the multiplication above.
+    unsafe {
+        let x = transmute::<u128, __m128i>(a);
+        let low = _mm_clmulepi64_si128::<LOW_BY_LOW>(x, x);
+        let high = _mm_clmulepi64_si128::<HIGH_BY_HIGH>(x, x);
+
+        // The inner fold has no middle coefficient to add to, so its exclusive or is skipped.
+        let tail = _mm_set_epi64x(0, TAIL_128 as i64);
+        let folded = _mm_xor_si128(
+            _mm_slli_si128::<8>(high),
+            _mm_clmulepi64_si128::<HIGH_BY_LOW>(high, tail),
+        );
+
+        transmute::<__m128i, u128>(fold_shifted(low, folded))
+    }
+}
+
+/// Sum unreduced products with three carryless multiplies per pair and two for reduction.
+#[inline]
+pub(crate) fn poly_dot_128(pairs: impl Iterator<Item = (u128, u128)>) -> u128 {
+    // SAFETY: this module requires PCLMULQDQ and x86-64 supplies SSE2.
+    // Every bit pattern is valid in both the integer and vector representations.
+    unsafe {
+        let mut low = _mm_setzero_si128();
+        let mut high = _mm_setzero_si128();
+        let mut middle = _mm_setzero_si128();
+        for (a, b) in pairs {
+            let x = transmute::<u128, __m128i>(a);
+            let y = transmute::<u128, __m128i>(b);
+            // Accumulate coefficients with weights 1, x^64, and x^128 separately.
+            low = _mm_xor_si128(low, _mm_clmulepi64_si128::<LOW_BY_LOW>(x, y));
+            high = _mm_xor_si128(high, _mm_clmulepi64_si128::<HIGH_BY_HIGH>(x, y));
+            // Karatsuba accumulates the product of the two sums of halves.
+            let mixed_x = _mm_xor_si128(x, _mm_shuffle_epi32::<0x4e>(x));
+            let mixed_y = _mm_xor_si128(y, _mm_shuffle_epi32::<0x4e>(y));
+            middle = _mm_xor_si128(middle, _mm_clmulepi64_si128::<LOW_BY_LOW>(mixed_x, mixed_y));
+        }
+        // Recover the cross terms from the three accumulated Karatsuba coefficients.
+        middle = _mm_xor_si128(middle, _mm_xor_si128(low, high));
+        // Invariant: reduction distributes over XOR, including an empty sum.
+        transmute::<__m128i, u128>(fold_shifted(low, fold_shifted(middle, high)))
+    }
+}
+
+/// Multiply by a polynomial of degree below 64 using three carryless products.
+#[inline]
+pub(crate) fn poly_mul_128_by_64(a: u128, b: u64) -> u128 {
+    // SAFETY: the module requires PCLMULQDQ and x86-64 supplies SSE2.
+    unsafe {
+        let a = transmute::<u128, __m128i>(a);
+        let b = _mm_set_epi64x(0, b as i64);
+        // Invariant: a*b = a0*b + x^64*(a1*b), so only one Horner fold is needed.
+        let low = _mm_clmulepi64_si128::<LOW_BY_LOW>(a, b);
+        let middle = _mm_clmulepi64_si128::<HIGH_BY_LOW>(a, b);
+        transmute::<__m128i, u128>(fold_shifted(low, middle))
     }
 }

--- a/binary-field/src/ghash.rs
+++ b/binary-field/src/ghash.rs
@@ -29,10 +29,7 @@ const TOWER_GENERATOR: u128 = 0x1_0000_0000_0000_0005;
 const ALPHA: u128 = clmul::tower_image_128(1 << 64);
 
 /// The inverse of an element known to be nonzero, by the addition chain over Frobenius maps.
-#[cfg(any(
-    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
-    all(target_arch = "aarch64", target_feature = "aes"),
-))]
+#[cfg(all(target_arch = "x86_64", target_feature = "pclmulqdq"))]
 #[inline]
 fn invert_nonzero(x: Ghash128) -> Ghash128 {
     Ghash128(clmul::poly_inverse_128(x.0))
@@ -40,12 +37,9 @@ fn invert_nonzero(x: Ghash128) -> Ghash128 {
 
 /// The inverse of an element known to be nonzero, through the tower norm.
 ///
-/// The tower inverts through a norm recursion down to a `GF(2^8)` lookup table.
-/// A software product costs more than the two changes of basis around it.
-#[cfg(not(any(
-    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
-    all(target_arch = "aarch64", target_feature = "aes"),
-)))]
+/// The tower recurses through the norm down to a `GF(2^8)` lookup table.
+/// Everywhere the addition chain is not faster, that beats it for no table at all.
+#[cfg(not(all(target_arch = "x86_64", target_feature = "pclmulqdq")))]
 #[inline]
 fn invert_nonzero(x: Ghash128) -> Ghash128 {
     Ghash128::from(BinaryField128::from(x).inverse())
@@ -186,18 +180,11 @@ impl PrimeCharacteristicRing for Ghash128 {
 
 impl Field for Ghash128 {
     // One element is one 128-bit lane, so a wide carryless multiply packs several of them.
-    #[cfg(all(
-        target_arch = "x86_64",
-        target_feature = "vpclmulqdq",
-        any(target_feature = "avx2", target_feature = "avx512f")
-    ))]
-    type Packing = crate::PackedGhash128;
-    #[cfg(not(all(
-        target_arch = "x86_64",
-        target_feature = "vpclmulqdq",
-        any(target_feature = "avx2", target_feature = "avx512f")
-    )))]
-    type Packing = Self;
+    // Which register that is, and whether there is one at all, is settled in `packed`.
+    //
+    // Without a packing the alias resolves to this type itself, which is why the lint is off.
+    #[allow(clippy::use_self)]
+    type Packing = crate::packed::Packing;
 
     const GENERATOR: Self = Self(clmul::tower_image_128(TOWER_GENERATOR));
 

--- a/binary-field/src/ghash.rs
+++ b/binary-field/src/ghash.rs
@@ -1,0 +1,560 @@
+//! `GF(2^128)` in the polynomial basis of `x^128 + x^7 + x^2 + x + 1`.
+
+use core::fmt::{self, Debug, Display, Formatter};
+use core::iter::{Product, Sum};
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use num_bigint::BigUint;
+use p3_field::op_assign_macros::{
+    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
+    impl_sub_assign, impl_sub_base_field, ring_sum,
+};
+use p3_field::{Algebra, Field, Packable, PrimeCharacteristicRing, RawDataSerializable};
+use rand::Rng;
+use rand::distr::{Distribution, StandardUniform};
+use serde::{Deserialize, Serialize};
+
+use crate::cantor::CANTOR_BASIS_128;
+use crate::tower::TowerLevel;
+use crate::{BinaryField128, Gf2, clmul};
+
+/// The bit pattern of the multiplicative generator of the tower representation.
+///
+/// Its image is the generator here, so the conversion carries one onto the other.
+const TOWER_GENERATOR: u128 = 0x1_0000_0000_0000_0005;
+
+/// The tower's generator of `GF(2^128)` over `GF(2^64)`, in this representation.
+///
+/// The tower carries that element as a single basis vector, at bit 64.
+const ALPHA: u128 = clmul::tower_image_128(1 << 64);
+
+/// The inverse of an element known to be nonzero, by the addition chain over Frobenius maps.
+#[cfg(any(
+    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+    all(target_arch = "aarch64", target_feature = "aes"),
+))]
+#[inline]
+fn invert_nonzero(x: Ghash128) -> Ghash128 {
+    Ghash128(clmul::poly_inverse_128(x.0))
+}
+
+/// The inverse of an element known to be nonzero, through the tower norm.
+///
+/// The tower inverts through a norm recursion down to a `GF(2^8)` lookup table.
+/// A software product costs more than the two changes of basis around it.
+#[cfg(not(any(
+    all(target_arch = "x86_64", target_feature = "pclmulqdq"),
+    all(target_arch = "aarch64", target_feature = "aes"),
+)))]
+#[inline]
+fn invert_nonzero(x: Ghash128) -> Ghash128 {
+    Ghash128::from(BinaryField128::from(x).inverse())
+}
+
+/// The Cantor basis in this representation.
+///
+/// These are the images of the tower's own basis vectors.
+/// Both representations therefore span the same additive NTT domain.
+const CANTOR_BASIS: [u128; 128] = {
+    let mut basis = [0u128; 128];
+    let mut i = 0;
+    while i < 128 {
+        basis[i] = clmul::tower_image_128(CANTOR_BASIS_128[i]);
+        i += 1;
+    }
+    basis
+};
+
+/// The binary field GF(2^128) modulo x^128 + x^7 + x^2 + x + 1.
+///
+/// Bit i stores the coefficient of x^i.
+/// Every 128-bit pattern is a distinct field element.
+///
+/// Hardware carryless multiplication operates directly on this representation.
+/// The tower representation instead provides byte-aligned subfields.
+///
+/// Inversion and conversions to or from the tower use operand-indexed tables.
+/// They are not constant-time for secret inputs.
+///
+/// NIST GCM blocks use the opposite coefficient order.
+/// Reverse all 128 bits of a big-endian block integer before interpreting it here.
+#[derive(Copy, Clone, Default, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+#[repr(transparent)]
+#[must_use]
+pub struct Ghash128(u128);
+
+impl Ghash128 {
+    /// The number of bits of an element.
+    pub(crate) const BITS: usize = 128;
+
+    /// Construct a field element from its little-endian byte representation.
+    ///
+    /// Every byte string of this length is a valid element.
+    #[inline]
+    pub const fn from_le_bytes(bytes: [u8; 16]) -> Self {
+        Self(u128::from_le_bytes(bytes))
+    }
+}
+
+impl Packable for Ghash128 {}
+
+impl Display for Ghash128 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+impl Debug for Ghash128 {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        Debug::fmt(&self.0, f)
+    }
+}
+
+impl Distribution<Ghash128> for StandardUniform {
+    #[inline]
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Ghash128 {
+        let mut bytes = [0u8; 16];
+        rng.fill_bytes(&mut bytes);
+        Ghash128::from_le_bytes(bytes)
+    }
+}
+
+impl PrimeCharacteristicRing for Ghash128 {
+    type PrimeSubfield = Gf2;
+
+    const ZERO: Self = Self(0);
+    const ONE: Self = Self(1);
+    // The characteristic is 2, so `TWO = ONE + ONE = ZERO`.
+    const TWO: Self = Self(0);
+    // The characteristic is 2, so `NEG_ONE = ONE`.
+    const NEG_ONE: Self = Self(1);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        Self::from_bool(f.is_one())
+    }
+
+    #[inline]
+    fn from_bool(b: bool) -> Self {
+        Self(u128::from(b))
+    }
+
+    #[inline]
+    fn double(&self) -> Self {
+        // `a + a = 0` in characteristic 2.
+        Self::ZERO
+    }
+
+    /// # Panics
+    /// Always panics: `2` is not invertible in characteristic 2.
+    #[inline]
+    fn halve(&self) -> Self {
+        panic!("halve is undefined in characteristic 2")
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        Self(clmul::poly_square_128(self.0))
+    }
+
+    #[inline]
+    fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
+        // Reduction is linear, so an entire sum pays for it only once.
+        Self(clmul::poly_dot_128(
+            u.iter().zip(v).map(|(a, b)| (a.0, b.0)),
+        ))
+    }
+
+    #[inline]
+    fn xor(&self, y: &Self) -> Self {
+        *self + *y
+    }
+
+    #[inline]
+    fn mul_2exp_u64(&self, exp: u64) -> Self {
+        if exp == 0 { *self } else { Self::ZERO }
+    }
+
+    /// # Panics
+    /// Always panics: `2` is not invertible in characteristic 2.
+    #[inline]
+    fn div_2exp_u64(&self, _exp: u64) -> Self {
+        panic!("div_2exp_u64 is undefined in characteristic 2")
+    }
+}
+
+impl Field for Ghash128 {
+    // One element is one 128-bit lane, so a wide carryless multiply packs several of them.
+    #[cfg(all(
+        target_arch = "x86_64",
+        target_feature = "vpclmulqdq",
+        any(target_feature = "avx2", target_feature = "avx512f")
+    ))]
+    type Packing = crate::PackedGhash128;
+    #[cfg(not(all(
+        target_arch = "x86_64",
+        target_feature = "vpclmulqdq",
+        any(target_feature = "avx2", target_feature = "avx512f")
+    )))]
+    type Packing = Self;
+
+    const GENERATOR: Self = Self(clmul::tower_image_128(TOWER_GENERATOR));
+
+    /// Invert through precomputed squaring maps on carryless-multiply targets.
+    /// The software backend instead uses the recursive tower norm.
+    ///
+    /// The operand-indexed tables make this operation variable-time.
+    #[inline]
+    fn try_inverse(&self) -> Option<Self> {
+        // Zero has no multiplicative inverse.
+        (self.0 != 0).then(|| invert_nonzero(*self))
+    }
+
+    #[inline]
+    fn try_sqrt(&self) -> Option<Self> {
+        // Separate even and odd coefficients to invert the squaring map directly.
+        Some(Self(clmul::poly_sqrt_128(self.0)))
+    }
+
+    #[inline]
+    fn order() -> BigUint {
+        BigUint::from(1u8) << Self::BITS
+    }
+
+    /// An element of `GF(2^n)` is exactly `n` bits wide.
+    #[inline]
+    fn bits() -> usize {
+        Self::BITS
+    }
+
+    /// The enumeration by bit pattern.
+    ///
+    /// The coordinates of the returned element over `GF(2)` are the bits of the index.
+    /// A pointer is never 128 bits wide, so every index is in range.
+    #[inline]
+    fn interpolation_node(i: usize) -> Self {
+        Self(i as u128)
+    }
+}
+
+impl RawDataSerializable for Ghash128 {
+    const NUM_BYTES: usize = 16;
+
+    #[inline]
+    fn into_bytes(self) -> impl IntoIterator<Item = u8> {
+        self.0.to_le_bytes()
+    }
+}
+
+impl crate::tower::private::Sealed for Ghash128 {}
+
+impl TowerLevel for Ghash128 {
+    type Repr = u128;
+
+    const LOG_BITS: usize = 7;
+
+    #[inline]
+    fn from_repr(r: Self::Repr) -> Self {
+        Self(r)
+    }
+
+    #[inline]
+    fn to_repr(self) -> Self::Repr {
+        self.0
+    }
+
+    /// That generator is a basis element in the tower, which gets this for a shift.
+    /// Here it is an arbitrary element, so it costs a full product.
+    #[inline]
+    fn mul_alpha(self) -> Self {
+        self * Self(ALPHA)
+    }
+
+    /// # Panics
+    /// Panics if the stream ends before a whole element has been read.
+    #[inline]
+    fn from_le_byte_iter(mut bytes: impl Iterator<Item = u8>) -> Self {
+        let mut buffer = [0u8; 16];
+        for byte in &mut buffer {
+            *byte = bytes
+                .next()
+                .expect("byte stream ended before a whole element was read");
+        }
+        Self::from_le_bytes(buffer)
+    }
+
+    /// # Panics
+    /// Panics if the index is at least the bit width of the field.
+    #[inline]
+    fn cantor_basis(i: usize) -> Self {
+        assert!(i < Self::BITS, "Cantor basis index out of range");
+        Self(CANTOR_BASIS[i])
+    }
+}
+
+impl From<BinaryField128> for Ghash128 {
+    /// The same field element, seen in the polynomial basis.
+    #[inline]
+    fn from(x: BinaryField128) -> Self {
+        Self(clmul::tower_to_poly_128(x.to_repr()))
+    }
+}
+
+impl From<Ghash128> for BinaryField128 {
+    /// The same field element, seen in the tower basis.
+    #[inline]
+    fn from(x: Ghash128) -> Self {
+        Self::from_repr(clmul::poly_to_tower_128(x.0))
+    }
+}
+
+impl Add for Ghash128 {
+    type Output = Self;
+
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn add(self, rhs: Self) -> Self {
+        // Addition in characteristic 2 is `XOR`.
+        Self(self.0 ^ rhs.0)
+    }
+}
+
+impl Sub for Ghash128 {
+    type Output = Self;
+
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: Self) -> Self {
+        // Subtraction coincides with addition in characteristic 2.
+        self + rhs
+    }
+}
+
+impl Neg for Ghash128 {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self::Output {
+        // `-x = x` in characteristic 2.
+        self
+    }
+}
+
+impl Mul for Ghash128 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        Self(clmul::poly_mul_128(self.0, rhs.0))
+    }
+}
+
+impl_add_assign!(Ghash128);
+impl_sub_assign!(Ghash128);
+impl_mul_methods!(Ghash128);
+impl_div_methods!(Ghash128, Ghash128);
+ring_sum!(Ghash128);
+
+impl From<Gf2> for Ghash128 {
+    /// `GF(2)` is the prime subfield, embedded as `{ZERO, ONE}`.
+    #[inline]
+    fn from(x: Gf2) -> Self {
+        Self::from_prime_subfield(x)
+    }
+}
+
+impl_add_base_field!(Ghash128, Gf2);
+impl_sub_base_field!(Ghash128, Gf2);
+impl_mul_base_field!(Ghash128, Gf2);
+
+impl Algebra<Gf2> for Ghash128 {}
+
+#[cfg(test)]
+mod tests {
+    extern crate std;
+
+    use std::vec::Vec;
+
+    use p3_field::{Field, PrimeCharacteristicRing, RawDataSerializable};
+    use proptest::prelude::*;
+
+    use super::{CANTOR_BASIS, Ghash128};
+    use crate::tower::TowerLevel;
+    use crate::{BinaryField128, Gf2};
+
+    /// The tower element with the given bit pattern.
+    fn tower(bits: u128) -> BinaryField128 {
+        BinaryField128::from_repr(bits)
+    }
+
+    #[test]
+    fn the_change_of_basis_fixes_the_constants() {
+        // Any field isomorphism fixes zero and one.
+        assert_eq!(Ghash128::from(BinaryField128::ZERO), Ghash128::ZERO);
+        assert_eq!(Ghash128::from(BinaryField128::ONE), Ghash128::ONE);
+    }
+
+    #[test]
+    fn the_generator_is_the_image_of_the_tower_generator() {
+        // Both representations are the same field, so one generator maps onto the other.
+        // This is what pins the transcribed bit pattern the constant is built from.
+        assert_eq!(
+            Ghash128::GENERATOR,
+            Ghash128::from(BinaryField128::GENERATOR)
+        );
+    }
+
+    #[test]
+    fn the_modulus_reduces_the_way_the_polynomial_says() {
+        // x^127 * x = x^128 = x^7 + x^2 + x + 1, the tail spelled 0x87.
+        let x = Ghash128::from_repr(2);
+        let top = Ghash128::from_repr(1 << 127);
+        assert_eq!(top * x, Ghash128::from_repr(0x87));
+
+        // x * x = x^2, nowhere near the modulus.
+        assert_eq!(x * x, Ghash128::from_repr(4));
+
+        // (x + 1)^2 = x^2 + 1, since the cross term doubles to zero.
+        assert_eq!(Ghash128::from_repr(3).square(), Ghash128::from_repr(5));
+    }
+
+    #[test]
+    fn the_cantor_basis_satisfies_its_recurrence() {
+        // Invariant: v_0 = 1 and v_i^2 + v_i = v_{i-1}.
+        // This is what the additive NTT domain is built on.
+        assert_eq!(Ghash128::cantor_basis(0), Ghash128::ONE);
+
+        for i in 1..Ghash128::BITS {
+            let v = Ghash128::cantor_basis(i);
+            assert_eq!(v.square() + v, Ghash128::cantor_basis(i - 1), "vector {i}");
+        }
+    }
+
+    #[test]
+    fn the_cantor_basis_is_the_image_of_the_tower_one() {
+        // The two representations must span the same additive NTT domain, vector by vector.
+        for i in 0..Ghash128::BITS {
+            assert_eq!(
+                Ghash128::cantor_basis(i),
+                Ghash128::from(BinaryField128::cantor_basis(i)),
+                "vector {i}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_cantor_basis_is_linearly_independent() {
+        // Row-reduce the vectors over GF(2): 128 independent vectors leave 128 pivots.
+        let mut rows: Vec<u128> = CANTOR_BASIS.to_vec();
+        let mut pivots = 0;
+
+        for bit in 0..128 {
+            // Find a remaining row with this bit set and move it into pivot position.
+            if let Some(k) = (pivots..rows.len()).find(|&k| (rows[k] >> bit) & 1 == 1) {
+                rows.swap(pivots, k);
+
+                // Clear the bit from every other row.
+                for k in 0..rows.len() {
+                    if k != pivots && (rows[k] >> bit) & 1 == 1 {
+                        rows[k] ^= rows[pivots];
+                    }
+                }
+                pivots += 1;
+            }
+        }
+
+        assert_eq!(pivots, 128, "the Cantor basis is not a basis");
+    }
+
+    #[test]
+    #[should_panic = "Cantor basis index out of range"]
+    fn the_cantor_basis_rejects_an_index_beyond_the_field() {
+        let _vector = Ghash128::cantor_basis(128);
+    }
+
+    #[test]
+    fn scaling_by_alpha_agrees_with_the_tower() {
+        // The tower scales by a basis element; here the same element is an arbitrary one.
+        for bits in [0, 1, 2, 0x87, 1 << 127, u128::MAX] {
+            let x = tower(bits);
+            assert_eq!(
+                Ghash128::from(x).mul_alpha(),
+                Ghash128::from(x.mul_alpha()),
+                "{bits:#x}"
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2000))]
+
+        #[test]
+        fn the_change_of_basis_round_trips(bits: u128) {
+            let x = Ghash128::from_repr(bits);
+            prop_assert_eq!(Ghash128::from(BinaryField128::from(x)), x);
+        }
+
+        #[test]
+        fn the_change_of_basis_is_a_ring_isomorphism(a: u128, b: u128) {
+            let (x, y) = (tower(a), tower(b));
+
+            // Additive: both representations add by exclusive or, over the same coordinates.
+            prop_assert_eq!(Ghash128::from(x + y), Ghash128::from(x) + Ghash128::from(y));
+
+            // Multiplicative: this is the part a mere change of coordinates would not give.
+            prop_assert_eq!(Ghash128::from(x * y), Ghash128::from(x) * Ghash128::from(y));
+        }
+
+        #[test]
+        fn squaring_agrees_with_multiplying_by_self(bits: u128) {
+            let x = Ghash128::from_repr(bits);
+            prop_assert_eq!(x.square(), x * x);
+        }
+
+        #[test]
+        fn a_nonzero_element_times_its_inverse_is_one(bits: u128) {
+            let x = Ghash128::from_repr(bits);
+            match x.try_inverse() {
+                Some(inverse) => prop_assert_eq!(x * inverse, Ghash128::ONE),
+                None => prop_assert_eq!(x, Ghash128::ZERO),
+            }
+        }
+
+        #[test]
+        fn the_square_root_squares_back(bits: u128) {
+            let x = Ghash128::from_repr(bits);
+            let root = x.try_sqrt().expect("every element of a binary field is a square");
+            prop_assert_eq!(root.square(), x);
+        }
+
+        #[test]
+        fn the_prime_subfield_embeds_as_zero_and_one(bit: bool) {
+            let embedded = Ghash128::from(Gf2::from_bool(bit));
+            prop_assert_eq!(embedded, Ghash128::from_bool(bit));
+        }
+
+        #[test]
+        fn the_byte_stream_reads_back_what_the_element_wrote(bits: u128) {
+            let x = Ghash128::from_repr(bits);
+            prop_assert_eq!(Ghash128::from_le_byte_iter(x.into_bytes().into_iter()), x);
+        }
+    }
+
+    #[test]
+    #[should_panic = "byte stream ended before a whole element was read"]
+    fn a_truncated_byte_stream_is_rejected() {
+        // Fifteen bytes is one short of an element.
+        let _element = Ghash128::from_le_byte_iter([0u8; 15].into_iter());
+    }
+
+    #[test]
+    fn serde_accepts_every_bit_pattern() {
+        // Unlike the narrower tower levels, no bit is masked off, so nothing is out of range.
+        for bits in [0u128, 1, u128::MAX, 1 << 127] {
+            let x = Ghash128::from_repr(bits);
+            let encoded = serde_json::to_string(&x).unwrap();
+            assert_eq!(serde_json::from_str::<Ghash128>(&encoded).unwrap(), x);
+        }
+    }
+}

--- a/binary-field/src/lib.rs
+++ b/binary-field/src/lib.rs
@@ -8,12 +8,21 @@ mod challenger;
 mod clmul;
 mod extension;
 mod gf2;
+mod ghash;
+mod packed;
 pub mod poly_basis;
 mod tables;
 mod tower;
 
 pub use challenger::BinaryChallenger;
 pub use gf2::Gf2;
+pub use ghash::Ghash128;
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "vpclmulqdq",
+    any(target_feature = "avx2", target_feature = "avx512f")
+))]
+pub use packed::*;
 pub use tower::{
     BinaryField2, BinaryField4, BinaryField8, BinaryField16, BinaryField32, BinaryField64,
     BinaryField128, TowerLevel,

--- a/binary-field/src/packed/mod.rs
+++ b/binary-field/src/packed/mod.rs
@@ -1,0 +1,21 @@
+//! The SIMD packing of the polynomial-basis `GF(2^128)`.
+//!
+//! A packing exists only where the multiply reaches more than one 128-bit lane.
+//! Only the widest such register is used, so there is one packing per build.
+//!
+//! The tower representation has no packing.
+//! A product there is table lookups, which no vector unit widens.
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "vpclmulqdq",
+    any(target_feature = "avx2", target_feature = "avx512f")
+))]
+mod x86_64;
+
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "vpclmulqdq",
+    any(target_feature = "avx2", target_feature = "avx512f")
+))]
+pub use x86_64::PackedGhash128;

--- a/binary-field/src/packed/mod.rs
+++ b/binary-field/src/packed/mod.rs
@@ -13,9 +13,23 @@
 ))]
 mod x86_64;
 
+// Which type the field packs into, decided once here rather than at each use.
+#[cfg(all(
+    target_arch = "x86_64",
+    target_feature = "vpclmulqdq",
+    any(target_feature = "avx2", target_feature = "avx512f")
+))]
+pub(crate) use PackedGhash128 as Packing;
 #[cfg(all(
     target_arch = "x86_64",
     target_feature = "vpclmulqdq",
     any(target_feature = "avx2", target_feature = "avx512f")
 ))]
 pub use x86_64::PackedGhash128;
+
+#[cfg(not(all(
+    target_arch = "x86_64",
+    target_feature = "vpclmulqdq",
+    any(target_feature = "avx2", target_feature = "avx512f")
+)))]
+pub(crate) use crate::Ghash128 as Packing;

--- a/binary-field/src/packed/x86_64.rs
+++ b/binary-field/src/packed/x86_64.rs
@@ -37,7 +37,7 @@ const HIGH_BY_HIGH: i32 = 0x11;
 /// Selects the high quadword of the first operand and the low quadword of the second.
 const HIGH_BY_LOW: i32 = 0x01;
 
-/// Exchanges the two 32-bit halves of each quadword, which swaps the halves of each lane.
+/// Swaps the two quadwords of every lane, so `x ^ swap(x)` holds `x_lo ^ x_hi` in both halves.
 const SWAP_QUADWORDS: i32 = 0x4e;
 
 /// The 256-bit register, holding two field elements.
@@ -289,6 +289,12 @@ impl Mul for PackedGhash128 {
         // Karatsuba reaches the middle coefficient with one product instead of two.
         //
         //     middle = (a0 + a1)(b0 + b1) + a0 b0 + a1 b1
+        //
+        // The scalar kernel takes the schoolbook form instead.
+        // A wide carryless multiply has half the throughput of the 128-bit one on Zen 4 and
+        // Zen 5, so trading a product for two shuffles and three exclusive ors pays only here.
+        //
+        // Measured on Zen 5, four lanes: 0.47 ns per element against 0.55 for schoolbook.
         let mixed_x = lanes::xor(x, lanes::swap_halves(x));
         let mixed_y = lanes::xor(y, lanes::swap_halves(y));
         let middle = lanes::xor(

--- a/binary-field/src/packed/x86_64.rs
+++ b/binary-field/src/packed/x86_64.rs
@@ -1,0 +1,468 @@
+//! The packing of the polynomial-basis `GF(2^128)` over the wide carryless multiply.
+//!
+//! `VPCLMULQDQ` applies the carryless multiply to every 128-bit lane of a wide register.
+//! One field element is exactly one lane, so the scalar kernel becomes the packed one.
+//!
+//! Every other operation is exclusive or, a lane-local shift, or a permutation of lanes.
+//!
+//! Only the widest register the target supports is compiled.
+//! One width per build means everything below the lane wrappers is written once.
+
+use core::iter::{Product, Sum};
+use core::mem::transmute;
+use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAssign};
+
+use p3_field::op_assign_macros::{
+    impl_add_assign, impl_add_base_field, impl_div_methods, impl_mul_base_field, impl_mul_methods,
+    impl_packed_field_div, impl_packed_value, impl_rng, impl_sub_assign, impl_sub_base_field,
+    impl_sum_prod_base_field, ring_sum,
+};
+use p3_field::{
+    Algebra, Field, PackedField, PackedFieldPow2, PackedValue, PrimeCharacteristicRing,
+};
+use rand::distr::{Distribution, StandardUniform};
+use rand::{Rng, RngExt};
+
+use crate::clmul::TAIL_128;
+use crate::{Gf2, Ghash128};
+
+/// Selects the low quadword of both operands.
+///
+/// Bit 0 picks the half of the first argument, bit 4 the half of the second.
+const LOW_BY_LOW: i32 = 0x00;
+
+/// Selects the high quadword of both operands.
+const HIGH_BY_HIGH: i32 = 0x11;
+
+/// Selects the high quadword of the first operand and the low quadword of the second.
+const HIGH_BY_LOW: i32 = 0x01;
+
+/// Exchanges the two 32-bit halves of each quadword, which swaps the halves of each lane.
+const SWAP_QUADWORDS: i32 = 0x4e;
+
+/// The 256-bit register, holding two field elements.
+#[cfg(all(
+    target_feature = "avx2",
+    target_feature = "vpclmulqdq",
+    not(target_feature = "avx512f")
+))]
+mod lanes {
+    use core::arch::x86_64::{
+        __m256i, _mm256_clmulepi64_epi128, _mm256_setzero_si256, _mm256_shuffle_epi32,
+        _mm256_unpacklo_epi64, _mm256_xor_si256,
+    };
+
+    use p3_field::interleave::interleave_u128;
+
+    /// The register one packed value occupies.
+    pub(super) type Reg = __m256i;
+
+    /// Field elements per register.
+    pub(super) const WIDTH: usize = 2;
+
+    // SAFETY for every wrapper below: this module is compiled only when the target features
+    // its intrinsics require are enabled for the crate, which is what makes each call sound.
+
+    /// All lanes zero.
+    #[inline(always)]
+    pub(super) fn zero() -> Reg {
+        unsafe { _mm256_setzero_si256() }
+    }
+
+    /// Bitwise exclusive or.
+    #[inline(always)]
+    pub(super) fn xor(a: Reg, b: Reg) -> Reg {
+        unsafe { _mm256_xor_si256(a, b) }
+    }
+
+    /// The low quadword of each operand, paired within each lane.
+    #[inline(always)]
+    pub(super) fn unpack_low_64(a: Reg, b: Reg) -> Reg {
+        unsafe { _mm256_unpacklo_epi64(a, b) }
+    }
+
+    /// The carryless product of one quadword of each operand, in every lane.
+    #[inline(always)]
+    pub(super) fn clmul<const IMM: i32>(a: Reg, b: Reg) -> Reg {
+        unsafe { _mm256_clmulepi64_epi128::<IMM>(a, b) }
+    }
+
+    /// Exchanges the two halves of every lane.
+    #[inline(always)]
+    pub(super) fn swap_halves(a: Reg) -> Reg {
+        unsafe { _mm256_shuffle_epi32::<{ super::SWAP_QUADWORDS }>(a) }
+    }
+
+    /// Interleaves whole field elements between two registers.
+    ///
+    /// # Panics
+    /// Panics if the block length does not divide the width.
+    #[inline(always)]
+    pub(super) fn interleave(a: Reg, b: Reg, block_len: usize) -> (Reg, Reg) {
+        match block_len {
+            1 => interleave_u128(a, b),
+            WIDTH => (a, b),
+            _ => panic!("unsupported block_len"),
+        }
+    }
+}
+
+/// The 512-bit register, holding four field elements.
+#[cfg(all(target_feature = "avx512f", target_feature = "vpclmulqdq"))]
+mod lanes {
+    use core::arch::x86_64::{
+        __m512i, _mm512_clmulepi64_epi128, _mm512_setzero_si512, _mm512_shuffle_epi32,
+        _mm512_unpacklo_epi64, _mm512_xor_si512,
+    };
+
+    use p3_field::interleave::{interleave_u128, interleave_u256};
+
+    /// The register one packed value occupies.
+    pub(super) type Reg = __m512i;
+
+    /// Field elements per register.
+    pub(super) const WIDTH: usize = 4;
+
+    // SAFETY for every wrapper below: this module is compiled only when the target features
+    // its intrinsics require are enabled for the crate, which is what makes each call sound.
+
+    /// All lanes zero.
+    #[inline(always)]
+    pub(super) fn zero() -> Reg {
+        unsafe { _mm512_setzero_si512() }
+    }
+
+    /// Bitwise exclusive or.
+    #[inline(always)]
+    pub(super) fn xor(a: Reg, b: Reg) -> Reg {
+        unsafe { _mm512_xor_si512(a, b) }
+    }
+
+    /// The low quadword of each operand, paired within each lane.
+    #[inline(always)]
+    pub(super) fn unpack_low_64(a: Reg, b: Reg) -> Reg {
+        unsafe { _mm512_unpacklo_epi64(a, b) }
+    }
+
+    /// The carryless product of one quadword of each operand, in every lane.
+    #[inline(always)]
+    pub(super) fn clmul<const IMM: i32>(a: Reg, b: Reg) -> Reg {
+        unsafe { _mm512_clmulepi64_epi128::<IMM>(a, b) }
+    }
+
+    /// Exchanges the two halves of every lane.
+    #[inline(always)]
+    pub(super) fn swap_halves(a: Reg) -> Reg {
+        unsafe { _mm512_shuffle_epi32::<{ super::SWAP_QUADWORDS }>(a) }
+    }
+
+    /// Interleaves whole field elements between two registers.
+    ///
+    /// # Panics
+    /// Panics if the block length does not divide the width.
+    #[inline(always)]
+    pub(super) fn interleave(a: Reg, b: Reg, block_len: usize) -> (Reg, Reg) {
+        match block_len {
+            1 => interleave_u128(a, b),
+            2 => interleave_u256(a, b),
+            WIDTH => (a, b),
+            _ => panic!("unsupported block_len"),
+        }
+    }
+}
+
+use lanes::WIDTH;
+
+/// Several elements of the polynomial-basis `GF(2^128)`, one per 128-bit lane of a register.
+///
+/// Two under `AVX2`, four under `AVX-512`.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+// Needed to make the transmutes below sound.
+#[repr(transparent)]
+#[must_use]
+pub struct PackedGhash128([Ghash128; WIDTH]);
+
+impl PackedGhash128 {
+    /// The register holding these elements.
+    #[inline]
+    #[must_use]
+    fn to_vector(self) -> lanes::Reg {
+        // SAFETY: the scalar is `repr(transparent)` over `u128`, so the array is `WIDTH`
+        // contiguous `u128` values, which is the register's own layout.
+        // This type is `repr(transparent)` over that array.
+        unsafe { transmute(self) }
+    }
+
+    /// The elements held in a register.
+    #[inline]
+    fn from_vector(vector: lanes::Reg) -> Self {
+        // SAFETY: the inverse of the transmute above.
+        // Every bit pattern is a valid element, so no value can be out of range.
+        unsafe { transmute(vector) }
+    }
+
+    /// The same element in every lane.
+    #[inline]
+    const fn broadcast(value: Ghash128) -> Self {
+        Self([value; WIDTH])
+    }
+
+    /// The modulus tail in the low quadword of every lane.
+    #[inline]
+    fn tail() -> lanes::Reg {
+        // SAFETY: `u128` and one 128-bit lane have the same layout.
+        unsafe { transmute::<[u128; WIDTH], lanes::Reg>([TAIL_128; WIDTH]) }
+    }
+
+    /// One Horner step of the reduction, in every lane at once.
+    ///
+    /// Splitting the second argument into its 64-bit halves rewrites the part that overflows:
+    ///
+    /// ```text
+    ///     T  = x^7 + x^2 + x + 1                    the modulus tail, since x^128 = T
+    ///     t1 = t1_lo + t1_hi x^64
+    ///
+    ///     t1 x^64 = t1_lo x^64 + t1_hi T
+    /// ```
+    #[inline]
+    fn fold_shifted(t0: lanes::Reg, t1: lanes::Reg) -> lanes::Reg {
+        // Interleaving against zero moves the low quadword up, scaling by x^64.
+        let raised = lanes::unpack_low_64(lanes::zero(), t1);
+
+        // The high quadword times the tail is what the modulus rewrites.
+        let folded = lanes::clmul::<HIGH_BY_LOW>(t1, Self::tail());
+
+        lanes::xor(t0, lanes::xor(raised, folded))
+    }
+}
+
+impl From<Ghash128> for PackedGhash128 {
+    #[inline]
+    fn from(value: Ghash128) -> Self {
+        Self::broadcast(value)
+    }
+}
+
+impl Add for PackedGhash128 {
+    type Output = Self;
+
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn add(self, rhs: Self) -> Self {
+        // Addition in characteristic 2 is `XOR`, lane by lane.
+        Self::from_vector(lanes::xor(self.to_vector(), rhs.to_vector()))
+    }
+}
+
+impl Sub for PackedGhash128 {
+    type Output = Self;
+
+    #[inline]
+    #[allow(clippy::suspicious_arithmetic_impl)]
+    fn sub(self, rhs: Self) -> Self {
+        // Subtraction coincides with addition in characteristic 2.
+        self + rhs
+    }
+}
+
+impl Neg for PackedGhash128 {
+    type Output = Self;
+
+    #[inline]
+    fn neg(self) -> Self {
+        // `-x = x` in characteristic 2.
+        self
+    }
+}
+
+impl Mul for PackedGhash128 {
+    type Output = Self;
+
+    #[inline]
+    fn mul(self, rhs: Self) -> Self {
+        let (x, y) = (self.to_vector(), rhs.to_vector());
+
+        // The two diagonal half products.
+        let low = lanes::clmul::<LOW_BY_LOW>(x, y);
+        let high = lanes::clmul::<HIGH_BY_HIGH>(x, y);
+
+        // Karatsuba reaches the middle coefficient with one product instead of two.
+        //
+        //     middle = (a0 + a1)(b0 + b1) + a0 b0 + a1 b1
+        let mixed_x = lanes::xor(x, lanes::swap_halves(x));
+        let mixed_y = lanes::xor(y, lanes::swap_halves(y));
+        let middle = lanes::xor(
+            lanes::xor(low, high),
+            lanes::clmul::<LOW_BY_LOW>(mixed_x, mixed_y),
+        );
+
+        // Inner fold brings the top limb down, outer fold finishes the reduction.
+        Self::from_vector(Self::fold_shifted(low, Self::fold_shifted(middle, high)))
+    }
+}
+
+impl PrimeCharacteristicRing for PackedGhash128 {
+    type PrimeSubfield = Gf2;
+
+    const ZERO: Self = Self::broadcast(Ghash128::ZERO);
+    const ONE: Self = Self::broadcast(Ghash128::ONE);
+    // The characteristic is 2, so `TWO = ONE + ONE = ZERO`.
+    const TWO: Self = Self::broadcast(Ghash128::ZERO);
+    // The characteristic is 2, so `NEG_ONE = ONE`.
+    const NEG_ONE: Self = Self::broadcast(Ghash128::ONE);
+
+    #[inline]
+    fn from_prime_subfield(f: Self::PrimeSubfield) -> Self {
+        Self::broadcast(Ghash128::from_prime_subfield(f))
+    }
+
+    #[inline]
+    fn double(&self) -> Self {
+        // `a + a = 0` in characteristic 2.
+        Self::ZERO
+    }
+
+    /// # Panics
+    /// Always panics: `2` is not invertible in characteristic 2.
+    #[inline]
+    fn halve(&self) -> Self {
+        panic!("halve is undefined in characteristic 2")
+    }
+
+    #[inline]
+    fn square(&self) -> Self {
+        let x = self.to_vector();
+
+        // The cross term of `(p0 + p1 x^64)^2` doubles to zero, so the square has no middle
+        // coefficient and the inner fold has nothing to add to.
+        let low = lanes::clmul::<LOW_BY_LOW>(x, x);
+        let high = lanes::clmul::<HIGH_BY_HIGH>(x, x);
+        let folded = lanes::xor(
+            lanes::unpack_low_64(lanes::zero(), high),
+            lanes::clmul::<HIGH_BY_LOW>(high, Self::tail()),
+        );
+
+        Self::from_vector(Self::fold_shifted(low, folded))
+    }
+
+    #[inline]
+    fn dot_product<const N: usize>(u: &[Self; N], v: &[Self; N]) -> Self {
+        let (mut low, mut high, mut middle) = (lanes::zero(), lanes::zero(), lanes::zero());
+
+        for (a, b) in u.iter().zip(v) {
+            let (x, y) = (a.to_vector(), b.to_vector());
+
+            // Accumulate the three polynomial coefficients without reducing.
+            low = lanes::xor(low, lanes::clmul::<LOW_BY_LOW>(x, y));
+            high = lanes::xor(high, lanes::clmul::<HIGH_BY_HIGH>(x, y));
+
+            // Karatsuba's third product, from the sum of each operand's halves.
+            let mixed_x = lanes::xor(x, lanes::swap_halves(x));
+            let mixed_y = lanes::xor(y, lanes::swap_halves(y));
+            middle = lanes::xor(middle, lanes::clmul::<LOW_BY_LOW>(mixed_x, mixed_y));
+        }
+
+        // Remove the diagonal contributions from the accumulated third product.
+        middle = lanes::xor(middle, lanes::xor(low, high));
+
+        // Reduction is linear, so the whole sum folds the modulus once.
+        Self::from_vector(Self::fold_shifted(low, Self::fold_shifted(middle, high)))
+    }
+
+    #[inline]
+    fn xor(&self, y: &Self) -> Self {
+        *self + *y
+    }
+
+    #[inline]
+    fn mul_2exp_u64(&self, exp: u64) -> Self {
+        if exp == 0 { *self } else { Self::ZERO }
+    }
+
+    /// # Panics
+    /// Always panics: `2` is not invertible in characteristic 2.
+    #[inline]
+    fn div_2exp_u64(&self, _exp: u64) -> Self {
+        panic!("div_2exp_u64 is undefined in characteristic 2")
+    }
+}
+
+impl_add_assign!(PackedGhash128);
+impl_sub_assign!(PackedGhash128);
+impl_mul_methods!(PackedGhash128);
+ring_sum!(PackedGhash128);
+impl_rng!(PackedGhash128);
+
+impl_add_base_field!(PackedGhash128, Ghash128);
+impl_sub_base_field!(PackedGhash128, Ghash128);
+impl_mul_base_field!(PackedGhash128, Ghash128);
+impl_div_methods!(PackedGhash128, Ghash128);
+impl_packed_field_div!(PackedGhash128);
+impl_sum_prod_base_field!(PackedGhash128, Ghash128);
+
+impl Algebra<Ghash128> for PackedGhash128 {}
+
+impl From<Gf2> for PackedGhash128 {
+    /// `GF(2)` is the prime subfield, embedded as `{ZERO, ONE}` in every lane.
+    #[inline]
+    fn from(x: Gf2) -> Self {
+        Self::from_prime_subfield(x)
+    }
+}
+
+impl_add_base_field!(PackedGhash128, Gf2);
+impl_sub_base_field!(PackedGhash128, Gf2);
+impl_mul_base_field!(PackedGhash128, Gf2);
+
+impl Algebra<Gf2> for PackedGhash128 {}
+
+impl_packed_value!(PackedGhash128, Ghash128, WIDTH);
+
+// SAFETY: the transparent array satisfies the packed layout contract.
+// Arithmetic acts independently on each 128-bit field element.
+unsafe impl PackedField for PackedGhash128 {
+    type Scalar = Ghash128;
+}
+
+// SAFETY: the width is two or four, both powers of two.
+unsafe impl PackedFieldPow2 for PackedGhash128 {
+    /// # Panics
+    /// Panics if the block length does not divide the width.
+    #[inline]
+    fn interleave(&self, other: Self, block_len: usize) -> (Self, Self) {
+        let (a, b) = lanes::interleave(self.to_vector(), other.to_vector(), block_len);
+        (Self::from_vector(a), Self::from_vector(b))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_field::PackedValue;
+    use p3_field_testing::test_packed_binary_field;
+
+    use crate::{Ghash128, PackedGhash128};
+
+    /// The bit patterns a random search is unlikely to reach.
+    ///
+    /// Each one drives the fold of the modulus to an extreme:
+    ///
+    /// ```text
+    ///     0            nothing to reduce
+    ///     all ones     every coefficient of the product is live
+    ///     x^127        the highest degree, so the fold spills furthest
+    ///     0x87         the modulus tail itself
+    /// ```
+    const SPECIAL: [u128; 4] = [0, u128::MAX, 1 << 127, 0x87];
+
+    /// One extreme bit pattern per lane.
+    fn specials() -> PackedGhash128 {
+        PackedValue::from_fn(|i| Ghash128::from_le_bytes(SPECIAL[i].to_le_bytes()))
+    }
+
+    test_packed_binary_field!(
+        crate::PackedGhash128,
+        &[crate::PackedGhash128::ZERO],
+        &[crate::PackedGhash128::ONE],
+        super::specials()
+    );
+}

--- a/binary-field/src/poly_basis.rs
+++ b/binary-field/src/poly_basis.rs
@@ -1,25 +1,17 @@
-//! `GF(2^128)` in the polynomial basis of `x^128 + x^7 + x^2 + x + 1`.
+//! Raw polynomial coordinates for `GF(2^128)` modulo `x^128 + x^7 + x^2 + x + 1`.
 //!
-//! [`BinaryField128`] stores its elements in the tower basis, and a product there is a change of
-//! basis on each operand, a carryless multiply, and a change of basis back — three table-driven
-//! conversions of sixteen dependent lookups each, which dominate the multiply. Code that
-//! performs many products on the same data can pay the conversion once at each end instead, and
-//! multiply through [`mul`] in between.
+//! Prefer the typed field for ordinary arithmetic.
+//! These helpers are for buffers whose representation the caller manages.
 //!
-//! Addition is `XOR` in either basis, so a sum needs no conversion at all: only products and
-//! squares do, which is what this module supplies. An element is carried as the `u128` of its
-//! coordinates, deliberately not as a field type — the two bases are indistinguishable once
-//! wrapped, and a value that reaches ordinary [`BinaryField128`] arithmetic in the wrong one is
-//! silently wrong rather than ill-typed.
+//! The coordinates stay a bare integer on purpose.
+//! Wrapped, the two bases look alike, and a value in the wrong one is silently wrong.
 
 use crate::tower::TowerLevel;
 use crate::{BinaryField128, clmul};
 
-/// Whether [`mul`] and [`square`] compile down to a hardware carryless multiply.
+/// Whether multiplication and squaring use hardware carryless multiplication.
 ///
-/// Where they do not, the carryless product is the bit-serial fallback, which is far slower than
-/// the recursive tower arithmetic `BinaryField128` uses on such a target. Working in this basis
-/// is a loss there, so a caller choosing between the two representations should branch on this.
+/// Otherwise multiplication uses masked integer products and squaring uses bit spreading.
 pub const HAS_HARDWARE_CLMUL: bool = clmul::HAS_HARDWARE_CLMUL;
 
 /// The polynomial-basis coordinates of a tower element.
@@ -35,14 +27,10 @@ pub fn to_tower(v: u128) -> BinaryField128 {
     BinaryField128::from_repr(clmul::poly_to_tower_128(v))
 }
 
-/// The product of two elements, both given and returned in the polynomial basis.
-///
-/// This is tuned for throughput. Where the target has a vector kernel it takes it, which keeps
-/// the operands off the general-purpose registers and lets independent products overlap, at the
-/// cost of a longer critical path through each one. A caller that instead threads its products
-/// through a single dependent chain — Horner evaluation, successive powers of one element —
-/// should expect this to be slower per product than the chain-friendly route the tower-basis
-/// [`BinaryField128`] operator takes.
+/// Multiply two elements expressed in polynomial coordinates.
+// Only the software backend is `const`, so leaving this one out keeps the signature the same
+// on every target.
+#[allow(clippy::missing_const_for_fn)]
 #[must_use]
 #[inline]
 pub fn mul(a: u128, b: u128) -> u128 {
@@ -50,6 +38,7 @@ pub fn mul(a: u128, b: u128) -> u128 {
 }
 
 /// The square of an element, given and returned in the polynomial basis.
+#[allow(clippy::missing_const_for_fn)]
 #[must_use]
 #[inline]
 pub fn square(a: u128) -> u128 {

--- a/binary-field/src/tower.rs
+++ b/binary-field/src/tower.rs
@@ -34,19 +34,29 @@ use crate::{Gf2, tables};
 /// `cantor_basis` is *the* Cantor basis — `v_0 = 1` and `v_i² + v_i = v_{i−1}` — not merely some
 /// `F_2`-linearly independent sequence. An external implementation satisfying none of that would
 /// fail silently, with wrong evaluations rather than a compile error, wherever those assume it.
-mod private {
+pub(crate) mod private {
     pub trait Sealed {}
 }
 
-/// One level of the Wiedemann tower. `Repr` is the backing integer; `LOG_BITS` is `k` for `GF(2^(2^k))`.
+/// One level of the Wiedemann tower, `GF(2^(2^k))`, in whichever basis carries it.
+///
+/// The tower fixes each level as an abstract field, not as a set of bit patterns.
+///
+/// An implementation may hold its elements in any `F_2`-basis of that field.
+/// What it may not do is report a Cantor basis other than the image of the tower's own.
+///
+/// That is what makes every transform agree whichever representation runs it.
 pub trait TowerLevel: Field + private::Sealed {
+    /// The backing integer of an element.
     type Repr: Copy;
+
+    /// The `k` in `GF(2^(2^k))`.
     const LOG_BITS: usize;
     /// Build an element from a bit pattern, discarding the bits above `2^LOG_BITS`.
     fn from_repr(r: Self::Repr) -> Self;
     /// The bit pattern of this element, zero above `2^LOG_BITS`.
     fn to_repr(self) -> Self::Repr;
-    /// Multiply by the generator `X_{k−1}` of this level over the one below.
+    /// Multiply by the tower's generator `X_{k−1}` of this level over the one below.
     fn mul_alpha(self) -> Self;
     /// Build an element from the next [`RawDataSerializable::NUM_BYTES`] bytes of a
     /// little-endian byte stream, discarding the bits above `2^LOG_BITS`.

--- a/binary-field/tests/field.rs
+++ b/binary-field/tests/field.rs
@@ -242,6 +242,42 @@ mod binary_field_128 {
     );
 }
 
+/// The same field as the widest tower level, in the polynomial basis of the GHASH modulus.
+///
+/// None of its arithmetic is shared with the tower's, so it runs the whole base suite.
+mod ghash_128 {
+    use num_bigint::BigUint;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field_testing::test_binary_field;
+
+    type F = p3_binary_field::Ghash128;
+
+    const ZEROS: [F; 1] = [F::ZERO];
+    const ONES: [F; 1] = [F::ONE];
+
+    /// Prime factorization of `2^128 - 1`.
+    fn multiplicative_group_prime_factorization() -> [(BigUint, u32); 9] {
+        [
+            (BigUint::from(3u32), 1),
+            (BigUint::from(5u32), 1),
+            (BigUint::from(17u32), 1),
+            (BigUint::from(257u32), 1),
+            (BigUint::from(641u32), 1),
+            (BigUint::from(65537u32), 1),
+            (BigUint::from(274177u32), 1),
+            (BigUint::from(6700417u32), 1),
+            (BigUint::from(67280421310721u64), 1),
+        ]
+    }
+
+    test_binary_field!(
+        super::F,
+        &super::ZEROS,
+        &super::ONES,
+        &super::multiplicative_group_prime_factorization()
+    );
+}
+
 mod gf2_16_over_gf2_8 {
     use p3_field_testing::{test_extension_field, test_frobenius};
 

--- a/binary-field/tests/ghash.rs
+++ b/binary-field/tests/ghash.rs
@@ -1,0 +1,99 @@
+//! Independent vectors and boundary coverage for polynomial-basis arithmetic.
+
+use core::array;
+
+use p3_binary_field::{Gf2, Ghash128};
+use p3_field::{Field, PackedField, PackedValue, PrimeCharacteristicRing};
+use proptest::prelude::*;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+/// Read a NIST block written as a big-endian integer into polynomial coordinates.
+const fn nist_block(block: u128) -> Ghash128 {
+    // NIST assigns x^0 to the leftmost bit.
+    // Polynomial coordinates assign it to the low bit.
+    Ghash128::from_le_bytes(block.reverse_bits().to_le_bytes())
+}
+
+#[test]
+fn nist_gcm_aes128_example_2() {
+    // Source: NIST GCM examples, GCM-AES128 Example #2, pages 2–3.
+    // https://csrc.nist.gov/CSRC/media/Projects/Cryptographic-Standards-and-Guidelines/documents/examples/AES_GCM.pdf
+    let h = nist_block(0xb83b533708bf535d0aa6e52980d53b78);
+    let blocks = [
+        0x42831ec2217774244b7221b784d0d49c,
+        0xe3aa212f2c02a4e035c17e2329aca12e,
+        0x21d514b25466931c7d8f6a5aac84aa05,
+        0x1ba30b396a0aac973d58e091473f5985,
+        // No associated data; 512 ciphertext bits in the final length block.
+        512,
+    ];
+
+    // GHASH absorbs each block by adding it and multiplying by the authentication key.
+    let result = blocks
+        .into_iter()
+        .fold(Ghash128::ZERO, |acc, block| (acc + nist_block(block)) * h);
+    assert_eq!(result, nist_block(0x7f1b32b81b820d02614f8895ac1d4eac));
+}
+
+/// Check every lane against independently reduced scalar products.
+fn check_dot<P: PackedField<Scalar = Ghash128> + Eq, const N: usize>(seed: u64) {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    // Different values in adjacent lanes expose accidental cross-lane carries.
+    let a: [P; N] = array::from_fn(|_| P::from_fn(|_| rng.random()));
+    let b: [P; N] = array::from_fn(|_| P::from_fn(|_| rng.random()));
+    let actual = P::dot_product(&a, &b);
+    for lane in 0..P::WIDTH {
+        let expected: Ghash128 = a
+            .iter()
+            .zip(&b)
+            .map(|(x, y)| x.as_slice()[lane] * y.as_slice()[lane])
+            .sum();
+        assert_eq!(actual.as_slice()[lane], expected);
+    }
+}
+
+/// Check one packing over the accumulation lengths that exercise each code path.
+///
+/// The length is a const generic, so the cases are spelled out rather than looped over.
+fn check_dot_lengths<P: PackedField<Scalar = Ghash128> + Eq>(seed: u64) {
+    // Empty, singleton, odd, and two longer runs.
+    check_dot::<P, 0>(seed);
+    check_dot::<P, 1>(seed);
+    check_dot::<P, 3>(seed);
+    check_dot::<P, 16>(seed);
+    check_dot::<P, 65>(seed);
+}
+
+proptest! {
+    #[test]
+    fn dot_products_match_scalar_reduction(seed: u64) {
+        // A scalar is a width-one packing, so both go through the same checks.
+        check_dot_lengths::<Ghash128>(seed);
+        check_dot_lengths::<<Ghash128 as Field>::Packing>(seed);
+    }
+}
+
+#[test]
+fn dot_product_cancellation_and_extremes() {
+    type P = <Ghash128 as Field>::Packing;
+    // Shift the extreme values between lanes so every lane sees every boundary.
+    let extremes = [0, 1, u128::MAX, 1 << 127, 1 << 64, u64::MAX as u128, 0x87];
+    for offset in 0..extremes.len() {
+        let a = P::from_fn(|i| {
+            Ghash128::from_le_bytes(extremes[(offset + i) % extremes.len()].to_le_bytes())
+        });
+        let b = P::from_fn(|i| {
+            Ghash128::from_le_bytes(extremes[(offset + i + 1) % extremes.len()].to_le_bytes())
+        });
+        // Two identical products cancel before reduction in characteristic two.
+        assert_eq!(P::dot_product(&[a, a], &[b, b]), P::ZERO);
+        assert_eq!(P::dot_product(&[a, a, a], &[b, b, b]), a * b);
+    }
+}
+
+#[test]
+fn packed_property_suite_supports_zero_in_small_fields() {
+    // Half the random GF(2) denominators are zero; the suite must handle them explicitly.
+    p3_field_testing::test_packed_vs_scalar_proptest::<Gf2>();
+}

--- a/field-testing/src/lib.rs
+++ b/field-testing/src/lib.rs
@@ -1594,41 +1594,46 @@ macro_rules! test_field {
     };
 }
 
-/// A [`test_field!`]-equivalent suite for fields of characteristic 2.
+/// The ring suite, for a ring of characteristic 2.
 ///
-/// `PrimeCharacteristicRing::{halve, div_2exp_u64}` are documented to panic
-/// unconditionally in characteristic 2, so this replaces [`test_div_2exp_u64`] with
-/// [`test_halve_panics_char2`] and [`test_div_2exp_u64_panics_char2`], which pin that
-/// panic, and swaps every other halve-dependent (or otherwise characteristic-2-degenerate)
-/// check for a characteristic-2-safe sibling (`test_ring_with_eq_char2`,
-/// `test_mul_2exp_u64_is_zero_above_e0`, `test_inverse_char2`, `test_sqrt_char2`,
-/// `test_powers_collect_char2`, `test_ring_axioms_proptest_char2`,
-/// `test_field_axioms_proptest_char2`).
+/// Halving and dividing by a power of two are undefined there.
+///
+/// This pins their panic rather than exercising them.
 #[macro_export]
-macro_rules! test_binary_field {
-    ($field:ty, $zeros: expr, $ones: expr, $factors: expr) => {
+macro_rules! test_ring_with_eq_char2 {
+    ($ring:ty, $zeros: expr, $ones: expr) => {
         mod ring_tests {
             use p3_field::PrimeCharacteristicRing;
 
             #[test]
             fn test_ring_with_eq() {
-                $crate::test_ring_with_eq_char2::<$field>($zeros, $ones);
+                $crate::test_ring_with_eq_char2::<$ring>($zeros, $ones);
             }
             #[test]
             fn test_mul_2exp_u64() {
-                $crate::test_mul_2exp_u64_is_zero_above_e0::<$field>();
+                $crate::test_mul_2exp_u64_is_zero_above_e0::<$ring>();
             }
             #[test]
             #[should_panic]
             fn test_halve_panics() {
-                $crate::test_halve_panics_char2::<$field>();
+                $crate::test_halve_panics_char2::<$ring>();
             }
             #[test]
             #[should_panic]
             fn test_div_2exp_u64_panics() {
-                $crate::test_div_2exp_u64_panics_char2::<$field>();
+                $crate::test_div_2exp_u64_panics_char2::<$ring>();
             }
         }
+    };
+}
+
+/// The full field suite, for a field of characteristic 2.
+///
+/// Every check that halving would reach is swapped for its characteristic-2 sibling.
+#[macro_export]
+macro_rules! test_binary_field {
+    ($field:ty, $zeros: expr, $ones: expr, $factors: expr) => {
+        $crate::test_ring_with_eq_char2!($field, $zeros, $ones);
 
         mod field_tests {
             #[test]

--- a/field-testing/src/packedfield_testing.rs
+++ b/field-testing/src/packedfield_testing.rs
@@ -910,7 +910,13 @@ where
         let sum = a + b;
         let diff = a - b;
         let prod = a * b;
-        let quot = a / b;
+        // Division requires a nonzero denominator in every lane.
+        // Keep the original operands for the other operations, including zero products.
+        let denominator = PF::from_fn(|i| {
+            let value = b.as_slice()[i];
+            if value.is_zero() { PF::Scalar::ONE } else { value }
+        });
+        let quot = a / denominator;
         let neg_a = -a;
 
         let sum = sum.as_slice();
@@ -928,7 +934,7 @@ where
                 "sub mismatch at lane {}", i);
             prop_assert_eq!(prod[i], a[i] * b[i],
                 "mul mismatch at lane {}", i);
-            prop_assert_eq!(quot[i], a[i] / b[i],
+            prop_assert_eq!(quot[i], a[i] / denominator.as_slice()[i],
                 "div mismatch at lane {}", i);
             prop_assert_eq!(neg_a[i], -a[i],
                 "neg mismatch at lane {}", i);
@@ -936,11 +942,12 @@ where
     });
 }
 
+/// Everything a packing must satisfy beyond being a ring.
+///
+/// Held apart from the ring suite so a characteristic-2 packing can pair it with its own.
 #[macro_export]
-macro_rules! test_packed_field {
-    ($packedfield:ty, $zeros:expr, $ones:expr, $specials:expr) => {
-        $crate::test_ring_with_eq!($packedfield, $zeros, $ones);
-
+macro_rules! test_packed_field_ops {
+    ($packedfield:ty, $specials:expr) => {
         mod packed_field_tests {
             use p3_field::PrimeCharacteristicRing;
 
@@ -989,6 +996,25 @@ macro_rules! test_packed_field {
                 $crate::test_packed_vs_scalar_proptest::<$packedfield>();
             }
         }
+    };
+}
+
+#[macro_export]
+macro_rules! test_packed_field {
+    ($packedfield:ty, $zeros:expr, $ones:expr, $specials:expr) => {
+        $crate::test_ring_with_eq!($packedfield, $zeros, $ones);
+        $crate::test_packed_field_ops!($packedfield, $specials);
+    };
+}
+
+/// The full packing suite, for a packing of a field of characteristic 2.
+///
+/// Only the ring half differs: halving and dividing by a power of two panic there.
+#[macro_export]
+macro_rules! test_packed_binary_field {
+    ($packedfield:ty, $zeros:expr, $ones:expr, $specials:expr) => {
+        $crate::test_ring_with_eq_char2!($packedfield, $zeros, $ones);
+        $crate::test_packed_field_ops!($packedfield, $specials);
     };
 }
 


### PR DESCRIPTION
## What a "basis" is here, and why it costs

`GF(2^128)` is a field with `2^128` elements. Every element is 128 bits, and addition is just
`XOR`. Multiplication is where the choices live.

To multiply, you first have to say *what the 128 bits mean*. A basis is that answer: it fixes
128 fixed elements `e_0 … e_127`, and bit `i` of the integer says whether `e_i` is part of the
element. Different bases describe the same field, but they make different operations cheap.

`BinaryField128` uses the **tower basis**, where the `e_i` are products of nested generators.
This is what makes `GF(2^8)`, `GF(2^16)`, `GF(2^32)` and `GF(2^64)` sit inside it as clean byte
slices — which ring switching and small-field witnesses rely on.

Hardware does not multiply in that basis. `PCLMULQDQ` on x86 and `PMULL` on AArch64 multiply in
the **polynomial basis**, where `e_i` is just `x^i` and elements are polynomials reduced modulo
`x^128 + x^7 + x^2 + x + 1`.

So today, one tower multiply looks like this:

```text
    a (tower)  --16 table lookups-->  a (polynomial)  --.
                                                        |--> 1 carryless multiply --> product
    b (tower)  --16 table lookups-->  b (polynomial)  --'          |
                                                                   |
                             product (tower)  <--16 table lookups--'
```

Forty-eight dependent table lookups wrapped around a single instruction. The conversions, not
the multiply, are the cost.

## The change

`Ghash128` is that same field, held in the polynomial basis from the start. Nothing converts,
because nothing needs to.

It is a full `Field`, so it works anywhere a Plonky3 field works. It also implements
`TowerLevel`, so the additive NTT in `p3-binary-dft` runs over it with no changes. `From`
conversions relate it to `BinaryField128` in both directions, at about 3.5 ns, so code can hold
data in whichever representation suits the step it is in.

### A worked example

Take `x`, the element whose only set bit is bit 1 — the polynomial `x` itself. Squaring it
gives `x^2`, so bit 2. Keep squaring and you climb: `x^4`, `x^8`, … up to `x^64`. Square once
more and you reach `x^128`, which is too big for 128 bits. That is exactly what the modulus is
for: it says `x^128 = x^7 + x^2 + x + 1`, so the answer wraps around to `0x87`.

Every routine in this PR is a way of doing that wrap efficiently. The multiply folds it with a
second carryless product instead of a shift; the square root runs it backwards; inversion
chains it.

## What is in it

- **`Ghash128`** — the scalar field, with derived rather than transcribed constants: its
  generator and its Cantor basis are computed at compile time as the images of the tower's, so
  both representations provably span the same NTT domain.
- **`PackedGhash128`** — two elements per register on `avx2` and four on `avx512f`, in both
  cases over `VPCLMULQDQ`, wired as `Ghash128::Packing`. One element is exactly one 128-bit
  lane, so the scalar kernel becomes the packed one unchanged.
- **Three backends** for product, square, square root, inverse and dot product: `pclmulqdq`,
  AArch64 `aes`, and software.
- **Square roots in one product.** A square interleaves the input's coefficients with zeros, so
  a square root un-interleaves them. Separating even from odd coefficients recovers the root
  with a single multiply instead of 127 squarings.
- **Inversion by addition chain.** The inverse is `x^(2^128 - 2)`. Squaring `2^k` times is a
  linear map, so the five maps the chain needs are tabulated at compile time.
- **Dot products that reduce once.** Reduction is linear, so a sum of products can accumulate
  unreduced and fold the modulus a single time at the end.
- **Packed butterflies** in `p3-binary-dft`: the NTT inner loop now runs over `F::Packing` with
  a scalar tail, which is what carries the packed multiply into the transform.
- The **software carryless multiply** replaces a 64-iteration bit-serial loop with the masked
  integer-multiply construction. It is compiled on every target, not only where it is used, so
  its carry argument is tested everywhere.

## Numbers

AMD Ryzen 9 9950X3D, `-C target-cpu=native`. Per element unless stated.

Against `BinaryField128`, which is the same field in the other basis:

| operation | tower | `Ghash128` | |
| --- | --- | --- | --- |
| multiply, dependent chain | 19.8 ns | 3.55 ns | 5.6x |
| multiply, independent | 15.3 ns | 2.17 ns | 7.1x |
| multiply, packed 4 wide | 15.3 ns | 0.47 ns | 33x |
| square | 14.1 ns | 4.49 ns | 3.1x |

The other two are new operations, so they are measured against the obvious way to write them:

- **inverse**, 88.8 ns, against 125 ns for converting to the tower and inverting there.
- **square root**, 5.73 ns, against 510 ns for raising to the power `2^127`.

Dot products, per call, deferred reduction against separately reduced products. The packed
column holds four elements per entry, so its 64-entry row is 256 products:

| entries | scalar | packed |
| --- | --- | --- |
| 4 | 10.7 → 6.7 ns | 10.2 → 7.1 ns |
| 16 | 47.0 → 25.8 ns | 38.1 → 27.5 ns |
| 64 | 192 → 90.0 ns | 143 → 72.4 ns |

Additive NTT, width 16, `parallel`, in milliseconds:

| log n | tower | `Ghash128` | |
| --- | --- | --- | --- |
| 14 | 2.31 | 0.87 | 2.6x |
| 16 | 7.77 | 2.63 | 3.0x |
| 18 | 32.8 | 12.2 | 2.7x |
| 20 | 186 | 181 | memory bound |

## Correctness

Every backend is checked against bit-serial reduction taken straight from the modulus, which
depends on no instruction and no table. On top of that:

- The full `test_binary_field!` and `test_packed_binary_field!` suites.
- A **NIST GCM known-answer vector**, which pins the field against a published specification
  rather than against our own code.
- The change of basis is checked to be a *ring* homomorphism, not merely invertible —
  multiplicativity is the part a change of coordinates does not give you for free.
- The NTT over `Ghash128` is checked to equal the NTT over `BinaryField128` under that change
  of basis. Since the transform is built from twiddle multiplies, this pins the whole
  polynomial-basis arithmetic one butterfly at a time.
- The Cantor basis is checked against its defining recurrence and for linear independence.
- Odd matrix widths and heights crossing the task boundary, so the packed prefix and the scalar
  tail are both exercised.

Verified on AVX-512, AVX2-only and a build with no carryless multiply at all; cross-compiled
for AArch64 and wasm32. `clippy --workspace --all-targets`, `fmt` and `rustdoc` are clean, and
the workspace suite passes.

## What this does not do

`Ghash128` has no byte-aligned subfields. `GF(2^8)` and friends live inside the tower
representation and not inside this one, so anything that needs the subfield structure should
stay on `BinaryField128`. No existing public API changes.

Two things worth a reviewer's attention:

- Inversion, the tower arithmetic and the conversions between bases all use operand-indexed
  tables, so they are not constant-time. The multiply, square, square root and dot product are.
  This is stated in the crate README.
- Inversion's Frobenius maps are 320 KiB of read-only tables. They are compiled only where a
  carryless multiply exists; everywhere else the tower norm is faster anyway, so the module is
  not built at all. Checked on `thumbv7em-none-eabi`, which CI compiles this crate for.

