### PR TITLE
feat(binary-pcs): multilinear commitment over binary tower fields

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -8,6 +8,7 @@ on:
     branches: [ "*" ]
     paths:
       - "whir/src/**"
+      - "binary-pcs/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -48,3 +49,17 @@ jobs:
 
       - name: Test WHIR exhaustive sweep with parallel
         run: cargo test -p p3-whir --features parallel pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact
+
+  binary_pcs_large_configuration:
+    name: binary-pcs 2^16 round trip
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Test the 2^16 round trip
+        run: cargo test -p p3-binary-pcs --release --test end_to_end large_configuration_2_16_round_trips -- --ignored --exact

--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -59,6 +59,12 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Set flags
+        # No x86_64 target carries carry-less multiply in its baseline, so without this the
+        # runner falls back to recursive tower multiplication and the job measures that
+        # instead. Appended to the existing flags so we keep -C debuginfo=0.
+        run: echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=+pclmulqdq" >> "$GITHUB_ENV"
+
       - uses: Swatinem/rust-cache@v2
 
       - name: Test the 2^16 round trip

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "batch-stark",
     "binary-dft",
     "binary-field",
+    "binary-pcs",
     "blake3",
     "blake3-air",
     "bn254",
@@ -108,6 +109,7 @@ p3-air = { path = "air", version = "0.7.0" }
 p3-baby-bear = { path = "baby-bear", version = "0.7.0" }
 p3-binary-dft = { path = "binary-dft", version = "0.7.0" }
 p3-binary-field = { path = "binary-field", version = "0.7.0" }
+p3-binary-pcs = { path = "binary-pcs", version = "0.7.0" }
 p3-blake3 = { path = "blake3", version = "0.7.0" }
 p3-blake3-air = { path = "blake3-air", version = "0.7.0" }
 p3-bn254 = { path = "bn254", version = "0.7.0" }

--- a/binary-pcs/Cargo.toml
+++ b/binary-pcs/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "p3-binary-pcs"
+description = "Multilinear polynomial commitment over Plonky3 binary tower fields, via additive-domain proximity"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
+# criterion pulls rayon transitively and rayon does not build on wasi.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion.workspace = true
+
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
+[dependencies]
+p3-binary-dft.workspace = true
+p3-binary-field.workspace = true
+p3-challenger.workspace = true
+p3-commit.workspace = true
+p3-field.workspace = true
+p3-matrix.workspace = true
+p3-maybe-rayon.workspace = true
+p3-multilinear-util.workspace = true
+p3-security.workspace = true
+p3-sumcheck.workspace = true
+p3-util.workspace = true
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+
+[dev-dependencies]
+p3-keccak = { path = "../keccak" }
+p3-merkle-tree = { path = "../merkle-tree" }
+p3-symmetric = { path = "../symmetric" }
+
+postcard = { workspace = true, features = ["alloc"] }
+proptest.workspace = true
+rand.workspace = true
+
+[[bench]]
+name = "pcs"
+harness = false
+
+[lints]
+workspace = true

--- a/binary-pcs/README.md
+++ b/binary-pcs/README.md
@@ -1,0 +1,15 @@
+# p3-binary-pcs
+
+A multilinear polynomial commitment scheme over `BinaryField128`, committing via an
+additive-domain Reed–Solomon code (the Cantor domain from `p3-binary-dft`) and proving
+proximity BaseFold-style, folding the codeword in lockstep with a multilinear sumcheck. See
+Diamond, Posen, *Succinct Arguments over Towers of Binary Fields* (Binius),
+<https://eprint.iacr.org/2023/1784>, and Diamond, Posen, *Polylogarithmic Proofs for
+Multilinears over Binary Towers* (FRI-Binius, ring switching),
+<https://eprint.iacr.org/2024/504>. Parameters are derived only in the unique-decoding regime.
+The capacity bound is refuted over characteristic 2 with `F_2`-subspace domains, and the Cantor
+domain is one. The Johnson bound is not refuted — it is an unconditional theorem whose radius
+those same counterexamples show to be tight — but `p3-security` documents it as resting on a
+correlated-agreement conjecture, and it is excluded here by choice, not by mathematics.
+
+Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.

--- a/binary-pcs/benches/pcs.rs
+++ b/binary-pcs/benches/pcs.rs
@@ -27,7 +27,7 @@ type MyHash = SerializingHasher<Keccak256Hash>;
 type MyCompress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
 type MyMmcs = MerkleTreeMmcs<F, u8, MyHash, MyCompress, 2, 32>;
 type MyChallenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
-type MyPcs = BinaryPcs<MyMmcs, SuffixProver<F, F>>;
+type MyPcs = BinaryPcs<MyMmcs>;
 
 /// The polynomial arities under test.
 const NUMS_VARIABLES: [usize; 3] = [16, 18, 20];
@@ -54,7 +54,7 @@ fn make_pcs(num_variables: usize) -> MyPcs {
         pow_bits: POW_BITS,
         security_level: SECURITY_LEVEL,
     };
-    let config = BinaryPcsConfig::try_new(num_variables, 0, params).unwrap();
+    let config = BinaryPcsConfig::try_new(num_variables, params).unwrap();
     BinaryPcs::new(config, mmcs())
 }
 

--- a/binary-pcs/benches/pcs.rs
+++ b/binary-pcs/benches/pcs.rs
@@ -1,0 +1,200 @@
+//! `commit`, `open`, `verify` and `fold_codeword` across `num_variables` in `{16, 18, 20}`, all
+//! through `SuffixProver` at `folding = 0`, the only configuration this crate's commit phase
+//! accepts.
+//!
+//! Every group uses `BatchSize::PerIteration`: under `BatchSize::LargeInput` the batch size
+//! Criterion allocates scales with the iteration count, so two arms measured at different
+//! iteration counts end up under different memory pressure and the comparison can invert.
+//! `bench_verify` also prints each proof's `postcard` size to stderr, since under unique
+//! decoding the query count — not the polynomial arity — dominates proof size and is worth
+//! stating plainly.
+
+use criterion::{BatchSize, BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_binary_field::{BinaryChallenger, BinaryField128};
+use p3_binary_pcs::{BinaryPcs, BinaryPcsConfig, BinaryPcsParams, fold_codeword, fold_pair};
+use p3_challenger::HashChallenger;
+use p3_commit::MultilinearPcs;
+use p3_keccak::Keccak256Hash;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_sumcheck::layout::{Layout, SuffixProver, Table, Witness};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
+
+type F = BinaryField128;
+type MyHash = SerializingHasher<Keccak256Hash>;
+type MyCompress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
+type MyMmcs = MerkleTreeMmcs<F, u8, MyHash, MyCompress, 2, 32>;
+type MyChallenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
+type MyPcs = BinaryPcs<MyMmcs, SuffixProver<F, F>>;
+
+/// The polynomial arities under test.
+const NUMS_VARIABLES: [usize; 3] = [16, 18, 20];
+
+const LOG_INV_RATE: usize = 2;
+const POW_BITS: usize = 8;
+const SECURITY_LEVEL: usize = 100;
+
+const fn mmcs() -> MyMmcs {
+    MyMmcs::new(
+        MyHash::new(Keccak256Hash),
+        MyCompress::new(Keccak256Hash),
+        0,
+    )
+}
+
+const fn challenger() -> MyChallenger {
+    MyChallenger::from_hasher(Vec::new(), Keccak256Hash)
+}
+
+fn make_pcs(num_variables: usize) -> MyPcs {
+    let params = BinaryPcsParams {
+        log_inv_rate: LOG_INV_RATE,
+        pow_bits: POW_BITS,
+        security_level: SECURITY_LEVEL,
+    };
+    let config = BinaryPcsConfig::try_new(num_variables, 0, params).unwrap();
+    BinaryPcs::new(config, mmcs())
+}
+
+fn make_witness(num_variables: usize, seed: u64) -> Witness<F> {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let table = Table::rand(&mut rng, 1, num_variables);
+    SuffixProver::<F, F>::new_witness(vec![table], 0)
+}
+
+fn make_protocol(num_variables: usize) -> OpeningProtocol {
+    OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(num_variables, 1),
+        vec![OpeningBatch::new(vec![0], Vec::new())],
+    )])
+}
+
+fn bench_commit(c: &mut Criterion) {
+    let mut group = c.benchmark_group("commit");
+    group.sample_size(10);
+    for &num_variables in &NUMS_VARIABLES {
+        let pcs = make_pcs(num_variables);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_variables),
+            &num_variables,
+            |b, &num_variables| {
+                b.iter_batched(
+                    || (make_witness(num_variables, 0), challenger()),
+                    |(witness, mut ch)| pcs.commit(witness, &mut ch),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_open(c: &mut Criterion) {
+    let mut group = c.benchmark_group("open");
+    group.sample_size(10);
+    for &num_variables in &NUMS_VARIABLES {
+        let pcs = make_pcs(num_variables);
+        let protocol = make_protocol(num_variables);
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_variables),
+            &num_variables,
+            |b, &num_variables| {
+                b.iter_batched(
+                    || {
+                        let witness = make_witness(num_variables, 1);
+                        let mut ch = challenger();
+                        let (_commitment, prover_data) = pcs.commit(witness, &mut ch);
+                        (prover_data, protocol.clone(), ch)
+                    },
+                    |(prover_data, protocol, mut ch)| pcs.open(prover_data, protocol, &mut ch),
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+fn bench_verify(c: &mut Criterion) {
+    let mut group = c.benchmark_group("verify");
+    group.sample_size(10);
+    for &num_variables in &NUMS_VARIABLES {
+        let pcs = make_pcs(num_variables);
+        let protocol = make_protocol(num_variables);
+        let witness = make_witness(num_variables, 2);
+
+        let mut prover_challenger = challenger();
+        let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+        let proof = pcs.open(prover_data, protocol.clone(), &mut prover_challenger);
+
+        let proof_bytes = postcard::to_allocvec(&proof).unwrap().len();
+        eprintln!("pcs/proof_size/{num_variables}: {proof_bytes} bytes");
+
+        group.bench_with_input(
+            BenchmarkId::from_parameter(num_variables),
+            &num_variables,
+            |b, _| {
+                b.iter_batched(
+                    challenger,
+                    |mut ch| {
+                        pcs.verify(&commitment, &proof, &mut ch, protocol.clone())
+                            .expect("verification failed in benchmark");
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
+/// The per-pair form: one `domain_point` call per output symbol, exactly what `fold_pair`
+/// computes for a single query's verifier-side check. Benchmarked serially, alongside
+/// `fold_codeword`'s task-local XOR chain, so the two are compared under one measurement
+/// rather than one inferred from the other.
+fn fold_codeword_per_pair(codeword: &[F], beta: F) -> Vec<F> {
+    codeword
+        .chunks(2)
+        .enumerate()
+        .map(|(index, pair)| fold_pair(index, beta, pair[0], pair[1]))
+        .collect()
+}
+
+/// Folds a full base-round codeword (length `2^(num_variables + log_inv_rate)`) once, in both
+/// the chained and the per-pair form. This is the round every real proof spends the most time
+/// in. `fold_codeword` only borrows its input, so neither arm needs `iter_batched`'s per-call
+/// setup; `fold_codeword` produces half as many outputs as `codeword` has inputs, so per-output
+/// timing (not per-input-element) is what the ratio below is stated against.
+fn bench_fold_codeword(c: &mut Criterion) {
+    let mut group = c.benchmark_group("fold_codeword");
+    group.sample_size(10);
+    let mut rng = SmallRng::seed_from_u64(3);
+    for &num_variables in &NUMS_VARIABLES {
+        let len = 1usize << (num_variables + LOG_INV_RATE);
+        let codeword: Vec<F> = (0..len).map(|_| rng.random()).collect();
+        let beta: F = rng.random();
+
+        group.bench_with_input(
+            BenchmarkId::new("chained", num_variables),
+            &codeword,
+            |b, codeword| b.iter(|| fold_codeword(codeword, beta)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("per_pair", num_variables),
+            &codeword,
+            |b, codeword| b.iter(|| fold_codeword_per_pair(codeword, beta)),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_commit,
+    bench_open,
+    bench_verify,
+    bench_fold_codeword
+);
+criterion_main!(benches);

--- a/binary-pcs/src/error.rs
+++ b/binary-pcs/src/error.rs
@@ -1,0 +1,104 @@
+//! Typed reasons an opening proof was rejected.
+
+use thiserror::Error;
+
+/// Why an opening proof was rejected.
+///
+/// Derives [`thiserror::Error`] and [`Debug`] only — not `PartialEq`/`Eq`. [`p3_commit::Mmcs`]
+/// carries no such bound on `Error` for a general MMCS (`commit/src/mmcs.rs`), so the derive
+/// cannot apply here.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum BinaryPcsError<MmcsError> {
+    /// The proof carries a different number of intermediate folding rounds than the config
+    /// derives.
+    ///
+    /// Checked before any indexing into `rounds`, so a malformed proof is rejected rather
+    /// than desyncing the round loop that walks it.
+    #[error("expected {expected} folding rounds, proof carries {actual}")]
+    RoundCountMismatch { expected: usize, actual: usize },
+
+    /// A round opened a different number of rows than the sampled query count demands.
+    ///
+    /// Checked before any indexing into the opened rows, so a short or padded opening list
+    /// is rejected instead of being read out of bounds or silently truncated.
+    #[error("round {round} opened {actual} rows, expected {expected}")]
+    OpeningCountMismatch {
+        round: usize,
+        expected: usize,
+        actual: usize,
+    },
+
+    /// An opened row had the wrong width.
+    ///
+    /// Every committed round holds a width-1 codeword; a row of any other width would desync
+    /// the fold if it were read as-is rather than rejected up front.
+    #[error("round {round} row {query} has width {actual}, expected {expected}")]
+    RowWidthMismatch {
+        round: usize,
+        query: usize,
+        expected: usize,
+        actual: usize,
+    },
+
+    /// The final codeword's length disagrees with the fold schedule.
+    ///
+    /// Checked before any query reads from it, so an under- or over-sized final codeword is
+    /// rejected instead of being indexed out of bounds.
+    #[error("final codeword has {actual} symbols, expected {expected}")]
+    FinalCodewordLengthMismatch { expected: usize, actual: usize },
+
+    /// A Merkle multiproof did not verify.
+    #[error("Merkle opening failed in round {round}")]
+    MerkleFailed {
+        round: usize,
+        #[source]
+        source: MmcsError,
+    },
+
+    /// Folding the queried pair at one round does not reproduce the value read at the next
+    /// round (or, at the last round, in the final codeword).
+    ///
+    /// This is what ties every committed round to its neighbours; without it, a prover could
+    /// commit to codewords with no relation to one another at all.
+    #[error("round {round} query {query} is not the fold of the previous round")]
+    FoldMismatch { round: usize, query: usize },
+
+    /// The final codeword does not encode the value the sumcheck ended at.
+    #[error("the final codeword does not encode the sumcheck's final value")]
+    FinalCheck,
+
+    /// The grinding witness did not meet the demanded difficulty.
+    #[error("proof-of-work witness rejected")]
+    InvalidPowWitness,
+
+    /// The proof carries a different number of opening-protocol evaluation batches than the
+    /// public protocol schedules.
+    ///
+    /// Checked before any claim is registered, so a malformed proof is rejected before it can
+    /// desync the transcript one claim at a time.
+    #[error("expected {expected} opening batches, proof carries {actual}")]
+    OpeningBatchCountMismatch { expected: usize, actual: usize },
+
+    /// One opening batch has the wrong number of evaluations for its column list.
+    #[error("table {table_idx} opening expected {expected} evaluations, got {actual}")]
+    OpeningBatchSizeMismatch {
+        table_idx: usize,
+        expected: usize,
+        actual: usize,
+    },
+
+    /// The sumcheck transcript did not verify.
+    #[error(transparent)]
+    Sumcheck(#[from] p3_sumcheck::SumcheckError),
+
+    /// The proof's sumcheck data carries PoW witnesses.
+    ///
+    /// Every fold round runs at `pow_bits = 0` (see `prover::fold_rounds`), and the verifier
+    /// replays each round with a freshly built, always-empty `pow_witnesses` vector, so
+    /// whatever the proof carries here is read by nothing and bound to nothing: a third party
+    /// could mutate it and keep a valid proof. `p3_sumcheck::ring_switch` rejects a non-empty
+    /// `pow_witnesses` for the same reason.
+    #[error("the sumcheck data carries {actual} PoW witnesses, expected none")]
+    NonEmptyPowWitnesses { actual: usize },
+}

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -1,0 +1,268 @@
+//! Folding a codeword over the Cantor additive domain.
+//!
+//! A codeword symbol at domain point `x` and its partner at `x + v_0 = x + 1` determine the
+//! two halves of the novel-basis decomposition
+//!
+//! ```text
+//!     f(x) = f_0(W_1(x)) + x * f_1(W_1(x))
+//! ```
+//!
+//! so `f_1 = f(x) + f(x + 1)` and `f_0 = f(x) + x * f_1`. The fold at `beta` is the
+//! evaluation-basis combination `(1 - beta) * f_0 + beta * f_1`, which over characteristic 2 is
+//! `f_0 + beta * (f_0 + f_1)`. This combination is chosen because it is exactly what
+//! `Poly::fix_suffix_var` computes on the message: folding the codeword and binding the
+//! multilinear's lowest variable in the evaluation basis are the same operation, which is what
+//! lets the sumcheck and the codeword move in lockstep.
+//!
+//! Because `W_1(x) = x^2 + x` is `F_2`-linear with `W_1(v_0) = 0` and `W_1(v_i) = v_{i-1}`, and
+//! `domain_point` is `F_2`-linear too, `W_1(domain_point(i)) = domain_point(i >> 1)`: the folded
+//! domain is the same function at a halved index, so no per-round domain state is carried. The
+//! folding partners `domain_point(2j)` and `domain_point(2j + 1)` differ by `v_0 = 1`, so they
+//! are adjacent rows in memory.
+
+use alloc::vec::Vec;
+
+use p3_binary_dft::domain_point;
+use p3_binary_field::{BinaryField128, TowerLevel};
+use p3_field::PrimeCharacteristicRing;
+use p3_maybe_rayon::prelude::*;
+
+/// Fold one pair of the codeword.
+///
+/// `lo` is the symbol at `domain_point(2 * index)`, `hi` the one at `domain_point(2 * index + 1)`.
+#[inline]
+pub fn fold_pair(
+    index: usize,
+    beta: BinaryField128,
+    lo: BinaryField128,
+    hi: BinaryField128,
+) -> BinaryField128 {
+    let x: BinaryField128 = domain_point(index << 1);
+    let f1 = lo + hi;
+    let f0 = lo + x * f1;
+    f0 + beta * (f0 + f1)
+}
+
+/// Output pairs one parallel task chains together, opened by a single `domain_point` call.
+///
+/// Large enough that the task-opening `domain_point` call is amortised over many folds; small
+/// enough to leave real parallelism at every codeword length this crate exercises.
+const FOLD_GRAIN: usize = 1 << 10;
+
+/// The XOR step from `domain_point(2 * j)` to `domain_point(2 * (j + 1))`, indexed by
+/// `(j + 1).trailing_zeros()`.
+///
+/// `domain_point` is `F_2`-linear, and `j XOR (j + 1)` sets exactly the trailing ones of `j`
+/// together with the first zero bit above them — bits `0..=level` for `level =
+/// (j + 1).trailing_zeros()`. So `domain_point(2 * j) + domain_point(2 * (j + 1))` is
+/// `domain_point` of that same run of bits shifted up by one: the sum of `cantor_basis(1)`
+/// through `cantor_basis(level + 1)`. `steps[level]` is that sum, computed once and reused by
+/// every transition that lands at the same level.
+fn gray_chain_steps(num_pairs: usize) -> Vec<BinaryField128> {
+    let levels = num_pairs.next_power_of_two().trailing_zeros() as usize;
+    let mut steps = Vec::with_capacity(levels);
+    let mut acc = BinaryField128::ZERO;
+    for level in 0..levels {
+        acc += BinaryField128::cantor_basis(level + 1);
+        steps.push(acc);
+    }
+    steps
+}
+
+/// Fold a whole codeword, halving its length.
+///
+/// Each parallel task opens with one `domain_point` call, then chains it across the task's own
+/// pairs by adding a precomputed per-level `F_2`-linear step at each transition: `fold_pair`'s
+/// single per-call `domain_point` is the right form for one query's verifier-side check, but
+/// here the same value would otherwise be recomputed once per output symbol of the whole
+/// codeword.
+///
+/// # Panics
+///
+/// Panics if `codeword` has odd length. A codeword always has a power-of-two length, so an odd
+/// one means the caller has lost track of the round schedule.
+#[must_use]
+pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<BinaryField128> {
+    assert!(
+        codeword.len().is_multiple_of(2),
+        "codeword length must be even"
+    );
+
+    let num_pairs = codeword.len() / 2;
+    let steps = gray_chain_steps(num_pairs);
+
+    codeword
+        .par_chunks(2 * FOLD_GRAIN)
+        .enumerate()
+        .flat_map_iter(|(block, chunk)| {
+            let start = block * FOLD_GRAIN;
+            let mut x: BinaryField128 = domain_point(start << 1);
+            let steps = &steps;
+            chunk.chunks(2).enumerate().map(move |(offset, pair)| {
+                if offset != 0 {
+                    x += steps[(start + offset).trailing_zeros() as usize];
+                }
+                let (lo, hi) = (pair[0], pair[1]);
+                let f1 = lo + hi;
+                let f0 = lo + x * f1;
+                f0 + beta * (f0 + f1)
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec::Vec;
+
+    use p3_binary_dft::{AdditiveNtt, NaiveAdditiveNtt, domain_point};
+    use p3_binary_field::{BinaryField128, TowerLevel};
+    use p3_field::PrimeCharacteristicRing;
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_multilinear_util::poly::Poly;
+    use proptest::prelude::*;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+
+    use super::{fold_codeword, fold_pair};
+
+    /// Encode novel-basis coefficients over the additive domain, through the oracle.
+    ///
+    /// `NaiveAdditiveNtt` evaluates the definition directly and depends on no identity the
+    /// fold also relies on, so agreement between the two is real evidence rather than a
+    /// restatement.
+    fn encode(coeffs: &[BinaryField128]) -> Vec<BinaryField128> {
+        NaiveAdditiveNtt::<BinaryField128>::default()
+            .ntt_batch(RowMajorMatrix::new(coeffs.to_vec(), 1))
+            .values
+    }
+
+    #[test]
+    fn the_folded_domain_is_domain_point_at_halved_index() {
+        // W_1(x) = x^2 + x, and W_1(domain_point(i)) == domain_point(i >> 1).
+        for i in 0..512usize {
+            let x: BinaryField128 = domain_point(i);
+            assert_eq!(
+                x.square() + x,
+                domain_point::<BinaryField128>(i >> 1),
+                "i={i}"
+            );
+        }
+    }
+
+    #[test]
+    fn folding_partners_are_adjacent_and_differ_by_one() {
+        for j in 0..256usize {
+            let lo: BinaryField128 = domain_point(2 * j);
+            let hi: BinaryField128 = domain_point(2 * j + 1);
+            assert_eq!(lo + BinaryField128::ONE, hi, "j={j}");
+        }
+    }
+
+    /// Folding the codeword equals binding the message's lowest variable in the evaluation
+    /// basis (`Poly::fix_suffix_var`), for codewords blown up at several rates: every real
+    /// prover fold runs on one.
+    #[test]
+    fn folding_the_codeword_equals_binding_the_lowest_variable() {
+        let mut rng = SmallRng::seed_from_u64(0xF01D);
+        for log_inv_rate in 0..=2 {
+            for log_n in 1..=7 {
+                let n = 1usize << log_n;
+                for trial in 0..4 {
+                    let coeffs: Vec<BinaryField128> =
+                        (0..n).map(|_| rng.random::<BinaryField128>()).collect();
+                    let beta: BinaryField128 = rng.random();
+
+                    let mut message = coeffs.clone();
+                    message.resize(n << log_inv_rate, BinaryField128::ZERO);
+
+                    let bound = Poly::new(coeffs).fix_suffix_var(beta);
+                    let mut bound_message = bound.into_evals();
+                    bound_message.resize(bound_message.len() << log_inv_rate, BinaryField128::ZERO);
+
+                    assert_eq!(
+                        fold_codeword(&encode(&message), beta),
+                        encode(&bound_message),
+                        "log_inv_rate={log_inv_rate} log_n={log_n} trial={trial}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// The chained form must agree with `fold_pair`'s independent per-call computation at
+    /// every position, including across `FOLD_GRAIN`'s block boundary: 4096 codeword symbols
+    /// is 2048 pairs, past `FOLD_GRAIN`'s 1024, so this covers two full parallel tasks and
+    /// exercises the cross-block chaining — block-start `domain_point(start << 1)` plus
+    /// `(start + offset).trailing_zeros()` indexing — that a single-block codeword leaves
+    /// silent.
+    #[test]
+    fn the_pair_form_agrees_with_the_vector_form() {
+        let mut rng = SmallRng::seed_from_u64(0x9E37_79B9_7F4A_7C15);
+        let codeword: Vec<BinaryField128> = (0..4096).map(|_| rng.random()).collect();
+        let beta: BinaryField128 = rng.random();
+        let folded = fold_codeword(&codeword, beta);
+        for (j, &value) in folded.iter().enumerate() {
+            assert_eq!(
+                value,
+                fold_pair(j, beta, codeword[2 * j], codeword[2 * j + 1]),
+                "j={j}"
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "codeword length must be even")]
+    fn an_odd_length_codeword_is_rejected() {
+        let odd = [BinaryField128::ONE; 3];
+        let _ = fold_codeword(&odd, BinaryField128::ONE);
+    }
+
+    /// `f_0 + beta * f_1`, the novel-basis combination, is a different operation from
+    /// `fold_pair`'s evaluation-basis combination: the two differ by exactly `beta * f_0`, so
+    /// they agree only when that term vanishes.
+    #[test]
+    fn the_novel_basis_fold_is_a_different_operation() {
+        let mut rng = SmallRng::seed_from_u64(0x51DE);
+        let j = 5usize;
+        let x: BinaryField128 = domain_point(2 * j);
+        let lo: BinaryField128 = rng.random();
+        let hi: BinaryField128 = rng.random();
+        let beta: BinaryField128 = rng.random();
+
+        let f1 = lo + hi;
+        let f0 = lo + x * f1;
+        let novel_basis_fold = lo + (x + beta) * (lo + hi);
+
+        assert_eq!(
+            fold_pair(j, beta, lo, hi) + novel_basis_fold,
+            beta * f0,
+            "the evaluation-basis and novel-basis folds differ by beta * f_0"
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn folding_is_affine_in_the_challenge(
+            lo_raw: u128, hi_raw: u128, b0_raw: u128, b1_raw: u128, j in 0usize..64,
+        ) {
+            let lo = BinaryField128::from_repr(lo_raw);
+            let hi = BinaryField128::from_repr(hi_raw);
+            let b0 = BinaryField128::from_repr(b0_raw);
+            let b1 = BinaryField128::from_repr(b1_raw);
+            let x: BinaryField128 = domain_point(2 * j);
+            let f1 = lo + hi;
+            let f0 = lo + x * f1;
+
+            // fold(beta) = f0 + beta * (f0 + f1), so fold(b0) + fold(b1) == (b0 + b1) * (f0 + f1).
+            prop_assert_eq!(
+                fold_pair(j, b0, lo, hi) + fold_pair(j, b1, lo, hi),
+                (b0 + b1) * (f0 + f1)
+            );
+
+            // At beta = 0 the fold is f0, pinning fold_pair's internal domain index against one
+            // computed independently here.
+            prop_assert_eq!(fold_pair(j, BinaryField128::ZERO, lo, hi), f0);
+        }
+    }
+}

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -159,34 +159,47 @@ mod tests {
         }
     }
 
-    /// Folding the codeword equals binding the message's lowest variable in the evaluation
-    /// basis (`Poly::fix_suffix_var`), for codewords blown up at several rates: every real
-    /// prover fold runs on one.
-    #[test]
-    fn folding_the_codeword_equals_binding_the_lowest_variable() {
-        let mut rng = SmallRng::seed_from_u64(0xF01D);
-        for log_inv_rate in 0..=2 {
-            for log_n in 1..=7 {
-                let n = 1usize << log_n;
-                for trial in 0..4 {
-                    let coeffs: Vec<BinaryField128> =
-                        (0..n).map(|_| rng.random::<BinaryField128>()).collect();
-                    let beta: BinaryField128 = rng.random();
+    proptest! {
+        // Each case runs the naive oracle twice over a codeword of up to 512 symbols, so the
+        // per-case cost is far above a typical property test's; 64 cases still explore every
+        // (rate, length) pair many times over.
+        #![proptest_config(ProptestConfig::with_cases(64))]
 
-                    let mut message = coeffs.clone();
-                    message.resize(n << log_inv_rate, BinaryField128::ZERO);
+        /// The crate's central identity: folding the codeword equals binding the message's
+        /// lowest variable in the evaluation basis (`Poly::fix_suffix_var`).
+        ///
+        /// The oracle is [`NaiveAdditiveNtt`], which evaluates the definition directly and
+        /// shares no identity with the fold, so agreement is evidence rather than restatement.
+        /// `log_n` and `log_inv_rate` are generated rather than swept because the identity is
+        /// claimed for every message length and every blowup a prover can configure, not for a
+        /// chosen list; every real prover fold runs on a blown-up codeword, so rate 0 is the
+        /// degenerate end of the range rather than the case of interest.
+        #[test]
+        fn folding_the_codeword_equals_binding_the_lowest_variable(
+            log_inv_rate in 0usize..=2,
+            log_n in 1usize..=7,
+            raw in prop::collection::vec(any::<u128>(), 128),
+            beta_raw: u128,
+        ) {
+            let n = 1usize << log_n;
+            let coeffs: Vec<BinaryField128> = raw[..n]
+                .iter()
+                .copied()
+                .map(BinaryField128::from_repr)
+                .collect();
+            let beta = BinaryField128::from_repr(beta_raw);
 
-                    let bound = Poly::new(coeffs).fix_suffix_var(beta);
-                    let mut bound_message = bound.into_evals();
-                    bound_message.resize(bound_message.len() << log_inv_rate, BinaryField128::ZERO);
+            let mut message = coeffs.clone();
+            message.resize(n << log_inv_rate, BinaryField128::ZERO);
 
-                    assert_eq!(
-                        fold_codeword(&encode(&message), beta),
-                        encode(&bound_message),
-                        "log_inv_rate={log_inv_rate} log_n={log_n} trial={trial}"
-                    );
-                }
-            }
+            let bound = Poly::new(coeffs).fix_suffix_var(beta);
+            let mut bound_message = bound.into_evals();
+            bound_message.resize(bound_message.len() << log_inv_rate, BinaryField128::ZERO);
+
+            prop_assert_eq!(
+                fold_codeword(&encode(&message), beta),
+                encode(&bound_message)
+            );
         }
     }
 

--- a/binary-pcs/src/lib.rs
+++ b/binary-pcs/src/lib.rs
@@ -1,0 +1,21 @@
+#![doc = include_str!("../README.md")]
+#![no_std]
+
+extern crate alloc;
+
+mod error;
+mod fold;
+mod params;
+mod pcs;
+mod proof;
+mod prover;
+#[cfg(test)]
+pub(crate) mod test_util;
+mod verifier;
+
+pub use error::BinaryPcsError;
+pub use fold::{fold_codeword, fold_pair};
+pub use params::{BinaryPcsConfig, BinaryPcsConfigError, BinaryPcsParams};
+pub use pcs::BinaryPcs;
+pub use proof::{BinaryPcsProof, RoundProof};
+pub use prover::BinaryPcsProverData;

--- a/binary-pcs/src/lib.rs
+++ b/binary-pcs/src/lib.rs
@@ -3,6 +3,9 @@
 
 extern crate alloc;
 
+use p3_binary_field::BinaryField128;
+use p3_sumcheck::layout::SuffixProver;
+
 mod error;
 mod fold;
 mod params;
@@ -19,3 +22,12 @@ pub use params::{BinaryPcsConfig, BinaryPcsConfigError, BinaryPcsParams};
 pub use pcs::BinaryPcs;
 pub use proof::{BinaryPcsProof, RoundProof};
 pub use prover::BinaryPcsProverData;
+
+/// The stacked-layout binding mode this scheme commits in.
+///
+/// Fixed rather than chosen by the caller: the codeword fold merges *adjacent pairs*, which
+/// only suffix-order binding matches. Prefix binding merges halves, and driving it through the
+/// same fold does not stay in lockstep — see `prover.rs`'s
+/// `prefix_layout_does_not_stay_in_lockstep`, which pins that as a property of the two binding
+/// orders rather than a tuning detail.
+pub(crate) type PcsLayout = SuffixProver<BinaryField128, BinaryField128>;

--- a/binary-pcs/src/params.rs
+++ b/binary-pcs/src/params.rs
@@ -1,3 +1,13 @@
+//! Caller-facing parameters, and the round schedule derived from them.
+//!
+//! [`BinaryPcsParams`] is what a caller picks: a code rate, a grinding budget, and a target
+//! security level. [`BinaryPcsConfig::try_new`] turns those, together with the committed
+//! polynomial's arity, into the schedule the prover and the verifier both read — how many
+//! folds run, how long the final codeword is, and how many queries the unique-decoding regime
+//! demands. Every way that combination can fail to describe a usable protocol is a variant of
+//! [`BinaryPcsConfigError`] and is returned rather than asserted, since the parameters come
+//! from the caller.
+
 use p3_security::SecurityAssumption;
 use thiserror::Error;
 
@@ -6,6 +16,12 @@ use thiserror::Error;
 /// The challenger asserts `bits + 8 <= min(F::bits(), 64)`, so the counter width, not the
 /// field width, is what binds at this level.
 const MAX_POW_BITS: usize = 56;
+
+/// Bit width of the codeword alphabet, `BinaryField128`.
+///
+/// Checked against the field itself by `the_alphabet_width_matches_the_field` below, so this
+/// cannot drift from the type the crate actually commits over.
+const ALPHABET_BITS: usize = 128;
 
 /// The regime this scheme is analysed in.
 ///
@@ -16,6 +32,40 @@ const MAX_POW_BITS: usize = 56;
 /// excluded here by choice, not by mathematics. It is fixed here rather than taken from the
 /// caller, which is why this crate does not re-export `SecurityAssumption`.
 const REGIME: SecurityAssumption = SecurityAssumption::UniqueDecoding;
+
+/// `ceil(log2(value))`.
+///
+/// For `value >= 2` the highest set bit of `value - 1` sits one below the ceiling at a power
+/// of two and exactly at it otherwise, so the leading-zero count gives the ceiling in both
+/// cases. `value <= 1` needs no bits.
+const fn log2_ceil_u128(value: u128) -> usize {
+    if value <= 1 {
+        return 0;
+    }
+    (u128::BITS - (value - 1).leading_zeros()) as usize
+}
+
+/// Bits of security the rounds leave once the field's width is paid for, rounded down.
+///
+/// The queries are not the only place soundness is spent, and the two rounds below lose bits
+/// that no query count buys back. Both are bounded by a multiple of `1/|F|`:
+///
+/// - **The commit phase.** At fold arity 2 in the unique-decoding regime the per-round
+///   proximity error is `(arity - 1) * (n + 1) / |F|`, i.e. `(n + 1) / |F|` for a base codeword
+///   of `n` symbols. That is the bound `p3_security::fri::commit_phase_error_udr` states, which
+///   `the_field_security_agrees_with_p3_security` below checks this function against.
+/// - **The sumcheck.** Each of the `num_fold_rounds` rounds sends a degree-2 polynomial, so a
+///   forged round survives a uniform challenge with probability at most `2 / |F|`.
+///
+/// Their sum is `n + 1 + 2 * num_fold_rounds` over `|F|`. The sum cannot overflow: `try_new`
+/// admits `log_domain_size` only below `usize::BITS`, so `n` stays below `2^64`.
+///
+/// Taking the ceiling of the logarithm rounds the result **down**, so this understates the
+/// achieved security by up to one bit rather than overstating it.
+const fn field_security_bits_at(log_domain_size: usize, num_fold_rounds: usize) -> usize {
+    let numerator = (1u128 << log_domain_size) + 1 + 2 * num_fold_rounds as u128;
+    ALPHABET_BITS.saturating_sub(log2_ceil_u128(numerator))
+}
 
 /// Parameters chosen by the caller.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -28,12 +78,11 @@ pub struct BinaryPcsParams {
     pub security_level: usize,
 }
 
-/// Parameters derived from [`BinaryPcsParams`], the polynomial's arity and the folding factor.
+/// The round schedule derived from [`BinaryPcsParams`] and the polynomial's arity.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BinaryPcsConfig {
     params: BinaryPcsParams,
     num_variables: usize,
-    folding: usize,
     num_queries: usize,
 }
 
@@ -41,13 +90,6 @@ pub struct BinaryPcsConfig {
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum BinaryPcsConfigError {
-    /// Folding factors above zero are not supported.
-    ///
-    /// The commit phase reads a width-1 codeword; a wider one would be fed to a fold that
-    /// assumes adjacent pairs lie in one column.
-    #[error("folding factor {requested} is not supported; only 0 is")]
-    FoldingNotSupported { requested: usize },
-
     /// The codeword length does not fit in a `usize`.
     ///
     /// A codeword is indexed by `usize`, so `log_len` must stay below `max_bits`
@@ -57,15 +99,9 @@ pub enum BinaryPcsConfigError {
     #[error("codeword length 2^{log_len} does not fit in a {max_bits}-bit usize index")]
     CodewordLengthExceedsUsize { log_len: usize, max_bits: usize },
 
-    /// Reached only when `num_variables == 0`, since folding is fixed at zero: the committed
-    /// polynomial has no variables at all, so there is nothing for a folding round to fold.
-    #[error(
-        "polynomial has no variables to fold (num_variables = {num_variables}, folding = {folding})"
-    )]
-    FoldingLeavesNoRounds {
-        num_variables: usize,
-        folding: usize,
-    },
+    /// The committed polynomial has no variables, so there is no round to fold.
+    #[error("polynomial has no variables to fold")]
+    NoVariablesToFold,
 
     /// The challenger cannot produce a witness this wide.
     #[error("grinding requests {requested} bits; the witness type admits at most {max}")]
@@ -77,6 +113,16 @@ pub enum BinaryPcsConfigError {
         security_level: usize,
         pow_bits: usize,
     },
+
+    /// The target exceeds what the alphabet can deliver at this domain size.
+    ///
+    /// Queries buy back only the proximity term. The fold and sumcheck rounds each lose bits
+    /// to the field's width, and no query count recovers them, so a target above `max` would
+    /// be reported as met while being unreachable at any query count.
+    #[error(
+        "security level {security_level} exceeds the {max} bits the field leaves at this domain size"
+    )]
+    SecurityLevelExceedsFieldCapacity { security_level: usize, max: usize },
 
     /// The derived query count was zero, which would accept any codeword.
     #[error("derived a query count of zero")]
@@ -91,23 +137,23 @@ pub enum BinaryPcsConfigError {
 }
 
 impl BinaryPcsConfig {
-    /// Derive the configuration for a polynomial in `num_variables` variables committed with
-    /// the given folding factor.
+    /// Derive the round schedule for a polynomial in `num_variables` variables.
+    ///
+    /// Every variable is folded: the commit phase lays the whole polynomial out as a single
+    /// codeword column, so there is no head of preprocessing rounds to configure. Binding a
+    /// prefix of the variables inside a committed row instead is the deferred head collapse,
+    /// which would reintroduce a folding parameter alongside the machinery to honour it.
     ///
     /// # Errors
     ///
     /// Returns a [`BinaryPcsConfigError`] if the codeword length does not fit in a `usize`,
-    /// if folding leaves no rounds, if grinding exceeds what the challenger can witness or the
-    /// security budget, or if the derived query count is zero.
+    /// if the polynomial has no variables, if grinding exceeds what the challenger can witness
+    /// or the security budget, if the target exceeds what the field can deliver, or if the
+    /// derived query count is zero.
     pub fn try_new(
         num_variables: usize,
-        folding: usize,
         params: BinaryPcsParams,
     ) -> Result<Self, BinaryPcsConfigError> {
-        if folding != 0 {
-            return Err(BinaryPcsConfigError::FoldingNotSupported { requested: folding });
-        }
-
         if !matches!(REGIME, SecurityAssumption::UniqueDecoding) {
             return Err(BinaryPcsConfigError::UnsupportedSoundnessRegime);
         }
@@ -126,11 +172,8 @@ impl BinaryPcsConfig {
             return Err(BinaryPcsConfigError::CodewordLengthExceedsUsize { log_len, max_bits });
         }
 
-        if folding >= num_variables {
-            return Err(BinaryPcsConfigError::FoldingLeavesNoRounds {
-                num_variables,
-                folding,
-            });
+        if num_variables == 0 {
+            return Err(BinaryPcsConfigError::NoVariablesToFold);
         }
 
         if params.pow_bits > MAX_POW_BITS {
@@ -147,6 +190,15 @@ impl BinaryPcsConfig {
             });
         }
 
+        // Every variable folds, so the fold-round count is the arity itself.
+        let field_security_bits = field_security_bits_at(log_len, num_variables);
+        if params.security_level > field_security_bits {
+            return Err(BinaryPcsConfigError::SecurityLevelExceedsFieldCapacity {
+                security_level: params.security_level,
+                max: field_security_bits,
+            });
+        }
+
         // Grinding buys back `pow_bits`, so the queries only cover the remainder.
         let protocol_security_level = params.security_level - params.pow_bits;
         let num_queries = REGIME.queries(protocol_security_level, params.log_inv_rate);
@@ -157,7 +209,6 @@ impl BinaryPcsConfig {
         Ok(Self {
             params,
             num_variables,
-            folding,
             num_queries,
         })
     }
@@ -168,16 +219,10 @@ impl BinaryPcsConfig {
         self.num_variables
     }
 
-    /// Number of variables bound inside a committed row.
-    #[must_use]
-    pub const fn folding(&self) -> usize {
-        self.folding
-    }
-
     /// Number of 2-to-1 codeword folds: one per residual sumcheck round.
     #[must_use]
     pub const fn num_fold_rounds(&self) -> usize {
-        self.num_variables - self.folding
+        self.num_variables
     }
 
     /// Log length of the final codeword, which is sent in full.
@@ -221,11 +266,25 @@ impl BinaryPcsConfig {
     pub fn query_security_bits(&self) -> f64 {
         REGIME.queries_error(self.params.log_inv_rate, self.num_queries)
     }
+
+    /// Bits of security the fold and sumcheck rounds leave, rounded down.
+    ///
+    /// This is the ceiling on the target: [`Self::try_new`] rejects a `security_level` above
+    /// it, because no query count buys those bits back.
+    #[must_use]
+    pub const fn field_security_bits(&self) -> usize {
+        field_security_bits_at(self.log_domain_size(), self.num_fold_rounds())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{BinaryPcsConfig, BinaryPcsConfigError, BinaryPcsParams};
+    use p3_binary_field::BinaryField128;
+    use p3_field::Field;
+    use p3_security::InstanceShape;
+    use p3_security::fri::{FriRegime, commit_phase_error_udr};
+
+    use super::{ALPHABET_BITS, BinaryPcsConfig, BinaryPcsConfigError, BinaryPcsParams};
 
     const fn params() -> BinaryPcsParams {
         BinaryPcsParams {
@@ -236,11 +295,15 @@ mod tests {
     }
 
     #[test]
+    fn the_alphabet_width_matches_the_field() {
+        assert_eq!(ALPHABET_BITS, BinaryField128::bits());
+    }
+
+    #[test]
     fn derives_the_fold_schedule_and_query_count() {
-        let config = BinaryPcsConfig::try_new(10, 0, params()).unwrap();
+        let config = BinaryPcsConfig::try_new(10, params()).unwrap();
         assert_eq!(config.num_variables(), 10);
-        assert_eq!(config.folding(), 0);
-        // Folding is fixed at zero, so every variable folds the codeword.
+        // Every variable folds the codeword.
         assert_eq!(config.num_fold_rounds(), 10);
         // Folding stops when the message is a constant, leaving the rate expansion.
         assert_eq!(config.log_final_len(), 2);
@@ -256,7 +319,7 @@ mod tests {
             pow_bits: 8,
             security_level: 100,
         };
-        let config = BinaryPcsConfig::try_new(16, 0, params).unwrap();
+        let config = BinaryPcsConfig::try_new(16, params).unwrap();
         let protocol_target = (params.security_level - params.pow_bits) as f64;
         assert!(
             config.query_security_bits() >= protocol_target,
@@ -271,30 +334,56 @@ mod tests {
         low.log_inv_rate = 1;
         let mut high = params();
         high.log_inv_rate = 4;
-        let few = BinaryPcsConfig::try_new(10, 0, high).unwrap().num_queries();
-        let many = BinaryPcsConfig::try_new(10, 0, low).unwrap().num_queries();
+        let few = BinaryPcsConfig::try_new(10, high).unwrap().num_queries();
+        let many = BinaryPcsConfig::try_new(10, low).unwrap().num_queries();
         assert!(
             many > few,
             "a worse rate must demand more queries: {many} vs {few}"
         );
     }
 
+    /// The fold term this crate charges must agree with the one `p3-security` states for the
+    /// unique-decoding commit phase, so the two cannot drift apart silently. Arity 2 is
+    /// `max_log_arity = 1`, and every fold round here runs at `pow_bits = 0`.
+    ///
+    /// This crate's value must never be the larger of the two — it is the one `try_new`
+    /// enforces — and must stay within a rounding of it: the two differ only by this crate's
+    /// extra sumcheck term, which the codeword term dwarfs, and by its rounding down to a
+    /// whole bit.
     #[test]
-    fn rejects_a_polynomial_with_no_variables() {
-        assert_eq!(
-            BinaryPcsConfig::try_new(0, 0, params()),
-            Err(BinaryPcsConfigError::FoldingLeavesNoRounds {
-                num_variables: 0,
-                folding: 0,
-            })
-        );
+    fn the_field_security_agrees_with_p3_security() {
+        for &num_variables in &[10usize, 16, 20, 24] {
+            let config = BinaryPcsConfig::try_new(num_variables, params()).unwrap();
+            let regime = FriRegime {
+                log_blowup: config.log_inv_rate(),
+                num_queries: config.num_queries(),
+                log_final_poly_len: config.log_final_len(),
+                max_log_arity: 1,
+                commit_pow_bits: 0,
+                query_pow_bits: config.pow_bits(),
+            };
+            let shape = InstanceShape {
+                log_trace_length: config.num_variables(),
+                modulus_bits: ALPHABET_BITS,
+                collision_resistance: ALPHABET_BITS,
+                num_batched_functions: 1,
+            };
+            let reference = commit_phase_error_udr(&regime, &shape)
+                .expect("arity 2 folds, so there is a commit-phase round")
+                .bits();
+            let ours = config.field_security_bits() as f64;
+            assert!(
+                ours <= reference && reference - ours < 1.5,
+                "num_variables={num_variables}: {ours} bits does not track p3-security's {reference}"
+            );
+        }
     }
 
     #[test]
-    fn rejects_a_nonzero_folding_factor() {
+    fn rejects_a_polynomial_with_no_variables() {
         assert_eq!(
-            BinaryPcsConfig::try_new(10, 1, params()),
-            Err(BinaryPcsConfigError::FoldingNotSupported { requested: 1 })
+            BinaryPcsConfig::try_new(0, params()),
+            Err(BinaryPcsConfigError::NoVariablesToFold)
         );
     }
 
@@ -303,7 +392,7 @@ mod tests {
         let mut p = params();
         p.pow_bits = 57;
         assert_eq!(
-            BinaryPcsConfig::try_new(10, 0, p),
+            BinaryPcsConfig::try_new(10, p),
             Err(BinaryPcsConfigError::PowBitsExceedWitnessCapacity {
                 requested: 57,
                 max: 56,
@@ -318,7 +407,7 @@ mod tests {
         // for which `1usize << log_len` is already invalid.
         let num_variables = max_bits - params().log_inv_rate;
         assert_eq!(
-            BinaryPcsConfig::try_new(num_variables, 0, params()),
+            BinaryPcsConfig::try_new(num_variables, params()),
             Err(BinaryPcsConfigError::CodewordLengthExceedsUsize {
                 log_len: max_bits,
                 max_bits,
@@ -333,7 +422,7 @@ mod tests {
         let mut p = params();
         p.log_inv_rate = 0;
         assert_eq!(
-            BinaryPcsConfig::try_new(10, 0, p),
+            BinaryPcsConfig::try_new(10, p),
             Err(BinaryPcsConfigError::ZeroQueries)
         );
     }
@@ -343,11 +432,48 @@ mod tests {
         let mut p = params();
         p.security_level = 16;
         assert_eq!(
-            BinaryPcsConfig::try_new(10, 0, p),
+            BinaryPcsConfig::try_new(10, p),
             Err(BinaryPcsConfigError::SecurityLevelBelowPowBits {
                 security_level: 16,
                 pow_bits: 16,
             })
+        );
+    }
+
+    /// A target the alphabet cannot deliver is rejected rather than met on paper by piling on
+    /// queries: at 20 variables and rate `2^-2` the base codeword holds `2^22` symbols, so the
+    /// fold and sumcheck rounds alone cap the achievable security at 105 bits.
+    #[test]
+    fn rejects_a_security_level_the_field_cannot_deliver() {
+        let mut p = params();
+        p.security_level = 120;
+        assert_eq!(
+            BinaryPcsConfig::try_new(20, p),
+            Err(BinaryPcsConfigError::SecurityLevelExceedsFieldCapacity {
+                security_level: 120,
+                max: 105,
+            })
+        );
+
+        // One bit below the cap is accepted, so the boundary is the stated one and not an
+        // accident of a much looser bound.
+        p.security_level = 105;
+        assert!(BinaryPcsConfig::try_new(20, p).is_ok());
+    }
+
+    /// The cap tightens as the committed polynomial grows: a longer codeword spends more of
+    /// the field's width on the fold's proximity term.
+    #[test]
+    fn the_field_capacity_shrinks_as_the_domain_grows() {
+        let small = BinaryPcsConfig::try_new(10, params())
+            .unwrap()
+            .field_security_bits();
+        let large = BinaryPcsConfig::try_new(20, params())
+            .unwrap()
+            .field_security_bits();
+        assert!(
+            large < small,
+            "a larger domain must leave fewer bits: {large} vs {small}"
         );
     }
 }

--- a/binary-pcs/src/params.rs
+++ b/binary-pcs/src/params.rs
@@ -1,0 +1,353 @@
+use p3_security::SecurityAssumption;
+use thiserror::Error;
+
+/// Largest grinding request `BinaryChallenger<BinaryField128, _>::grind` accepts.
+///
+/// The challenger asserts `bits + 8 <= min(F::bits(), 64)`, so the counter width, not the
+/// field width, is what binds at this level.
+const MAX_POW_BITS: usize = 56;
+
+/// The regime this scheme is analysed in.
+///
+/// Capacity-rate list decodability is refuted over characteristic 2 with `F_2`-subspace
+/// domains, and the Cantor domain is one. The Johnson bound is not refuted by this: it is an
+/// unconditional theorem whose radius those same counterexamples show to be tight, but
+/// `p3-security` documents it as resting on a correlated-agreement conjecture, and it is
+/// excluded here by choice, not by mathematics. It is fixed here rather than taken from the
+/// caller, which is why this crate does not re-export `SecurityAssumption`.
+const REGIME: SecurityAssumption = SecurityAssumption::UniqueDecoding;
+
+/// Parameters chosen by the caller.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BinaryPcsParams {
+    /// Log of the inverse code rate. The codeword is `2^log_inv_rate` times the message.
+    pub log_inv_rate: usize,
+    /// Grinding bits demanded once, before the query phase.
+    pub pow_bits: usize,
+    /// Target security, in bits.
+    pub security_level: usize,
+}
+
+/// Parameters derived from [`BinaryPcsParams`], the polynomial's arity and the folding factor.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct BinaryPcsConfig {
+    params: BinaryPcsParams,
+    num_variables: usize,
+    folding: usize,
+    num_queries: usize,
+}
+
+/// Why a [`BinaryPcsConfig`] could not be derived.
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum BinaryPcsConfigError {
+    /// Folding factors above zero are not supported.
+    ///
+    /// The commit phase reads a width-1 codeword; a wider one would be fed to a fold that
+    /// assumes adjacent pairs lie in one column.
+    #[error("folding factor {requested} is not supported; only 0 is")]
+    FoldingNotSupported { requested: usize },
+
+    /// The codeword length does not fit in a `usize`.
+    ///
+    /// A codeword is indexed by `usize`, so `log_len` must stay below `max_bits`
+    /// (`usize::BITS`): at or past that width, computing the codeword's length as
+    /// `1usize << log_len` is already invalid, regardless of how large the additive domain
+    /// itself is.
+    #[error("codeword length 2^{log_len} does not fit in a {max_bits}-bit usize index")]
+    CodewordLengthExceedsUsize { log_len: usize, max_bits: usize },
+
+    /// Reached only when `num_variables == 0`, since folding is fixed at zero: the committed
+    /// polynomial has no variables at all, so there is nothing for a folding round to fold.
+    #[error(
+        "polynomial has no variables to fold (num_variables = {num_variables}, folding = {folding})"
+    )]
+    FoldingLeavesNoRounds {
+        num_variables: usize,
+        folding: usize,
+    },
+
+    /// The challenger cannot produce a witness this wide.
+    #[error("grinding requests {requested} bits; the witness type admits at most {max}")]
+    PowBitsExceedWitnessCapacity { requested: usize, max: usize },
+
+    /// Grinding would consume the whole budget, leaving nothing for the queries to buy.
+    #[error("security level {security_level} does not exceed the grinding budget {pow_bits}")]
+    SecurityLevelBelowPowBits {
+        security_level: usize,
+        pow_bits: usize,
+    },
+
+    /// The derived query count was zero, which would accept any codeword.
+    #[error("derived a query count of zero")]
+    ZeroQueries,
+
+    /// Reached with a regime other than unique decoding.
+    ///
+    /// Unreachable through the public API, which exposes no regime knob; this guards the
+    /// private core against a future caller.
+    #[error("only the unique-decoding regime is supported over F_2-subspace domains")]
+    UnsupportedSoundnessRegime,
+}
+
+impl BinaryPcsConfig {
+    /// Derive the configuration for a polynomial in `num_variables` variables committed with
+    /// the given folding factor.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`BinaryPcsConfigError`] if the codeword length does not fit in a `usize`,
+    /// if folding leaves no rounds, if grinding exceeds what the challenger can witness or the
+    /// security budget, or if the derived query count is zero.
+    pub fn try_new(
+        num_variables: usize,
+        folding: usize,
+        params: BinaryPcsParams,
+    ) -> Result<Self, BinaryPcsConfigError> {
+        if folding != 0 {
+            return Err(BinaryPcsConfigError::FoldingNotSupported { requested: folding });
+        }
+
+        if !matches!(REGIME, SecurityAssumption::UniqueDecoding) {
+            return Err(BinaryPcsConfigError::UnsupportedSoundnessRegime);
+        }
+
+        // The codeword length is computed downstream as `1usize << log_len`, so `log_len`
+        // must stay below `usize::BITS` or that shift is already invalid. `checked_add`
+        // guards the sum itself: an adversarial `num_variables` and `log_inv_rate` must not
+        // silently wrap into an in-range `log_len`.
+        let max_bits = usize::BITS as usize;
+        let log_len = num_variables.saturating_add(params.log_inv_rate);
+        let in_range = matches!(
+            num_variables.checked_add(params.log_inv_rate),
+            Some(len) if len < max_bits
+        );
+        if !in_range {
+            return Err(BinaryPcsConfigError::CodewordLengthExceedsUsize { log_len, max_bits });
+        }
+
+        if folding >= num_variables {
+            return Err(BinaryPcsConfigError::FoldingLeavesNoRounds {
+                num_variables,
+                folding,
+            });
+        }
+
+        if params.pow_bits > MAX_POW_BITS {
+            return Err(BinaryPcsConfigError::PowBitsExceedWitnessCapacity {
+                requested: params.pow_bits,
+                max: MAX_POW_BITS,
+            });
+        }
+
+        if params.security_level <= params.pow_bits {
+            return Err(BinaryPcsConfigError::SecurityLevelBelowPowBits {
+                security_level: params.security_level,
+                pow_bits: params.pow_bits,
+            });
+        }
+
+        // Grinding buys back `pow_bits`, so the queries only cover the remainder.
+        let protocol_security_level = params.security_level - params.pow_bits;
+        let num_queries = REGIME.queries(protocol_security_level, params.log_inv_rate);
+        if num_queries == 0 {
+            return Err(BinaryPcsConfigError::ZeroQueries);
+        }
+
+        Ok(Self {
+            params,
+            num_variables,
+            folding,
+            num_queries,
+        })
+    }
+
+    /// Number of variables of the committed polynomial.
+    #[must_use]
+    pub const fn num_variables(&self) -> usize {
+        self.num_variables
+    }
+
+    /// Number of variables bound inside a committed row.
+    #[must_use]
+    pub const fn folding(&self) -> usize {
+        self.folding
+    }
+
+    /// Number of 2-to-1 codeword folds: one per residual sumcheck round.
+    #[must_use]
+    pub const fn num_fold_rounds(&self) -> usize {
+        self.num_variables - self.folding
+    }
+
+    /// Log length of the final codeword, which is sent in full.
+    #[must_use]
+    pub const fn log_final_len(&self) -> usize {
+        self.params.log_inv_rate
+    }
+
+    /// Log length of the base codeword: the polynomial's arity blown up by the inverse rate.
+    #[must_use]
+    pub(crate) const fn log_domain_size(&self) -> usize {
+        self.num_variables + self.params.log_inv_rate
+    }
+
+    /// Length of the base codeword committed at commit time.
+    #[must_use]
+    pub(crate) const fn domain_size(&self) -> usize {
+        1usize << self.log_domain_size()
+    }
+
+    /// Number of query indices sampled in the query phase.
+    #[must_use]
+    pub const fn num_queries(&self) -> usize {
+        self.num_queries
+    }
+
+    /// Log of the inverse code rate.
+    #[must_use]
+    pub const fn log_inv_rate(&self) -> usize {
+        self.params.log_inv_rate
+    }
+
+    /// Grinding bits demanded before the query phase.
+    #[must_use]
+    pub const fn pow_bits(&self) -> usize {
+        self.params.pow_bits
+    }
+
+    /// Bits of security the sampled queries deliver.
+    #[must_use]
+    pub fn query_security_bits(&self) -> f64 {
+        REGIME.queries_error(self.params.log_inv_rate, self.num_queries)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BinaryPcsConfig, BinaryPcsConfigError, BinaryPcsParams};
+
+    const fn params() -> BinaryPcsParams {
+        BinaryPcsParams {
+            log_inv_rate: 2,
+            pow_bits: 16,
+            security_level: 100,
+        }
+    }
+
+    #[test]
+    fn derives_the_fold_schedule_and_query_count() {
+        let config = BinaryPcsConfig::try_new(10, 0, params()).unwrap();
+        assert_eq!(config.num_variables(), 10);
+        assert_eq!(config.folding(), 0);
+        // Folding is fixed at zero, so every variable folds the codeword.
+        assert_eq!(config.num_fold_rounds(), 10);
+        // Folding stops when the message is a constant, leaving the rate expansion.
+        assert_eq!(config.log_final_len(), 2);
+        assert!(config.num_queries() > 0);
+    }
+
+    /// `query_security_bits` reports the achieved security the sampled queries buy back after
+    /// grinding, which must at least meet the protocol's target: `security_level - pow_bits`.
+    #[test]
+    fn query_security_bits_meets_the_protocol_target() {
+        let params = BinaryPcsParams {
+            log_inv_rate: 2,
+            pow_bits: 8,
+            security_level: 100,
+        };
+        let config = BinaryPcsConfig::try_new(16, 0, params).unwrap();
+        let protocol_target = (params.security_level - params.pow_bits) as f64;
+        assert!(
+            config.query_security_bits() >= protocol_target,
+            "{} does not meet the protocol target {protocol_target}",
+            config.query_security_bits()
+        );
+    }
+
+    #[test]
+    fn query_count_grows_as_the_rate_approaches_one() {
+        let mut low = params();
+        low.log_inv_rate = 1;
+        let mut high = params();
+        high.log_inv_rate = 4;
+        let few = BinaryPcsConfig::try_new(10, 0, high).unwrap().num_queries();
+        let many = BinaryPcsConfig::try_new(10, 0, low).unwrap().num_queries();
+        assert!(
+            many > few,
+            "a worse rate must demand more queries: {many} vs {few}"
+        );
+    }
+
+    #[test]
+    fn rejects_a_polynomial_with_no_variables() {
+        assert_eq!(
+            BinaryPcsConfig::try_new(0, 0, params()),
+            Err(BinaryPcsConfigError::FoldingLeavesNoRounds {
+                num_variables: 0,
+                folding: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_a_nonzero_folding_factor() {
+        assert_eq!(
+            BinaryPcsConfig::try_new(10, 1, params()),
+            Err(BinaryPcsConfigError::FoldingNotSupported { requested: 1 })
+        );
+    }
+
+    #[test]
+    fn rejects_grinding_beyond_the_witness_capacity() {
+        let mut p = params();
+        p.pow_bits = 57;
+        assert_eq!(
+            BinaryPcsConfig::try_new(10, 0, p),
+            Err(BinaryPcsConfigError::PowBitsExceedWitnessCapacity {
+                requested: 57,
+                max: 56,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_a_codeword_at_least_as_wide_as_the_index_type() {
+        let max_bits = usize::BITS as usize;
+        // `num_variables + log_inv_rate` lands exactly on `max_bits`, the smallest length
+        // for which `1usize << log_len` is already invalid.
+        let num_variables = max_bits - params().log_inv_rate;
+        assert_eq!(
+            BinaryPcsConfig::try_new(num_variables, 0, params()),
+            Err(BinaryPcsConfigError::CodewordLengthExceedsUsize {
+                log_len: max_bits,
+                max_bits,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_a_rate_that_derives_zero_queries() {
+        // At log_inv_rate = 0, log_1_delta(0) = log2(1 + 2^0) - 1 = 0.0 exactly, so the
+        // derived query count saturates to zero regardless of the security level.
+        let mut p = params();
+        p.log_inv_rate = 0;
+        assert_eq!(
+            BinaryPcsConfig::try_new(10, 0, p),
+            Err(BinaryPcsConfigError::ZeroQueries)
+        );
+    }
+
+    #[test]
+    fn rejects_a_security_level_at_or_below_the_grinding_budget() {
+        let mut p = params();
+        p.security_level = 16;
+        assert_eq!(
+            BinaryPcsConfig::try_new(10, 0, p),
+            Err(BinaryPcsConfigError::SecurityLevelBelowPowBits {
+                security_level: 16,
+                pow_bits: 16,
+            })
+        );
+    }
+}

--- a/binary-pcs/src/pcs.rs
+++ b/binary-pcs/src/pcs.rs
@@ -1,0 +1,594 @@
+//! `MultilinearPcs` and `PrescribedPointPcs` over `BinaryField128`, tying the stacked-sumcheck
+//! layout machinery to the commit/fold/query pipeline the rest of this crate builds.
+//!
+//! The opening claims an `OpeningProtocol` names are folded into the residual sumcheck exactly
+//! as `p3_sumcheck::layout` already does for any other stacked-layout consumer: each claim
+//! contributes an alpha-batched equality weight, and the sumcheck reduces the claim down to a
+//! single scalar as it folds. What is specific to this crate is what that scalar is checked
+//! against: the alpha-batched weight polynomial evaluated at the fold-derived point, times the
+//! (uniform) value the final codeword carries in the clear — `verify_query_paths` ties every
+//! sampled query to that same codeword, so together the two checks close the proximity and the
+//! evaluation claim in one proof.
+
+use alloc::vec;
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+use p3_binary_dft::AdditiveRsEncoder;
+use p3_binary_field::BinaryField128;
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_commit::{Mmcs, MultilinearPcs};
+use p3_field::PrimeCharacteristicRing;
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::Poly;
+use p3_sumcheck::layout::{Layout, Verifier, Witness};
+use p3_sumcheck::strategy::{Basis, VariableOrder};
+use p3_sumcheck::{OpeningEvals, OpeningProtocol, PrescribedPointPcs, SumcheckData, SumcheckError};
+
+use crate::error::BinaryPcsError;
+use crate::params::BinaryPcsConfig;
+use crate::proof::BinaryPcsProof;
+use crate::prover::{BinaryPcsProverData, commit, fold_rounds, open_queries};
+use crate::verifier::{check_round_and_final_lengths, verify_query_paths};
+
+/// A multilinear polynomial commitment scheme over `BinaryField128`: an additive-domain
+/// Reed-Solomon codeword folded in lockstep with a residual sumcheck.
+///
+/// `L` selects the stacked-layout binding mode; the commit and fold phases reject any layout
+/// other than [`SuffixProver`](p3_sumcheck::layout::SuffixProver) at run time (see `prover.rs`),
+/// since the codeword fold only stays in correspondence with suffix-order binding.
+pub struct BinaryPcs<MT, L> {
+    config: BinaryPcsConfig,
+    mmcs: MT,
+    encoder: AdditiveRsEncoder<BinaryField128>,
+    _marker: PhantomData<L>,
+}
+
+impl<MT, L> BinaryPcs<MT, L> {
+    /// Builds a PCS instance from a derived configuration and a base-field MMCS.
+    pub fn new(config: BinaryPcsConfig, mmcs: MT) -> Self {
+        Self {
+            config,
+            mmcs,
+            encoder: AdditiveRsEncoder::default(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<MT, L> BinaryPcs<MT, L>
+where
+    MT: Mmcs<BinaryField128>,
+    L: Layout<BinaryField128, BinaryField128>,
+{
+    /// Runs the fold-and-query pipeline shared by `open` and `open_at`, once every opening
+    /// claim the protocol names has already been recorded against `prover_data.layout`.
+    fn finish_open<Challenger>(
+        &self,
+        prover_data: BinaryPcsProverData<MT, L>,
+        evals: Vec<OpeningEvals<BinaryField128>>,
+        challenger: &mut Challenger,
+    ) -> BinaryPcsProof<MT>
+    where
+        Challenger: FieldChallenger<BinaryField128>
+            + GrindingChallenger<Witness = BinaryField128>
+            + CanSampleUniformBits<BinaryField128>
+            + CanObserve<MT::Commitment>,
+    {
+        let (base_merkle_data, sumcheck_data, rounds, _randomness, final_codeword) =
+            fold_rounds(prover_data, &self.config, &self.mmcs, challenger);
+        let query_proofs = open_queries(
+            &self.config,
+            &self.mmcs,
+            challenger,
+            &base_merkle_data,
+            &rounds,
+        );
+
+        BinaryPcsProof {
+            sumcheck: sumcheck_data,
+            rounds: query_proofs.rounds,
+            base_opened_values: query_proofs.base_opened_values,
+            base_multi_proof: query_proofs.base_multi_proof,
+            final_codeword: Poly::new(final_codeword),
+            pow_witness: query_proofs.pow_witness,
+            evals,
+        }
+    }
+
+    /// Replays an opening proof's transcript against `protocol`'s claims and returns the
+    /// claimed evaluations once the proof checks out.
+    ///
+    /// `points` selects prescribed-point mode: `Some` records each claim at its supplied point
+    /// via [`Verifier::add_claim_at`], `None` samples the point from the transcript via
+    /// [`Verifier::add_claim`], mirroring the prover's `eval_at`/`eval` choice.
+    ///
+    /// `OpeningBatchCountMismatch`, both round-count checks, `FinalCodewordLengthMismatch` and
+    /// `NonEmptyPowWitnesses` run before this function performs any transcript operation of its
+    /// own, so a malformed proof is rejected rather than indexed out of bounds or used to
+    /// desync the replay. That does not mean the challenger itself is untouched: `verify`
+    /// observes the commitment before calling here, and `verify_at`'s contract requires the
+    /// caller to have done the same. `OpeningBatchSizeMismatch`, by contrast, is checked once
+    /// per claim inside the claim-recording loop below, after every earlier claim in the same
+    /// proof has already been absorbed — it is ordered only relative to its own claim, not to
+    /// the transcript as a whole.
+    ///
+    /// The per-round sumcheck replay is interleaved with each intermediate round's commitment
+    /// observation, one `SumcheckData::verify_rounds` call per fold round, because a single
+    /// call covering every round would consume all of the proof's polynomial messages before
+    /// any round commitment is observed, desyncing the transcript from what the prover produced.
+    ///
+    /// The claim closes by checking that the alpha-batched weight polynomial, evaluated at the
+    /// point the fold challenges define, times the final codeword's (uniform) value equals the
+    /// running sumcheck claim; `verify_query_paths` then ties every sampled query's fold chain
+    /// to that same codeword.
+    fn verify_opening<Challenger>(
+        &self,
+        commitment: &MT::Commitment,
+        proof: &BinaryPcsProof<MT>,
+        protocol: &OpeningProtocol,
+        points: Option<&[Point<BinaryField128>]>,
+        challenger: &mut Challenger,
+    ) -> Result<Vec<OpeningEvals<BinaryField128>>, BinaryPcsError<MT::Error>>
+    where
+        Challenger: FieldChallenger<BinaryField128>
+            + GrindingChallenger<Witness = BinaryField128>
+            + CanSampleUniformBits<BinaryField128>
+            + CanObserve<MT::Commitment>,
+    {
+        assert_eq!(
+            L::strategy().variable_order,
+            VariableOrder::Suffix,
+            "the codeword folds adjacent pairs, which only suffix-order binding matches"
+        );
+
+        if protocol.num_openings() != proof.evals.len() {
+            return Err(BinaryPcsError::OpeningBatchCountMismatch {
+                expected: protocol.num_openings(),
+                actual: proof.evals.len(),
+            });
+        }
+
+        let num_fold_rounds = self.config.num_fold_rounds();
+        if proof.sumcheck.num_rounds() != num_fold_rounds {
+            return Err(SumcheckError::RoundCountMismatch {
+                expected: num_fold_rounds,
+                actual: proof.sumcheck.num_rounds(),
+            }
+            .into());
+        }
+
+        // Every fold round below replays with a freshly built `pow_witnesses: Vec::new()`
+        // (see the round loop further down), so nothing ever reads `proof.sumcheck`'s own
+        // vector; a non-empty one is unchecked, mutable data riding along with the proof.
+        if !proof.sumcheck.pow_witnesses.is_empty() {
+            return Err(BinaryPcsError::NonEmptyPowWitnesses {
+                actual: proof.sumcheck.pow_witnesses.len(),
+            });
+        }
+
+        check_round_and_final_lengths(&self.config, proof)?;
+
+        // From here on the transcript is touched: every remaining check runs against the
+        // replayed randomness, not the proof's raw bytes.
+        let mut layout_verifier = Verifier::<BinaryField128, BinaryField128>::new(
+            &protocol.table_shapes(),
+            L::strategy(),
+        );
+
+        for (i, (table_idx, batch)) in protocol.iter_openings().enumerate() {
+            let evals = &proof.evals[i];
+            if !batch.has_same_shape(evals) {
+                return Err(BinaryPcsError::OpeningBatchSizeMismatch {
+                    table_idx,
+                    expected: batch.len(),
+                    actual: evals.len(),
+                });
+            }
+            match points {
+                Some(points) => {
+                    layout_verifier
+                        .add_claim_at(table_idx, batch, &points[i], evals, challenger)?;
+                }
+                None => {
+                    layout_verifier.add_claim(table_idx, batch, evals, challenger)?;
+                }
+            }
+        }
+
+        // `into_sumcheck` samples this batching challenge unconditionally, even with no
+        // recorded claims, and folds every claim's weight by its successive power.
+        let alpha: BinaryField128 = challenger.sample_algebra_element();
+        let constraint = layout_verifier.constraint(alpha);
+        let mut claimed_sum = BinaryField128::ZERO;
+        constraint.combine_evals(&mut claimed_sum);
+
+        // One `verify_rounds` call per fold round: a single call spanning every round would
+        // read all of the proof's polynomial messages before any intermediate commitment is
+        // observed, which is not the order the prover produced them in.
+        let mut betas = Vec::with_capacity(num_fold_rounds);
+        for r in 0..num_fold_rounds {
+            let round_data = SumcheckData {
+                polynomial_evaluations: vec![proof.sumcheck.polynomial_evaluations()[r]],
+                pow_witnesses: Vec::new(),
+            };
+            let round_point =
+                round_data.verify_rounds(challenger, &mut claimed_sum, 1, 0, Basis::Evaluation)?;
+            betas.push(round_point.as_slice()[0]);
+
+            if r + 1 < num_fold_rounds {
+                challenger.observe(proof.rounds[r].commitment.clone());
+            }
+        }
+
+        // The codeword fold runs in `L`'s own variable order: suffix binding folds the last
+        // variable first, so `betas` ends up in round order, and the committed polynomial's
+        // variable-order point is its reverse — exactly what `eval_constraints_poly`
+        // reconstructs internally when given that same order.
+        let fold_point = Point::new(betas);
+        let evaluation_of_weights = L::strategy()
+            .variable_order
+            .eval_constraints_poly(core::slice::from_ref(&constraint), &fold_point);
+        let final_value = proof.final_codeword.as_slice()[0];
+        let final_codeword_is_uniform = proof
+            .final_codeword
+            .as_slice()
+            .iter()
+            .all(|&v| v == final_value);
+        if !final_codeword_is_uniform || claimed_sum != evaluation_of_weights * final_value {
+            return Err(BinaryPcsError::FinalCheck);
+        }
+
+        verify_query_paths(
+            &self.config,
+            &self.mmcs,
+            commitment,
+            fold_point.as_slice(),
+            proof,
+            challenger,
+        )?;
+
+        Ok(proof.evals.clone())
+    }
+}
+
+impl<MT, L, Challenger> MultilinearPcs<BinaryField128, Challenger> for BinaryPcs<MT, L>
+where
+    MT: Mmcs<BinaryField128>,
+    L: Layout<BinaryField128, BinaryField128>,
+    Challenger: FieldChallenger<BinaryField128>
+        + GrindingChallenger<Witness = BinaryField128>
+        + CanSampleUniformBits<BinaryField128>
+        + CanObserve<MT::Commitment>,
+{
+    type Val = BinaryField128;
+    type Commitment = MT::Commitment;
+    type ProverData = BinaryPcsProverData<MT, L>;
+    type Proof = BinaryPcsProof<MT>;
+    type Error = BinaryPcsError<MT::Error>;
+    type Witness = Witness<BinaryField128>;
+    type OpeningProtocol = OpeningProtocol;
+
+    fn num_vars(&self) -> usize {
+        self.config.num_variables()
+    }
+
+    fn commit(
+        &self,
+        witness: Self::Witness,
+        challenger: &mut Challenger,
+    ) -> (Self::Commitment, Self::ProverData) {
+        commit::<L, _, MT, _>(&self.config, &self.encoder, &self.mmcs, challenger, witness)
+    }
+
+    fn open(
+        &self,
+        mut prover_data: Self::ProverData,
+        protocol: Self::OpeningProtocol,
+        challenger: &mut Challenger,
+    ) -> Self::Proof {
+        let evals = protocol
+            .iter_openings()
+            .map(|(table_idx, batch)| prover_data.layout.eval(table_idx, batch, challenger))
+            .collect();
+        self.finish_open(prover_data, evals, challenger)
+    }
+
+    fn verify(
+        &self,
+        commitment: &Self::Commitment,
+        proof: &Self::Proof,
+        challenger: &mut Challenger,
+        protocol: Self::OpeningProtocol,
+    ) -> Result<(), Self::Error> {
+        // `commit` absorbs the base commitment itself (via `Layout::commit` -> `commit_base`);
+        // the verifier never calls `commit`, so it absorbs the same root here instead.
+        challenger.observe(commitment.clone());
+        self.verify_opening(commitment, proof, &protocol, None, challenger)
+            .map(|_| ())
+    }
+}
+
+impl<MT, L, Challenger> PrescribedPointPcs<BinaryField128, Challenger> for BinaryPcs<MT, L>
+where
+    MT: Mmcs<BinaryField128>,
+    L: Layout<BinaryField128, BinaryField128>,
+    Challenger: FieldChallenger<BinaryField128>
+        + GrindingChallenger<Witness = BinaryField128>
+        + CanSampleUniformBits<BinaryField128>
+        + CanObserve<MT::Commitment>,
+{
+    /// Opens the columns `protocol` names at `points` instead of sampling each opening point
+    /// from the transcript.
+    ///
+    /// This trait gives no Fiat-Shamir guarantee on its own: the caller must have bound
+    /// `points` to the shared transcript (see [`PrescribedPointPcs`]'s own Fiat-Shamir /
+    /// Soundness doc) before calling this method, exactly as it must before `verify_at`.
+    fn open_at(
+        &self,
+        mut prover_data: Self::ProverData,
+        protocol: &OpeningProtocol,
+        points: &[Point<BinaryField128>],
+        challenger: &mut Challenger,
+    ) -> Self::Proof {
+        assert_eq!(protocol.num_openings(), points.len());
+        let evals = protocol
+            .iter_openings()
+            .zip(points)
+            .map(|((table_idx, batch), point)| {
+                prover_data
+                    .layout
+                    .eval_at(table_idx, batch, point, challenger)
+            })
+            .collect();
+        self.finish_open(prover_data, evals, challenger)
+    }
+
+    /// Verifies an opening proof against `points` instead of sampling each opening point from
+    /// the transcript.
+    ///
+    /// This trait gives no Fiat-Shamir guarantee on its own: the caller must have bound
+    /// `points` to the shared transcript before calling, exactly as `open_at`'s prover side
+    /// did (see [`PrescribedPointPcs`]'s own Fiat-Shamir / Soundness doc). This method also
+    /// does not absorb `commitment` itself; the caller absorbs it once, before its own
+    /// challenges — that absorption is what binding `points` to the transcript depends on in
+    /// the first place.
+    fn verify_at(
+        &self,
+        commitment: &Self::Commitment,
+        proof: &Self::Proof,
+        protocol: &OpeningProtocol,
+        points: &[Point<BinaryField128>],
+        challenger: &mut Challenger,
+    ) -> Result<Vec<OpeningEvals<BinaryField128>>, Self::Error> {
+        assert_eq!(protocol.num_openings(), points.len());
+        self.verify_opening(commitment, proof, protocol, Some(points), challenger)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_binary_field::BinaryField128;
+    use p3_challenger::{CanObserve, FieldChallenger};
+    use p3_commit::{Mmcs, MultilinearPcs};
+    use p3_multilinear_util::point::Point;
+    use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
+    use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::BinaryPcs;
+    use crate::error::BinaryPcsError;
+    use crate::params::{BinaryPcsConfig, BinaryPcsParams};
+    use crate::proof::BinaryPcsProof;
+    use crate::test_util::{MyMmcs, challenger, mmcs, run_lifecycle};
+
+    type F = BinaryField128;
+
+    const NUM_VARIABLES: usize = 8;
+
+    /// Commit, open at a transcript-sampled point, verify. The prover and verifier run on
+    /// independent challengers seeded identically, which is what makes a transcript desync
+    /// show up as a failure rather than pass by sharing state.
+    #[test]
+    fn commit_open_verify_round_trips() {
+        let (pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES, 0);
+
+        let mut verifier_challenger = challenger();
+        pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol)
+            .unwrap();
+    }
+
+    /// A verifier instantiated with a `PrefixProver` layout is stopped before it inspects any
+    /// proof content: `verify_opening` asserts `L::strategy()` against `VariableOrder::Suffix`,
+    /// mirroring the same guard on the prover side (`prover::commit`, `prover::fold_rounds`).
+    /// Without it, a `BinaryPcs<MT, PrefixProver<F, F>>` verifier would run the whole protocol
+    /// against a genuine `SuffixProver` proof and reject it only at `FinalCheck`, with no
+    /// indication that the layouts disagree.
+    #[test]
+    #[should_panic(expected = "only suffix-order binding matches")]
+    fn verify_rejects_a_non_suffix_layout() {
+        let (_pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES, 0);
+
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let mismatched_pcs: BinaryPcs<MyMmcs, PrefixProver<F, F>> = BinaryPcs::new(config, mmcs());
+
+        let mut verifier_challenger = challenger();
+        let _ = mismatched_pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol);
+    }
+
+    /// The workspace wire format is postcard, which is not self-describing; a proof type that
+    /// only round-trips through a self-describing format is not actually shippable. Decoding
+    /// also exercises the `Poly` deserialize path `FinalCodewordLengthMismatch` exists to guard.
+    #[test]
+    fn a_proof_round_trips_through_postcard() {
+        let (pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES, 0);
+
+        let bytes = postcard::to_allocvec(&proof).unwrap();
+        let decoded: BinaryPcsProof<MyMmcs> = postcard::from_bytes(&bytes).unwrap();
+        assert_eq!(decoded.rounds.len(), proof.rounds.len());
+
+        let mut verifier_challenger = challenger();
+        pcs.verify(&commitment, &decoded, &mut verifier_challenger, protocol)
+            .unwrap();
+    }
+
+    const fn params() -> BinaryPcsParams {
+        BinaryPcsParams {
+            log_inv_rate: 2,
+            pow_bits: 4,
+            security_level: 40,
+        }
+    }
+
+    /// Commits a random single-column table and opens it with [`PrescribedPointPcs::open_at`]
+    /// at a point derived from the prover's own transcript, after the commitment `commit` has
+    /// already absorbed — the same "sampled after the commitment" convention [`Layout::eval`]
+    /// uses internally for the transcript-sampled path, just performed by the caller instead.
+    ///
+    /// Returns the point alongside everything a caller needs to replay `verify_at`, so a test
+    /// can either re-derive a matching point on its own challenger, or reuse this exact one.
+    #[allow(clippy::type_complexity)]
+    fn open_at_fixture(
+        seed: u64,
+    ) -> (
+        BinaryPcs<MyMmcs, SuffixProver<F, F>>,
+        <MyMmcs as Mmcs<F>>::Commitment,
+        BinaryPcsProof<MyMmcs>,
+        OpeningProtocol,
+        Point<F>,
+    ) {
+        let mut rng = SmallRng::seed_from_u64(seed);
+        let table = Table::rand(&mut rng, 1, NUM_VARIABLES);
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(NUM_VARIABLES, 1),
+            vec![OpeningBatch::new(vec![0], Vec::new())],
+        )]);
+
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let pcs = BinaryPcs::new(config, mmcs());
+
+        let mut prover_challenger = challenger();
+        let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+        let sample: F = prover_challenger.sample_algebra_element();
+        let point = Point::expand_from_univariate(sample, NUM_VARIABLES);
+        let proof = pcs.open_at(
+            prover_data,
+            &protocol,
+            core::slice::from_ref(&point),
+            &mut prover_challenger,
+        );
+
+        (pcs, commitment, proof, protocol, point)
+    }
+
+    /// Commit, open at a point the prover derives from its own transcript, verify against a
+    /// point the verifier derives, independently, from its own — never a clone taken after
+    /// proving. Both challengers are seeded identically and have, at the point each samples,
+    /// observed exactly the commitment and nothing else, so the two derivations agree; that
+    /// agreement is `PrescribedPointPcs`'s whole Fiat-Shamir contract, exercised here rather
+    /// than assumed.
+    #[test]
+    fn verify_at_round_trips_with_transcript_derived_points() {
+        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED);
+
+        // `verify_at` does not absorb the commitment; the caller does, exactly once, before
+        // deriving the point it then hands to `verify_at`.
+        let mut verifier_challenger = challenger();
+        verifier_challenger.observe(commitment.clone());
+        let sample: F = verifier_challenger.sample_algebra_element();
+        let verifier_point = Point::expand_from_univariate(sample, NUM_VARIABLES);
+        assert_eq!(
+            verifier_point, point,
+            "both sides derive the same point from identically-seeded transcripts"
+        );
+
+        pcs.verify_at(
+            &commitment,
+            &proof,
+            &protocol,
+            core::slice::from_ref(&verifier_point),
+            &mut verifier_challenger,
+        )
+        .unwrap();
+    }
+
+    /// A verifier that skips absorbing the commitment before calling `verify_at` — the one
+    /// responsibility `verify_at` leaves to its caller — must reject the proof, even though the
+    /// point it supplies is the genuine one the proof was opened at. This is what would catch a
+    /// future edit that "fixes" `verify_at` to absorb the commitment internally for symmetry
+    /// with `verify`: such a fix could not repair a point already computed from an unabsorbed
+    /// transcript, but it would make this exact scenario (genuine point, skipped absorption)
+    /// verify anyway, since the point supplied here needs no repair — only the challenger does.
+    #[test]
+    fn verify_at_rejects_a_proof_when_the_caller_skips_absorbing_the_commitment() {
+        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED);
+
+        let mut verifier_challenger = challenger();
+        let err = pcs
+            .verify_at(
+                &commitment,
+                &proof,
+                &protocol,
+                core::slice::from_ref(&point),
+                &mut verifier_challenger,
+            )
+            .unwrap_err();
+        assert!(
+            matches!(err, BinaryPcsError::FinalCheck),
+            "expected FinalCheck, got {err:?}"
+        );
+    }
+
+    /// `run_lifecycle`'s single-table, single-column, `next = []` fixture stacks trivially:
+    /// the committed polynomial's arity already equals the one table's own arity, so no
+    /// selector bits are spent lifting a local claim into the stacked space, and the
+    /// `Statements::Next` arm of `Verifier::constraint` never runs. A two-table layout forces
+    /// real selector lifting, and a `next` opening exercises the repeat-last successor view.
+    ///
+    /// Table A costs one slot per column at its own arity — a multi-column table does not
+    /// share a hypercube across its columns — so its two columns at arity 2 cost `2 * 2^2 = 8`
+    /// cells; table B costs `1 * 2^3 = 8` more. The stacked arity is `log2_ceil` of that total,
+    /// `4`, not a sum of the two tables' own arities.
+    #[test]
+    fn commit_open_verify_round_trips_with_a_stacked_multi_table_layout() {
+        let table_a_arity = 2;
+        let table_b_arity = 3;
+        let stacked_arity = 4;
+
+        let mut rng = SmallRng::seed_from_u64(0x57AC);
+        let table_a = Table::rand(&mut rng, 2, table_a_arity);
+        let table_b = Table::rand(&mut rng, 1, table_b_arity);
+        let witness = SuffixProver::<F, F>::new_witness(vec![table_a, table_b], 0);
+
+        let protocol = OpeningProtocol::new(vec![
+            TableSpec::new(
+                TableShape::new(table_a_arity, 2),
+                vec![OpeningBatch::new(vec![0, 1], Vec::new())],
+            ),
+            TableSpec::new(
+                TableShape::new(table_b_arity, 1),
+                // Column 0 opened both directly and through the repeat-last successor view,
+                // at the same sampled point, which is what puts a `Statements::Next` entry
+                // into the constraint the final check evaluates.
+                vec![OpeningBatch::new(vec![0], vec![0])],
+            ),
+        ]);
+
+        let config = BinaryPcsConfig::try_new(stacked_arity, 0, params()).unwrap();
+        let pcs: BinaryPcs<MyMmcs, SuffixProver<F, F>> = BinaryPcs::new(config, mmcs());
+
+        let mut prover_challenger = challenger();
+        let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+        let proof = pcs.open(prover_data, protocol.clone(), &mut prover_challenger);
+
+        let mut verifier_challenger = challenger();
+        pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol)
+            .unwrap();
+    }
+}

--- a/binary-pcs/src/pcs.rs
+++ b/binary-pcs/src/pcs.rs
@@ -12,7 +12,6 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use core::marker::PhantomData;
 
 use p3_binary_dft::AdditiveRsEncoder;
 use p3_binary_field::BinaryField128;
@@ -22,9 +21,10 @@ use p3_field::PrimeCharacteristicRing;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, Verifier, Witness};
-use p3_sumcheck::strategy::{Basis, VariableOrder};
+use p3_sumcheck::strategy::Basis;
 use p3_sumcheck::{OpeningEvals, OpeningProtocol, PrescribedPointPcs, SumcheckData, SumcheckError};
 
+use crate::PcsLayout;
 use crate::error::BinaryPcsError;
 use crate::params::BinaryPcsConfig;
 use crate::proof::BinaryPcsProof;
@@ -34,38 +34,35 @@ use crate::verifier::{check_round_and_final_lengths, verify_query_paths};
 /// A multilinear polynomial commitment scheme over `BinaryField128`: an additive-domain
 /// Reed-Solomon codeword folded in lockstep with a residual sumcheck.
 ///
-/// `L` selects the stacked-layout binding mode; the commit and fold phases reject any layout
-/// other than [`SuffixProver`](p3_sumcheck::layout::SuffixProver) at run time (see `prover.rs`),
-/// since the codeword fold only stays in correspondence with suffix-order binding.
-pub struct BinaryPcs<MT, L> {
+/// The stacked-layout binding mode is fixed rather than chosen: the codeword fold merges
+/// adjacent pairs, which only the suffix-order binding of
+/// [`SuffixProver`](p3_sumcheck::layout::SuffixProver) matches.
+pub struct BinaryPcs<MT> {
     config: BinaryPcsConfig,
     mmcs: MT,
     encoder: AdditiveRsEncoder<BinaryField128>,
-    _marker: PhantomData<L>,
 }
 
-impl<MT, L> BinaryPcs<MT, L> {
+impl<MT> BinaryPcs<MT> {
     /// Builds a PCS instance from a derived configuration and a base-field MMCS.
     pub fn new(config: BinaryPcsConfig, mmcs: MT) -> Self {
         Self {
             config,
             mmcs,
             encoder: AdditiveRsEncoder::default(),
-            _marker: PhantomData,
         }
     }
 }
 
-impl<MT, L> BinaryPcs<MT, L>
+impl<MT> BinaryPcs<MT>
 where
     MT: Mmcs<BinaryField128>,
-    L: Layout<BinaryField128, BinaryField128>,
 {
     /// Runs the fold-and-query pipeline shared by `open` and `open_at`, once every opening
     /// claim the protocol names has already been recorded against `prover_data.layout`.
     fn finish_open<Challenger>(
         &self,
-        prover_data: BinaryPcsProverData<MT, L>,
+        prover_data: BinaryPcsProverData<MT>,
         evals: Vec<OpeningEvals<BinaryField128>>,
         challenger: &mut Challenger,
     ) -> BinaryPcsProof<MT>
@@ -136,12 +133,6 @@ where
             + CanSampleUniformBits<BinaryField128>
             + CanObserve<MT::Commitment>,
     {
-        assert_eq!(
-            L::strategy().variable_order,
-            VariableOrder::Suffix,
-            "the codeword folds adjacent pairs, which only suffix-order binding matches"
-        );
-
         if protocol.num_openings() != proof.evals.len() {
             return Err(BinaryPcsError::OpeningBatchCountMismatch {
                 expected: protocol.num_openings(),
@@ -173,7 +164,7 @@ where
         // replayed randomness, not the proof's raw bytes.
         let mut layout_verifier = Verifier::<BinaryField128, BinaryField128>::new(
             &protocol.table_shapes(),
-            L::strategy(),
+            PcsLayout::strategy(),
         );
 
         for (i, (table_idx, batch)) in protocol.iter_openings().enumerate() {
@@ -221,12 +212,12 @@ where
             }
         }
 
-        // The codeword fold runs in `L`'s own variable order: suffix binding folds the last
-        // variable first, so `betas` ends up in round order, and the committed polynomial's
-        // variable-order point is its reverse — exactly what `eval_constraints_poly`
-        // reconstructs internally when given that same order.
+        // The codeword fold runs in the layout's own variable order: suffix binding folds the
+        // last variable first, so `betas` ends up in round order, and the committed
+        // polynomial's variable-order point is its reverse — exactly what
+        // `eval_constraints_poly` reconstructs internally when given that same order.
         let fold_point = Point::new(betas);
-        let evaluation_of_weights = L::strategy()
+        let evaluation_of_weights = PcsLayout::strategy()
             .variable_order
             .eval_constraints_poly(core::slice::from_ref(&constraint), &fold_point);
         let final_value = proof.final_codeword.as_slice()[0];
@@ -252,10 +243,9 @@ where
     }
 }
 
-impl<MT, L, Challenger> MultilinearPcs<BinaryField128, Challenger> for BinaryPcs<MT, L>
+impl<MT, Challenger> MultilinearPcs<BinaryField128, Challenger> for BinaryPcs<MT>
 where
     MT: Mmcs<BinaryField128>,
-    L: Layout<BinaryField128, BinaryField128>,
     Challenger: FieldChallenger<BinaryField128>
         + GrindingChallenger<Witness = BinaryField128>
         + CanSampleUniformBits<BinaryField128>
@@ -263,7 +253,7 @@ where
 {
     type Val = BinaryField128;
     type Commitment = MT::Commitment;
-    type ProverData = BinaryPcsProverData<MT, L>;
+    type ProverData = BinaryPcsProverData<MT>;
     type Proof = BinaryPcsProof<MT>;
     type Error = BinaryPcsError<MT::Error>;
     type Witness = Witness<BinaryField128>;
@@ -278,7 +268,7 @@ where
         witness: Self::Witness,
         challenger: &mut Challenger,
     ) -> (Self::Commitment, Self::ProverData) {
-        commit::<L, _, MT, _>(&self.config, &self.encoder, &self.mmcs, challenger, witness)
+        commit(&self.config, &self.encoder, &self.mmcs, challenger, witness)
     }
 
     fn open(
@@ -309,10 +299,9 @@ where
     }
 }
 
-impl<MT, L, Challenger> PrescribedPointPcs<BinaryField128, Challenger> for BinaryPcs<MT, L>
+impl<MT, Challenger> PrescribedPointPcs<BinaryField128, Challenger> for BinaryPcs<MT>
 where
     MT: Mmcs<BinaryField128>,
-    L: Layout<BinaryField128, BinaryField128>,
     Challenger: FieldChallenger<BinaryField128>
         + GrindingChallenger<Witness = BinaryField128>
         + CanSampleUniformBits<BinaryField128>
@@ -375,7 +364,7 @@ mod tests {
     use p3_challenger::{CanObserve, FieldChallenger};
     use p3_commit::{Mmcs, MultilinearPcs};
     use p3_multilinear_util::point::Point;
-    use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
+    use p3_sumcheck::layout::{Layout, SuffixProver, Table};
     use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
@@ -395,29 +384,11 @@ mod tests {
     /// show up as a failure rather than pass by sharing state.
     #[test]
     fn commit_open_verify_round_trips() {
-        let (pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES, 0);
+        let (pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES);
 
         let mut verifier_challenger = challenger();
         pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol)
             .unwrap();
-    }
-
-    /// A verifier instantiated with a `PrefixProver` layout is stopped before it inspects any
-    /// proof content: `verify_opening` asserts `L::strategy()` against `VariableOrder::Suffix`,
-    /// mirroring the same guard on the prover side (`prover::commit`, `prover::fold_rounds`).
-    /// Without it, a `BinaryPcs<MT, PrefixProver<F, F>>` verifier would run the whole protocol
-    /// against a genuine `SuffixProver` proof and reject it only at `FinalCheck`, with no
-    /// indication that the layouts disagree.
-    #[test]
-    #[should_panic(expected = "only suffix-order binding matches")]
-    fn verify_rejects_a_non_suffix_layout() {
-        let (_pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES, 0);
-
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
-        let mismatched_pcs: BinaryPcs<MyMmcs, PrefixProver<F, F>> = BinaryPcs::new(config, mmcs());
-
-        let mut verifier_challenger = challenger();
-        let _ = mismatched_pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol);
     }
 
     /// The workspace wire format is postcard, which is not self-describing; a proof type that
@@ -425,7 +396,7 @@ mod tests {
     /// also exercises the `Poly` deserialize path `FinalCodewordLengthMismatch` exists to guard.
     #[test]
     fn a_proof_round_trips_through_postcard() {
-        let (pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES, 0);
+        let (pcs, commitment, proof, protocol) = run_lifecycle(NUM_VARIABLES);
 
         let bytes = postcard::to_allocvec(&proof).unwrap();
         let decoded: BinaryPcsProof<MyMmcs> = postcard::from_bytes(&bytes).unwrap();
@@ -455,7 +426,7 @@ mod tests {
     fn open_at_fixture(
         seed: u64,
     ) -> (
-        BinaryPcs<MyMmcs, SuffixProver<F, F>>,
+        BinaryPcs<MyMmcs>,
         <MyMmcs as Mmcs<F>>::Commitment,
         BinaryPcsProof<MyMmcs>,
         OpeningProtocol,
@@ -470,7 +441,7 @@ mod tests {
             vec![OpeningBatch::new(vec![0], Vec::new())],
         )]);
 
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params()).unwrap();
         let pcs = BinaryPcs::new(config, mmcs());
 
         let mut prover_challenger = challenger();
@@ -580,8 +551,8 @@ mod tests {
             ),
         ]);
 
-        let config = BinaryPcsConfig::try_new(stacked_arity, 0, params()).unwrap();
-        let pcs: BinaryPcs<MyMmcs, SuffixProver<F, F>> = BinaryPcs::new(config, mmcs());
+        let config = BinaryPcsConfig::try_new(stacked_arity, params()).unwrap();
+        let pcs: BinaryPcs<MyMmcs> = BinaryPcs::new(config, mmcs());
 
         let mut prover_challenger = challenger();
         let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);

--- a/binary-pcs/src/proof.rs
+++ b/binary-pcs/src/proof.rs
@@ -1,0 +1,58 @@
+//! Proof types produced by the commit-fold-query pipeline.
+
+use alloc::vec::Vec;
+
+use p3_binary_field::BinaryField128;
+use p3_commit::Mmcs;
+use p3_multilinear_util::poly::Poly;
+use p3_sumcheck::{OpeningEvals, SumcheckData};
+use serde::{Deserialize, Serialize};
+
+/// One intermediate folding round: the commitment to that round's folded codeword, and its
+/// query openings.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "MT::Commitment: Serialize, MT::MultiProof: Serialize",
+    deserialize = "MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
+))]
+pub struct RoundProof<MT: Mmcs<BinaryField128>> {
+    /// Merkle root of this round's folded codeword.
+    pub commitment: MT::Commitment,
+    /// Opened rows, two per query — the low- then high-indexed symbol of that query's fold
+    /// pair at this round — in the order the query indices were sampled.
+    pub opened_values: Vec<Vec<BinaryField128>>,
+    /// One multiproof authenticating every opened row of this round together.
+    pub multi_proof: MT::MultiProof,
+}
+
+/// A full opening proof.
+///
+/// The last folding round has no [`RoundProof`]: its codeword has already shrunk to
+/// `2^log_inv_rate` symbols, so it is sent in full as `final_codeword` instead of committed —
+/// a Merkle path over it would only repeat what the verifier can already read directly. Every
+/// earlier round appears in `rounds`, committed and opened at the paired positions each query
+/// needs.
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "MT::Commitment: Serialize, MT::MultiProof: Serialize",
+    deserialize = "MT::Commitment: Deserialize<'de>, MT::MultiProof: Deserialize<'de>"
+))]
+pub struct BinaryPcsProof<MT: Mmcs<BinaryField128>> {
+    /// Every sumcheck round message, in round order.
+    pub sumcheck: SumcheckData<BinaryField128, BinaryField128>,
+    /// One entry per intermediate folding round, i.e. every folding round except the last.
+    pub rounds: Vec<RoundProof<MT>>,
+    /// Openings of the base commitment: two width-1 rows per query — the pair's low- then
+    /// high-indexed symbol — in the order query indices were sampled.
+    pub base_opened_values: Vec<Vec<BinaryField128>>,
+    /// Multiproof for the base commitment's queried rows.
+    pub base_multi_proof: MT::MultiProof,
+    /// The final folded codeword, sent in full.
+    pub final_codeword: Poly<BinaryField128>,
+    /// Witness for the single grind before the query phase.
+    pub pow_witness: BinaryField128,
+    /// Opening-protocol claimed evaluations, in schedule order: one batch per
+    /// [`p3_sumcheck::OpeningProtocol`] entry, each holding the current-point evaluations
+    /// separately from the repeat-last successor-point evaluations.
+    pub evals: Vec<OpeningEvals<BinaryField128>>,
+}

--- a/binary-pcs/src/prover.rs
+++ b/binary-pcs/src/prover.rs
@@ -1,16 +1,17 @@
-//! Prover side: commit the stacked polynomial at `folding = 0`, then fold its codeword in
-//! lockstep with the residual sumcheck.
+//! Prover side: commit the stacked polynomial as one codeword column, then fold that codeword
+//! in lockstep with the residual sumcheck.
 //!
-//! At `folding = 0`, `Layout::commit` produces a width-1 codeword — one Reed-Solomon-encoded
-//! column, the whole committed polynomial — and `Layout::into_sumcheck` consumes zero
-//! preprocessing rounds, so every one of the `num_variables` residual sumcheck rounds is a
-//! folding round. Each round's challenge both binds one multilinear variable, through
-//! [`SuffixProver`](p3_sumcheck::layout::SuffixProver)'s evaluation-basis binding, and folds
-//! the codeword by the same challenge, through [`fold_codeword`], a Reed-Solomon codeword fold
+//! [`PcsLayout`] commits with no preprocessing depth, so `Layout::commit` produces a width-1
+//! codeword — one Reed-Solomon-encoded column, the whole committed polynomial — and
+//! `Layout::into_sumcheck` consumes zero preprocessing rounds, leaving every one of the
+//! `num_variables` residual sumcheck rounds a folding round. Each round's challenge is used
+//! twice: it binds one multilinear variable, through [`PcsLayout`]'s evaluation-basis suffix
+//! binding, and it folds the codeword, through [`fold_codeword`], a Reed-Solomon codeword fold
 //! in the same basis (see `fold.rs`). The two stay in correspondence throughout: see
 //! `the_codeword_and_the_sumcheck_stay_in_lockstep` below, which drives the real `Layout`
 //! machinery and checks it, and `prefix_layout_does_not_stay_in_lockstep`, which checks that
-//! `PrefixProver`'s prefix-first binding does not share the property.
+//! prefix-first binding does not share the property — the reason [`PcsLayout`] is fixed rather
+//! than chosen by the caller.
 
 use alloc::vec::Vec;
 
@@ -21,22 +22,31 @@ use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_multilinear_util::point::Point;
 use p3_sumcheck::SumcheckData;
 use p3_sumcheck::layout::{Layout, Witness};
-use p3_sumcheck::strategy::VariableOrder;
 
+use crate::PcsLayout;
 use crate::fold::fold_codeword;
 use crate::params::BinaryPcsConfig;
 use crate::proof::RoundProof;
 use crate::verifier::{flat_pair_indices, sample_query_indices};
 
+/// Preprocessing depth the commit phase lays out inside a committed row.
+///
+/// Zero, so the codeword is a single column and every variable is folded rather than bound
+/// across a row. Binding a prefix inside the row is the deferred head collapse, which needs
+/// its own eq-weighted column combination before it composes with the folds below.
+const FOLDING: usize = 0;
+
 /// Data produced by committing the base codeword: the layout used to build the residual
 /// sumcheck, and the base commitment's Merkle prover data.
-pub struct BinaryPcsProverData<MT: Mmcs<BinaryField128>, L> {
+///
+/// Opaque to callers, who receive it from `commit` and hand it back to `open`.
+pub struct BinaryPcsProverData<MT: Mmcs<BinaryField128>> {
     /// The layout that ran the commit phase, carried forward to build the residual sumcheck
     /// and, later, to evaluate opening claims against the committed polynomial.
-    pub layout: L,
+    pub(crate) layout: PcsLayout,
     /// The base codeword's Merkle prover data, needed to open base-round queries once the
     /// query phase samples its indices.
-    pub merkle_data: MT::ProverData<DenseMatrix<BinaryField128>>,
+    pub(crate) merkle_data: MT::ProverData<DenseMatrix<BinaryField128>>,
 }
 
 /// One folding round's prover-side output.
@@ -50,17 +60,15 @@ pub(crate) struct RoundCommitment<MT: Mmcs<BinaryField128>> {
 /// Commits `witness`'s stacked polynomial and returns the base commitment alongside the data
 /// needed to run the residual sumcheck and later open the base codeword's queries.
 ///
-/// `witness` must have `config.num_variables()` variables and `config.folding()` preprocessing
-/// depth.
-pub(crate) fn commit<L, E, MT, Ch>(
+/// `witness` must have `config.num_variables()` variables and be built at [`FOLDING`].
+pub(crate) fn commit<E, MT, Ch>(
     config: &BinaryPcsConfig,
     encoder: &E,
     mmcs: &MT,
     challenger: &mut Ch,
     witness: Witness<BinaryField128>,
-) -> (MT::Commitment, BinaryPcsProverData<MT, L>)
+) -> (MT::Commitment, BinaryPcsProverData<MT>)
 where
-    L: Layout<BinaryField128, BinaryField128>,
     E: Encoder<BinaryField128>,
     MT: Mmcs<BinaryField128>,
     Ch: FieldChallenger<BinaryField128>
@@ -68,23 +76,17 @@ where
         + CanObserve<MT::Commitment>,
 {
     assert_eq!(
-        L::strategy().variable_order,
-        VariableOrder::Suffix,
-        "the codeword folds adjacent pairs, which only suffix-order binding matches"
-    );
-
-    assert_eq!(
         witness.num_variables(),
         config.num_variables(),
         "witness arity must match the config it is committed against"
     );
 
-    let (layout, commitment, merkle_data) = L::commit(
+    let (layout, commitment, merkle_data) = PcsLayout::commit(
         encoder,
         mmcs,
         challenger,
         witness,
-        config.folding(),
+        FOLDING,
         config.log_inv_rate(),
     );
 
@@ -112,8 +114,8 @@ where
 /// folded codeword.
 #[must_use]
 #[allow(clippy::type_complexity)]
-pub(crate) fn fold_rounds<L, MT, Ch>(
-    prover_data: BinaryPcsProverData<MT, L>,
+pub(crate) fn fold_rounds<MT, Ch>(
+    prover_data: BinaryPcsProverData<MT>,
     config: &BinaryPcsConfig,
     mmcs: &MT,
     challenger: &mut Ch,
@@ -125,18 +127,11 @@ pub(crate) fn fold_rounds<L, MT, Ch>(
     Vec<BinaryField128>,
 )
 where
-    L: Layout<BinaryField128, BinaryField128>,
     MT: Mmcs<BinaryField128>,
     Ch: FieldChallenger<BinaryField128>
         + GrindingChallenger<Witness = BinaryField128>
         + CanObserve<MT::Commitment>,
 {
-    assert_eq!(
-        L::strategy().variable_order,
-        VariableOrder::Suffix,
-        "the codeword folds adjacent pairs, which only suffix-order binding matches"
-    );
-
     let BinaryPcsProverData {
         layout,
         merkle_data,
@@ -147,15 +142,14 @@ where
     assert_eq!(
         randomness.num_variables(),
         0,
-        "the commit phase runs at folding = 0, so the residual sumcheck consumes no head rounds"
+        "the commit phase runs at zero preprocessing depth, so the sumcheck consumes no head rounds"
     );
 
-    // At folding = 0, the base commitment is a width-1 codeword: the starting point for the
-    // fold loop below.
+    // The base commitment is a width-1 codeword: the starting point for the fold loop below.
     let base_matrix = mmcs.get_matrices(&merkle_data)[0];
     assert_eq!(
         base_matrix.width, 1,
-        "folding = 0 commits a width-1 codeword"
+        "zero preprocessing depth commits a width-1 codeword"
     );
     let mut codeword = base_matrix.values.clone();
 
@@ -285,7 +279,7 @@ mod tests {
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
-    use super::{BinaryPcsProverData, commit, fold_codeword, fold_rounds};
+    use super::{commit, fold_codeword, fold_rounds};
     use crate::params::{BinaryPcsConfig, BinaryPcsParams};
     use crate::test_util::{challenger, mmcs};
 
@@ -330,9 +324,13 @@ mod tests {
         assert!(codeword.iter().all(|&v| v == final_value));
     }
 
-    /// The lockstep property is specific to `SuffixProver`'s evaluation-basis binding order:
-    /// driving the identical procedure through `PrefixProver` does not leave every symbol of
-    /// the final codeword equal to the constant the sumcheck folds to.
+    /// The lockstep property is specific to suffix binding's evaluation-basis order: driving
+    /// the identical procedure through `PrefixProver` does not leave every symbol of the final
+    /// codeword equal to the constant the sumcheck folds to.
+    ///
+    /// This is why `PcsLayout` is a fixed type rather than a caller-supplied parameter: the
+    /// two orders are not interchangeable, and the difference is a property of the fold's
+    /// pair-merging arithmetic, not a tuning choice.
     #[test]
     fn prefix_layout_does_not_stay_in_lockstep() {
         let mut rng = SmallRng::seed_from_u64(21);
@@ -384,18 +382,13 @@ mod tests {
             pow_bits: 4,
             security_level: 40,
         };
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params).unwrap();
         let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
         let mmcs_instance = mmcs();
 
         let mut ch = challenger();
-        let (_commitment, prover_data) = commit::<SuffixProver<F, F>, _, _, _>(
-            &config,
-            &encoder,
-            &mmcs_instance,
-            &mut ch,
-            witness,
-        );
+        let (_commitment, prover_data) =
+            commit(&config, &encoder, &mmcs_instance, &mut ch, witness);
         let (_merkle_data, _sumcheck_data, rounds, randomness, final_codeword) =
             fold_rounds(prover_data, &config, &mmcs_instance, &mut ch);
 
@@ -410,33 +403,6 @@ mod tests {
         assert!(final_codeword.iter().all(|&v| v == expected));
     }
 
-    /// `commit` rejects a `PrefixProver` layout before doing any work: the codeword fold only
-    /// matches suffix-order binding.
-    #[test]
-    #[should_panic(expected = "only suffix-order binding matches")]
-    fn commit_rejects_a_non_suffix_layout() {
-        let params = BinaryPcsParams {
-            log_inv_rate: LOG_INV_RATE,
-            pow_bits: 4,
-            security_level: 40,
-        };
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
-        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
-        let mmcs_instance = mmcs();
-        let mut ch = challenger();
-        let poly = Poly::<F>::rand(&mut SmallRng::seed_from_u64(0), NUM_VARIABLES);
-        let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
-        let witness = PrefixProver::<F, F>::new_witness(vec![table], 0);
-
-        let _ = commit::<PrefixProver<F, F>, _, _, _>(
-            &config,
-            &encoder,
-            &mmcs_instance,
-            &mut ch,
-            witness,
-        );
-    }
-
     /// `commit` rejects a witness whose arity disagrees with the config in every build
     /// profile, not only a debug one: falling through would surface later as a confusing
     /// `FinalCodewordLengthMismatch`, or a panic inside `fold_codeword` on a length-1
@@ -449,7 +415,7 @@ mod tests {
             pow_bits: 4,
             security_level: 40,
         };
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params).unwrap();
         let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
         let mmcs_instance = mmcs();
         let mut ch = challenger();
@@ -457,46 +423,6 @@ mod tests {
         let table = Table::rand(&mut rng, 1, NUM_VARIABLES - 1);
         let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
 
-        let _ = commit::<SuffixProver<F, F>, _, _, _>(
-            &config,
-            &encoder,
-            &mmcs_instance,
-            &mut ch,
-            witness,
-        );
-    }
-
-    /// `fold_rounds` rejects a `PrefixProver` layout too, independently of `commit`'s own
-    /// guard: a caller that assembled `BinaryPcsProverData` by some other path must still be
-    /// stopped here.
-    #[test]
-    #[should_panic(expected = "only suffix-order binding matches")]
-    fn fold_rounds_rejects_a_non_suffix_layout() {
-        let mut rng = SmallRng::seed_from_u64(21);
-        let table = Table::rand(&mut rng, 1, NUM_VARIABLES);
-        let witness = PrefixProver::<F, F>::new_witness(vec![table], 0);
-
-        let mut ch = challenger();
-        let (layout, _root, merkle_data) = PrefixProver::<F, F>::commit(
-            &AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default(),
-            &mmcs(),
-            &mut ch,
-            witness,
-            0,
-            LOG_INV_RATE,
-        );
-
-        let params = BinaryPcsParams {
-            log_inv_rate: LOG_INV_RATE,
-            pow_bits: 4,
-            security_level: 40,
-        };
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
-        let prover_data = BinaryPcsProverData {
-            layout,
-            merkle_data,
-        };
-
-        let _ = fold_rounds(prover_data, &config, &mmcs(), &mut ch);
+        let _ = commit(&config, &encoder, &mmcs_instance, &mut ch, witness);
     }
 }

--- a/binary-pcs/src/prover.rs
+++ b/binary-pcs/src/prover.rs
@@ -1,0 +1,502 @@
+//! Prover side: commit the stacked polynomial at `folding = 0`, then fold its codeword in
+//! lockstep with the residual sumcheck.
+//!
+//! At `folding = 0`, `Layout::commit` produces a width-1 codeword — one Reed-Solomon-encoded
+//! column, the whole committed polynomial — and `Layout::into_sumcheck` consumes zero
+//! preprocessing rounds, so every one of the `num_variables` residual sumcheck rounds is a
+//! folding round. Each round's challenge both binds one multilinear variable, through
+//! [`SuffixProver`](p3_sumcheck::layout::SuffixProver)'s evaluation-basis binding, and folds
+//! the codeword by the same challenge, through [`fold_codeword`], a Reed-Solomon codeword fold
+//! in the same basis (see `fold.rs`). The two stay in correspondence throughout: see
+//! `the_codeword_and_the_sumcheck_stay_in_lockstep` below, which drives the real `Layout`
+//! machinery and checks it, and `prefix_layout_does_not_stay_in_lockstep`, which checks that
+//! `PrefixProver`'s prefix-first binding does not share the property.
+
+use alloc::vec::Vec;
+
+use p3_binary_field::BinaryField128;
+use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_commit::{Encoder, Mmcs};
+use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
+use p3_multilinear_util::point::Point;
+use p3_sumcheck::SumcheckData;
+use p3_sumcheck::layout::{Layout, Witness};
+use p3_sumcheck::strategy::VariableOrder;
+
+use crate::fold::fold_codeword;
+use crate::params::BinaryPcsConfig;
+use crate::proof::RoundProof;
+use crate::verifier::{flat_pair_indices, sample_query_indices};
+
+/// Data produced by committing the base codeword: the layout used to build the residual
+/// sumcheck, and the base commitment's Merkle prover data.
+pub struct BinaryPcsProverData<MT: Mmcs<BinaryField128>, L> {
+    /// The layout that ran the commit phase, carried forward to build the residual sumcheck
+    /// and, later, to evaluate opening claims against the committed polynomial.
+    pub layout: L,
+    /// The base codeword's Merkle prover data, needed to open base-round queries once the
+    /// query phase samples its indices.
+    pub merkle_data: MT::ProverData<DenseMatrix<BinaryField128>>,
+}
+
+/// One folding round's prover-side output.
+pub(crate) struct RoundCommitment<MT: Mmcs<BinaryField128>> {
+    /// Merkle root of this round's folded codeword.
+    pub commitment: MT::Commitment,
+    /// Merkle prover data for this round's folded codeword, needed to open its queries.
+    pub merkle_data: MT::ProverData<DenseMatrix<BinaryField128>>,
+}
+
+/// Commits `witness`'s stacked polynomial and returns the base commitment alongside the data
+/// needed to run the residual sumcheck and later open the base codeword's queries.
+///
+/// `witness` must have `config.num_variables()` variables and `config.folding()` preprocessing
+/// depth.
+pub(crate) fn commit<L, E, MT, Ch>(
+    config: &BinaryPcsConfig,
+    encoder: &E,
+    mmcs: &MT,
+    challenger: &mut Ch,
+    witness: Witness<BinaryField128>,
+) -> (MT::Commitment, BinaryPcsProverData<MT, L>)
+where
+    L: Layout<BinaryField128, BinaryField128>,
+    E: Encoder<BinaryField128>,
+    MT: Mmcs<BinaryField128>,
+    Ch: FieldChallenger<BinaryField128>
+        + GrindingChallenger<Witness = BinaryField128>
+        + CanObserve<MT::Commitment>,
+{
+    assert_eq!(
+        L::strategy().variable_order,
+        VariableOrder::Suffix,
+        "the codeword folds adjacent pairs, which only suffix-order binding matches"
+    );
+
+    assert_eq!(
+        witness.num_variables(),
+        config.num_variables(),
+        "witness arity must match the config it is committed against"
+    );
+
+    let (layout, commitment, merkle_data) = L::commit(
+        encoder,
+        mmcs,
+        challenger,
+        witness,
+        config.folding(),
+        config.log_inv_rate(),
+    );
+
+    (
+        commitment,
+        BinaryPcsProverData {
+            layout,
+            merkle_data,
+        },
+    )
+}
+
+/// Runs the residual sumcheck in lockstep with the codeword fold: one sumcheck round, one
+/// 2-to-1 fold, per iteration, with one Merkle commitment for every fold except the last —
+/// that fold's codeword is returned directly as the final codeword rather than committed, since
+/// its whole content already travels in the clear.
+///
+/// The single grinding budget is spent once before the query phase, not here, so every round
+/// runs with `pow_bits = 0`.
+///
+/// Returns the base commitment's Merkle prover data (handed back so the caller can still open
+/// base-round queries against it), the sumcheck transcript, one [`RoundCommitment`] per fold
+/// round except the last, the folding randomness in round order — `randomness.as_slice()[r]` is
+/// round `r`'s challenge, matching what [`Layout::into_sumcheck`] returns — and the final
+/// folded codeword.
+#[must_use]
+#[allow(clippy::type_complexity)]
+pub(crate) fn fold_rounds<L, MT, Ch>(
+    prover_data: BinaryPcsProverData<MT, L>,
+    config: &BinaryPcsConfig,
+    mmcs: &MT,
+    challenger: &mut Ch,
+) -> (
+    MT::ProverData<DenseMatrix<BinaryField128>>,
+    SumcheckData<BinaryField128, BinaryField128>,
+    Vec<RoundCommitment<MT>>,
+    Point<BinaryField128>,
+    Vec<BinaryField128>,
+)
+where
+    L: Layout<BinaryField128, BinaryField128>,
+    MT: Mmcs<BinaryField128>,
+    Ch: FieldChallenger<BinaryField128>
+        + GrindingChallenger<Witness = BinaryField128>
+        + CanObserve<MT::Commitment>,
+{
+    assert_eq!(
+        L::strategy().variable_order,
+        VariableOrder::Suffix,
+        "the codeword folds adjacent pairs, which only suffix-order binding matches"
+    );
+
+    let BinaryPcsProverData {
+        layout,
+        merkle_data,
+    } = prover_data;
+
+    let mut sumcheck_data = SumcheckData::default();
+    let (mut sumcheck, mut randomness) = layout.into_sumcheck(&mut sumcheck_data, 0, challenger);
+    assert_eq!(
+        randomness.num_variables(),
+        0,
+        "the commit phase runs at folding = 0, so the residual sumcheck consumes no head rounds"
+    );
+
+    // At folding = 0, the base commitment is a width-1 codeword: the starting point for the
+    // fold loop below.
+    let base_matrix = mmcs.get_matrices(&merkle_data)[0];
+    assert_eq!(
+        base_matrix.width, 1,
+        "folding = 0 commits a width-1 codeword"
+    );
+    let mut codeword = base_matrix.values.clone();
+
+    // One sumcheck round, one codeword fold, per iteration. The last fold's codeword is not
+    // committed: it is returned as the final codeword, so the round loop only commits the
+    // folds a `RoundCommitment` actually needs.
+    let num_fold_rounds = config.num_fold_rounds();
+    let mut rounds = Vec::with_capacity(num_fold_rounds - 1);
+    for round in 0..num_fold_rounds {
+        let challenge =
+            sumcheck.compute_sumcheck_polynomials(&mut sumcheck_data, challenger, 1, 0, None);
+        let beta = challenge.as_slice()[0];
+        randomness.extend(&challenge);
+
+        codeword = fold_codeword(&codeword, beta);
+
+        if round + 1 < num_fold_rounds {
+            let (commitment, round_data) =
+                mmcs.commit_matrix(RowMajorMatrix::new(codeword.clone(), 1));
+            challenger.observe(commitment.clone());
+            rounds.push(RoundCommitment {
+                commitment,
+                merkle_data: round_data,
+            });
+        }
+    }
+
+    (merkle_data, sumcheck_data, rounds, randomness, codeword)
+}
+
+/// The query phase's prover-side output: every opening `verifier::verify_query_paths` needs,
+/// plus the grinding witness.
+pub(crate) struct QueryProofs<MT: Mmcs<BinaryField128>> {
+    /// Openings of the base commitment: two width-1 rows per query — the pair's low- then
+    /// high-indexed symbol — in the order query indices were sampled.
+    pub base_opened_values: Vec<Vec<BinaryField128>>,
+    /// Multiproof for the base commitment's queried rows.
+    pub base_multi_proof: MT::MultiProof,
+    /// One [`RoundProof`] per intermediate folding round, i.e. every round except the last.
+    pub rounds: Vec<RoundProof<MT>>,
+    /// Witness for the single grind before the query phase.
+    pub pow_witness: BinaryField128,
+}
+
+/// Runs the query phase: grinds the single proof-of-work witness, samples query indices from
+/// the base codeword's domain, then opens the base commitment and every intermediate
+/// folding-round commitment at the paired indices each sampled query needs.
+///
+/// `rounds` is every [`RoundCommitment`] `fold_rounds` produced: one per fold round except the
+/// last, whose codeword is never committed — it travels in the clear as the proof's
+/// `final_codeword` instead, so a Merkle path for it would only repeat what the verifier can
+/// already read directly.
+pub(crate) fn open_queries<MT, Ch>(
+    config: &BinaryPcsConfig,
+    mmcs: &MT,
+    challenger: &mut Ch,
+    base_merkle_data: &MT::ProverData<DenseMatrix<BinaryField128>>,
+    rounds: &[RoundCommitment<MT>],
+) -> QueryProofs<MT>
+where
+    MT: Mmcs<BinaryField128>,
+    Ch: FieldChallenger<BinaryField128>
+        + GrindingChallenger<Witness = BinaryField128>
+        + CanSampleUniformBits<BinaryField128>,
+{
+    assert_eq!(
+        rounds.len(),
+        config.num_fold_rounds() - 1,
+        "rounds is the caller's own fold_rounds output, never proof-supplied data"
+    );
+
+    let pow_witness = challenger.grind(config.pow_bits());
+
+    let domain_size = config.domain_size();
+    let indices =
+        sample_query_indices::<_, BinaryField128>(domain_size, config.num_queries(), challenger);
+
+    let base_indices = flat_pair_indices(&indices, 0);
+    let (base_values, base_multi_proof) = mmcs.open_multi_batch(&base_indices, base_merkle_data);
+    let base_opened_values = single_matrix_rows(base_values);
+
+    let opened_rounds = rounds
+        .iter()
+        .enumerate()
+        .map(|(r, round)| {
+            let round_indices = flat_pair_indices(&indices, r + 1);
+            let (values, multi_proof) = mmcs.open_multi_batch(&round_indices, &round.merkle_data);
+            RoundProof {
+                commitment: round.commitment.clone(),
+                opened_values: single_matrix_rows(values),
+                multi_proof,
+            }
+        })
+        .collect();
+
+    QueryProofs {
+        base_opened_values,
+        base_multi_proof,
+        rounds: opened_rounds,
+        pow_witness,
+    }
+}
+
+/// Strips the always-one-matrix middle index from an [`Mmcs::open_multi_batch`] result,
+/// asserting the count instead of assuming it.
+fn single_matrix_rows(values: Vec<Vec<Vec<BinaryField128>>>) -> Vec<Vec<BinaryField128>> {
+    values
+        .into_iter()
+        .map(|mut per_matrix| {
+            assert_eq!(per_matrix.len(), 1, "each round commits exactly one matrix");
+            per_matrix.swap_remove(0)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_binary_dft::{AdditiveRsEncoder, NaiveAdditiveNtt};
+    use p3_binary_field::BinaryField128;
+    use p3_commit::Mmcs;
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_multilinear_util::poly::Poly;
+    use p3_sumcheck::SumcheckData;
+    use p3_sumcheck::layout::{Layout, PrefixProver, SuffixProver, Table};
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::{BinaryPcsProverData, commit, fold_codeword, fold_rounds};
+    use crate::params::{BinaryPcsConfig, BinaryPcsParams};
+    use crate::test_util::{challenger, mmcs};
+
+    type F = BinaryField128;
+
+    const NUM_VARIABLES: usize = 8;
+    const LOG_INV_RATE: usize = 2;
+
+    /// After every round, the codeword and the sumcheck describe the same polynomial: the
+    /// final codeword's symbols all equal the constant the sumcheck folds to.
+    #[test]
+    fn the_codeword_and_the_sumcheck_stay_in_lockstep() {
+        let mut rng = SmallRng::seed_from_u64(21);
+        let table = Table::rand(&mut rng, 1, NUM_VARIABLES);
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let mut ch = challenger();
+        let (mut layout, _root, data) = SuffixProver::<F, F>::commit(
+            &AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default(),
+            &mmcs(),
+            &mut ch,
+            witness,
+            0,
+            LOG_INV_RATE,
+        );
+        let m = mmcs().get_matrices(&data)[0].clone();
+        assert_eq!(m.width, 1);
+        let mut codeword = m.values;
+
+        let _virtual_eval = layout.add_virtual_eval(&mut ch);
+        let mut sc = SumcheckData::<F, F>::default();
+        let (mut prover, head) = layout.into_sumcheck(&mut sc, 0, &mut ch);
+        assert_eq!(head.num_variables(), 0);
+
+        for _ in 0..prover.num_variables() {
+            let beta = prover.compute_sumcheck_polynomials(&mut sc, &mut ch, 1, 0, None);
+            codeword = fold_codeword(&codeword, beta.as_slice()[0]);
+        }
+
+        let final_value = prover.evals().as_constant().expect("fully folded");
+        assert_eq!(codeword.len(), 1 << LOG_INV_RATE);
+        assert!(codeword.iter().all(|&v| v == final_value));
+    }
+
+    /// The lockstep property is specific to `SuffixProver`'s evaluation-basis binding order:
+    /// driving the identical procedure through `PrefixProver` does not leave every symbol of
+    /// the final codeword equal to the constant the sumcheck folds to.
+    #[test]
+    fn prefix_layout_does_not_stay_in_lockstep() {
+        let mut rng = SmallRng::seed_from_u64(21);
+        let table = Table::rand(&mut rng, 1, NUM_VARIABLES);
+        let witness = PrefixProver::<F, F>::new_witness(vec![table], 0);
+
+        let mut ch = challenger();
+        let (mut layout, _root, data) = PrefixProver::<F, F>::commit(
+            &AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default(),
+            &mmcs(),
+            &mut ch,
+            witness,
+            0,
+            LOG_INV_RATE,
+        );
+        let m = mmcs().get_matrices(&data)[0].clone();
+        assert_eq!(m.width, 1);
+        let mut codeword = m.values;
+
+        let _virtual_eval = layout.add_virtual_eval(&mut ch);
+        let mut sc = SumcheckData::<F, F>::default();
+        let (mut prover, head) = layout.into_sumcheck(&mut sc, 0, &mut ch);
+        assert_eq!(head.num_variables(), 0);
+
+        for _ in 0..prover.num_variables() {
+            let beta = prover.compute_sumcheck_polynomials(&mut sc, &mut ch, 1, 0, None);
+            codeword = fold_codeword(&codeword, beta.as_slice()[0]);
+        }
+
+        let final_value = prover.evals().as_constant().expect("fully folded");
+        assert!(!codeword.iter().all(|&v| v == final_value));
+    }
+
+    /// Drives the crate's own [`commit`] and [`fold_rounds`] end to end and checks their
+    /// output against an independent oracle: folding the original message variable by
+    /// variable, via [`Poly::fix_suffix_var_mut`], over the randomness `fold_rounds` returns,
+    /// in the order returned, must produce the constant every symbol of the final codeword
+    /// equals.
+    #[test]
+    fn commit_and_fold_rounds_match_an_independent_message_fold() {
+        let mut rng = SmallRng::seed_from_u64(0xC0FFEE);
+        let poly = Poly::<F>::rand(&mut rng, NUM_VARIABLES);
+        let mut message = poly.clone();
+        let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let params = BinaryPcsParams {
+            log_inv_rate: LOG_INV_RATE,
+            pow_bits: 4,
+            security_level: 40,
+        };
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
+        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
+        let mmcs_instance = mmcs();
+
+        let mut ch = challenger();
+        let (_commitment, prover_data) = commit::<SuffixProver<F, F>, _, _, _>(
+            &config,
+            &encoder,
+            &mmcs_instance,
+            &mut ch,
+            witness,
+        );
+        let (_merkle_data, _sumcheck_data, rounds, randomness, final_codeword) =
+            fold_rounds(prover_data, &config, &mmcs_instance, &mut ch);
+
+        assert_eq!(rounds.len(), config.num_fold_rounds() - 1);
+        assert_eq!(randomness.num_variables(), NUM_VARIABLES);
+        assert_eq!(final_codeword.len(), 1 << LOG_INV_RATE);
+
+        for &beta in randomness.as_slice() {
+            message.fix_suffix_var_mut(beta);
+        }
+        let expected = message.as_constant().expect("fully folded");
+        assert!(final_codeword.iter().all(|&v| v == expected));
+    }
+
+    /// `commit` rejects a `PrefixProver` layout before doing any work: the codeword fold only
+    /// matches suffix-order binding.
+    #[test]
+    #[should_panic(expected = "only suffix-order binding matches")]
+    fn commit_rejects_a_non_suffix_layout() {
+        let params = BinaryPcsParams {
+            log_inv_rate: LOG_INV_RATE,
+            pow_bits: 4,
+            security_level: 40,
+        };
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
+        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
+        let mmcs_instance = mmcs();
+        let mut ch = challenger();
+        let poly = Poly::<F>::rand(&mut SmallRng::seed_from_u64(0), NUM_VARIABLES);
+        let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
+        let witness = PrefixProver::<F, F>::new_witness(vec![table], 0);
+
+        let _ = commit::<PrefixProver<F, F>, _, _, _>(
+            &config,
+            &encoder,
+            &mmcs_instance,
+            &mut ch,
+            witness,
+        );
+    }
+
+    /// `commit` rejects a witness whose arity disagrees with the config in every build
+    /// profile, not only a debug one: falling through would surface later as a confusing
+    /// `FinalCodewordLengthMismatch`, or a panic inside `fold_codeword` on a length-1
+    /// codeword, instead of at the actual precondition.
+    #[test]
+    #[should_panic(expected = "witness arity must match the config it is committed against")]
+    fn commit_rejects_a_witness_arity_mismatch() {
+        let params = BinaryPcsParams {
+            log_inv_rate: LOG_INV_RATE,
+            pow_bits: 4,
+            security_level: 40,
+        };
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
+        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
+        let mmcs_instance = mmcs();
+        let mut ch = challenger();
+        let mut rng = SmallRng::seed_from_u64(0);
+        let table = Table::rand(&mut rng, 1, NUM_VARIABLES - 1);
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let _ = commit::<SuffixProver<F, F>, _, _, _>(
+            &config,
+            &encoder,
+            &mmcs_instance,
+            &mut ch,
+            witness,
+        );
+    }
+
+    /// `fold_rounds` rejects a `PrefixProver` layout too, independently of `commit`'s own
+    /// guard: a caller that assembled `BinaryPcsProverData` by some other path must still be
+    /// stopped here.
+    #[test]
+    #[should_panic(expected = "only suffix-order binding matches")]
+    fn fold_rounds_rejects_a_non_suffix_layout() {
+        let mut rng = SmallRng::seed_from_u64(21);
+        let table = Table::rand(&mut rng, 1, NUM_VARIABLES);
+        let witness = PrefixProver::<F, F>::new_witness(vec![table], 0);
+
+        let mut ch = challenger();
+        let (layout, _root, merkle_data) = PrefixProver::<F, F>::commit(
+            &AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default(),
+            &mmcs(),
+            &mut ch,
+            witness,
+            0,
+            LOG_INV_RATE,
+        );
+
+        let params = BinaryPcsParams {
+            log_inv_rate: LOG_INV_RATE,
+            pow_bits: 4,
+            security_level: 40,
+        };
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params).unwrap();
+        let prover_data = BinaryPcsProverData {
+            layout,
+            merkle_data,
+        };
+
+        let _ = fold_rounds(prover_data, &config, &mmcs(), &mut ch);
+    }
+}

--- a/binary-pcs/src/test_util.rs
+++ b/binary-pcs/src/test_util.rs
@@ -1,0 +1,84 @@
+//! Shared fixtures for `p3-binary-pcs` tests: a Merkle tree MMCS over `BinaryField128` with a
+//! Keccak byte hasher, the matching binary Fiat-Shamir challenger, and a full commit/open
+//! lifecycle for tests that check `verify` against a (possibly mutated) genuine proof.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_binary_field::{BinaryChallenger, BinaryField128};
+use p3_challenger::HashChallenger;
+use p3_commit::{Mmcs, MultilinearPcs};
+use p3_keccak::Keccak256Hash;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_sumcheck::layout::{Layout, SuffixProver, Table};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableShape, TableSpec};
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+use crate::params::{BinaryPcsConfig, BinaryPcsParams};
+use crate::pcs::BinaryPcs;
+use crate::proof::BinaryPcsProof;
+
+type F = BinaryField128;
+type MyHash = SerializingHasher<Keccak256Hash>;
+type MyCompress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
+pub(crate) type MyMmcs = MerkleTreeMmcs<F, u8, MyHash, MyCompress, 2, 32>;
+pub(crate) type MyChallenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
+
+pub(crate) const fn mmcs() -> MyMmcs {
+    MyMmcs::new(
+        MyHash::new(Keccak256Hash),
+        MyCompress::new(Keccak256Hash),
+        0,
+    )
+}
+
+pub(crate) const fn challenger() -> MyChallenger {
+    MyChallenger::from_hasher(Vec::new(), Keccak256Hash)
+}
+
+/// Fixed parameters `run_lifecycle` derives its config from.
+const fn params() -> BinaryPcsParams {
+    BinaryPcsParams {
+        log_inv_rate: 2,
+        pow_bits: 4,
+        security_level: 40,
+    }
+}
+
+/// Commits a random single-column table, opens column 0 at a transcript-sampled point, and
+/// returns everything a caller needs to replay or mutate the proof: the PCS instance (reusable
+/// for a fresh verify call), the commitment, the genuine proof, and the opening protocol that
+/// produced it.
+///
+/// `num_variables` and `folding` are forwarded to [`BinaryPcsConfig::try_new`] verbatim; only
+/// `folding = 0` derives a config this crate's commit phase accepts.
+#[allow(clippy::type_complexity)]
+pub(crate) fn run_lifecycle(
+    num_variables: usize,
+    folding: usize,
+) -> (
+    BinaryPcs<MyMmcs, SuffixProver<F, F>>,
+    <MyMmcs as Mmcs<F>>::Commitment,
+    BinaryPcsProof<MyMmcs>,
+    OpeningProtocol,
+) {
+    let mut rng = SmallRng::seed_from_u64(0xB1DA_u64);
+    let table = Table::rand(&mut rng, 1, num_variables);
+    let witness = SuffixProver::<F, F>::new_witness(vec![table], folding);
+
+    let protocol = OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(num_variables, 1),
+        vec![OpeningBatch::new(vec![0], Vec::new())],
+    )]);
+
+    let config = BinaryPcsConfig::try_new(num_variables, folding, params()).unwrap();
+    let pcs = BinaryPcs::new(config, mmcs());
+
+    let mut prover_challenger = challenger();
+    let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+    let proof = pcs.open(prover_data, protocol.clone(), &mut prover_challenger);
+
+    (pcs, commitment, proof, protocol)
+}

--- a/binary-pcs/src/test_util.rs
+++ b/binary-pcs/src/test_util.rs
@@ -51,29 +51,25 @@ const fn params() -> BinaryPcsParams {
 /// returns everything a caller needs to replay or mutate the proof: the PCS instance (reusable
 /// for a fresh verify call), the commitment, the genuine proof, and the opening protocol that
 /// produced it.
-///
-/// `num_variables` and `folding` are forwarded to [`BinaryPcsConfig::try_new`] verbatim; only
-/// `folding = 0` derives a config this crate's commit phase accepts.
 #[allow(clippy::type_complexity)]
 pub(crate) fn run_lifecycle(
     num_variables: usize,
-    folding: usize,
 ) -> (
-    BinaryPcs<MyMmcs, SuffixProver<F, F>>,
+    BinaryPcs<MyMmcs>,
     <MyMmcs as Mmcs<F>>::Commitment,
     BinaryPcsProof<MyMmcs>,
     OpeningProtocol,
 ) {
     let mut rng = SmallRng::seed_from_u64(0xB1DA_u64);
     let table = Table::rand(&mut rng, 1, num_variables);
-    let witness = SuffixProver::<F, F>::new_witness(vec![table], folding);
+    let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
 
     let protocol = OpeningProtocol::new(vec![TableSpec::new(
         TableShape::new(num_variables, 1),
         vec![OpeningBatch::new(vec![0], Vec::new())],
     )]);
 
-    let config = BinaryPcsConfig::try_new(num_variables, folding, params()).unwrap();
+    let config = BinaryPcsConfig::try_new(num_variables, params()).unwrap();
     let pcs = BinaryPcs::new(config, mmcs());
 
     let mut prover_challenger = challenger();

--- a/binary-pcs/src/verifier.rs
+++ b/binary-pcs/src/verifier.rs
@@ -284,6 +284,8 @@ mod tests {
     use p3_binary_dft::{AdditiveRsEncoder, NaiveAdditiveNtt};
     use p3_binary_field::BinaryField128;
     use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+    use p3_commit::Mmcs;
+    use p3_field::PrimeCharacteristicRing;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_multilinear_util::poly::Poly;
     use p3_sumcheck::layout::{Layout, SuffixProver, Table};
@@ -293,7 +295,7 @@ mod tests {
     use super::{BinaryPcsError, sample_query_indices, verify_query_paths};
     use crate::params::{BinaryPcsConfig, BinaryPcsParams};
     use crate::proof::BinaryPcsProof;
-    use crate::prover::{commit, fold_rounds, open_queries};
+    use crate::prover::{RoundCommitment, commit, fold_rounds, open_queries};
     use crate::test_util::{challenger, mmcs};
 
     type F = BinaryField128;
@@ -485,5 +487,79 @@ mod tests {
         );
 
         assert_eq!(verifier_indices, prover_indices);
+    }
+
+    /// The fold chain is the only thing tying one committed round to the next, and this is the
+    /// attack it exists for: a prover that commits a round which is a perfectly valid codeword
+    /// but simply is not the fold of its predecessor.
+    ///
+    /// The tamper adds one constant to every symbol of the first intermediate round. Constants
+    /// are degree-0 polynomials, so the shifted vector is still a codeword of that round's
+    /// code — not a malformed object any shape or proximity check could reject, but a
+    /// well-formed commitment to the wrong polynomial. It is re-committed and opened honestly
+    /// against its own root, so the round's Merkle multiproof verifies and the transcript is
+    /// untouched; `fold_pair` is what disagrees.
+    #[test]
+    fn a_committed_round_that_is_not_the_fold_of_its_predecessor_is_rejected() {
+        let mut rng = SmallRng::seed_from_u64(0xF01D);
+        let poly = Poly::<F>::rand(&mut rng, NUM_VARIABLES);
+        let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params()).unwrap();
+        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
+        let mmcs_instance = mmcs();
+
+        let mut prover_ch = challenger();
+        let (base_commitment, prover_data) =
+            commit(&config, &encoder, &mmcs_instance, &mut prover_ch, witness);
+        let (base_merkle_data, sumcheck_data, mut rounds, randomness, final_codeword) =
+            fold_rounds(prover_data, &config, &mmcs_instance, &mut prover_ch);
+
+        // `rounds[0]` carries fold round 1, the round the base round's fold must reproduce.
+        let shifted: Vec<F> = mmcs_instance.get_matrices(&rounds[0].merkle_data)[0]
+            .values
+            .iter()
+            .map(|&v| v + F::ONE)
+            .collect();
+        let (commitment, merkle_data) =
+            mmcs_instance.commit_matrix(RowMajorMatrix::new(shifted, 1));
+        rounds[0] = RoundCommitment {
+            commitment,
+            merkle_data,
+        };
+
+        let mut verifier_ch = prover_ch.clone();
+        let query_proofs = open_queries(
+            &config,
+            &mmcs_instance,
+            &mut prover_ch,
+            &base_merkle_data,
+            &rounds,
+        );
+
+        let proof = BinaryPcsProof {
+            sumcheck: sumcheck_data,
+            rounds: query_proofs.rounds,
+            base_opened_values: query_proofs.base_opened_values,
+            base_multi_proof: query_proofs.base_multi_proof,
+            final_codeword: Poly::new(final_codeword),
+            pow_witness: query_proofs.pow_witness,
+            evals: Vec::new(),
+        };
+
+        let err = verify_query_paths(
+            &config,
+            &mmcs_instance,
+            &base_commitment,
+            randomness.as_slice(),
+            &proof,
+            &mut verifier_ch,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, BinaryPcsError::FoldMismatch { round: 1, query: 0 }),
+            "expected FoldMismatch at round 1 query 0, got {err:?}"
+        );
     }
 }

--- a/binary-pcs/src/verifier.rs
+++ b/binary-pcs/src/verifier.rs
@@ -1,0 +1,499 @@
+//! Query sampling and the per-query fold-consistency check.
+//!
+//! Every round's codeword is a flat vector; round 0 is the base commitment, round `r` for
+//! `1 <= r < num_fold_rounds` is `proof.rounds[r - 1]`, and round `num_fold_rounds` is
+//! `proof.final_codeword`, sent in full rather than committed. A query index `i`, drawn from
+//! the base codeword's domain, addresses position `i >> r` at round `r`; folding that
+//! position's pair with round `r`'s challenge must reproduce the value read at position
+//! `i >> (r + 1)` of round `r + 1`.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_binary_field::BinaryField128;
+use p3_challenger::{CanSampleUniformBits, FieldChallenger, GrindingChallenger};
+use p3_commit::Mmcs;
+use p3_field::Field;
+use p3_matrix::Dimensions;
+use p3_util::log2_strict_usize;
+
+use crate::error::BinaryPcsError;
+use crate::fold::fold_pair;
+use crate::params::BinaryPcsConfig;
+use crate::proof::BinaryPcsProof;
+
+/// Samples `num_queries` distinct indices, uniformly at random, from `[0, domain_size)`.
+///
+/// Indices come from `sample_uniform_bits::<true>`, which rejection-samples internally,
+/// rather than from the low bits of a sampled field element: the latter biases each draw and
+/// inflates the decoding radius the query bound is stated against.
+///
+/// Duplicates are rejected, so the output length is `min(num_queries, domain_size)`; a
+/// request for more indices than the domain holds returns the whole domain. Returns indices
+/// in ascending order.
+///
+/// # Panics
+///
+/// Panics if `domain_size` is not a power of two.
+pub(crate) fn sample_query_indices<Challenger, F>(
+    domain_size: usize,
+    num_queries: usize,
+    challenger: &mut Challenger,
+) -> Vec<usize>
+where
+    Challenger: FieldChallenger<F> + CanSampleUniformBits<F>,
+    F: Field,
+{
+    let bits = log2_strict_usize(domain_size);
+    let target = num_queries.min(domain_size);
+
+    let mut indices: Vec<usize> = Vec::with_capacity(target);
+    while indices.len() < target {
+        let index = challenger
+            .sample_uniform_bits::<true>(bits)
+            .expect("RESAMPLE = true: rejection loops internally, never errors");
+        if !indices.contains(&index) {
+            indices.push(index);
+        }
+    }
+
+    indices.sort_unstable();
+    indices
+}
+
+/// The pair of positions round `round`'s codeword must supply to carry query `index` onward:
+/// the position `index` addresses at that round, and its fold sibling — low bit clear first.
+const fn fold_pair_positions(index: usize, round: usize) -> [usize; 2] {
+    let position = index >> round;
+    let even = position & !1;
+    [even, even + 1]
+}
+
+/// Every position round `round` must open: one pair per sampled query index, in query order.
+pub(crate) fn flat_pair_indices(indices: &[usize], round: usize) -> Vec<usize> {
+    indices
+        .iter()
+        .flat_map(|&index| fold_pair_positions(index, round))
+        .collect()
+}
+
+/// Checks a round's opened-row shape against the count every query demands.
+///
+/// Runs before any index arithmetic on the round's contents, so a wrong row count or a
+/// mis-sized row is rejected here rather than read out of bounds.
+fn check_round_shape<E>(
+    round: usize,
+    opened_values: &[Vec<BinaryField128>],
+    expected_opens: usize,
+) -> Result<(), BinaryPcsError<E>> {
+    if opened_values.len() != expected_opens {
+        return Err(BinaryPcsError::OpeningCountMismatch {
+            round,
+            expected: expected_opens,
+            actual: opened_values.len(),
+        });
+    }
+    for (query, row) in opened_values.iter().enumerate() {
+        if row.len() != 1 {
+            return Err(BinaryPcsError::RowWidthMismatch {
+                round,
+                query,
+                expected: 1,
+                actual: row.len(),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Wraps opened rows for [`Mmcs::verify_multi_batch`], which expects a `[query][matrix]`
+/// shape; every round here commits exactly one matrix, so each row gets a one-element outer
+/// slice.
+fn wrap_rows(opened_values: &[Vec<BinaryField128>]) -> Vec<Vec<&[BinaryField128]>> {
+    opened_values
+        .iter()
+        .map(|row| vec![row.as_slice()])
+        .collect()
+}
+
+/// Checks the proof's declared intermediate round count and final-codeword length against
+/// what `config` derives, before any transcript operation: `BinaryPcs::verify_opening` and
+/// [`verify_query_paths`] both need this pair of structural checks, ahead of everything each
+/// one does on its own.
+pub(crate) fn check_round_and_final_lengths<MT>(
+    config: &BinaryPcsConfig,
+    proof: &BinaryPcsProof<MT>,
+) -> Result<(), BinaryPcsError<MT::Error>>
+where
+    MT: Mmcs<BinaryField128>,
+{
+    let expected_intermediate_rounds = config.num_fold_rounds() - 1;
+    if proof.rounds.len() != expected_intermediate_rounds {
+        return Err(BinaryPcsError::RoundCountMismatch {
+            expected: expected_intermediate_rounds,
+            actual: proof.rounds.len(),
+        });
+    }
+
+    let expected_final_len = 1usize << config.log_final_len();
+    if proof.final_codeword.num_evals() != expected_final_len {
+        return Err(BinaryPcsError::FinalCodewordLengthMismatch {
+            expected: expected_final_len,
+            actual: proof.final_codeword.num_evals(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Verifies the query phase of an opening proof: the single grind, the sampled query
+/// indices, every round's Merkle multiproof, and the fold-consistency chain tying each round
+/// to the next.
+///
+/// `betas` is the fold challenge used at each round, `betas[r]` for round `r`, in the order
+/// `fold_rounds` samples them; the caller derives it by replaying the sumcheck transcript
+/// (this function does not touch the sumcheck rounds or the commitments' own transcript
+/// order). All proof-shape checks run before `challenger` is touched, so a malformed proof is
+/// rejected without ever grinding or sampling against it.
+///
+/// # Panics
+///
+/// Panics if `betas.len() != config.num_fold_rounds()`: `betas` is the caller's own
+/// transcript-replay output, never proof-supplied data, so a length mismatch here is a caller
+/// bug rather than a malformed proof.
+pub(crate) fn verify_query_paths<MT, Ch>(
+    config: &BinaryPcsConfig,
+    mmcs: &MT,
+    base_commitment: &MT::Commitment,
+    betas: &[BinaryField128],
+    proof: &BinaryPcsProof<MT>,
+    challenger: &mut Ch,
+) -> Result<(), BinaryPcsError<MT::Error>>
+where
+    MT: Mmcs<BinaryField128>,
+    Ch: FieldChallenger<BinaryField128>
+        + GrindingChallenger<Witness = BinaryField128>
+        + CanSampleUniformBits<BinaryField128>,
+{
+    let num_fold_rounds = config.num_fold_rounds();
+    assert_eq!(betas.len(), num_fold_rounds, "one fold challenge per round");
+
+    // Structural checks: every one derivable from `config` and the proof's own declared
+    // lengths, none needing the transcript.
+    check_round_and_final_lengths(config, proof)?;
+
+    let domain_size = config.domain_size();
+    let target_queries = config.num_queries().min(domain_size);
+    let expected_opens = 2 * target_queries;
+
+    check_round_shape(0, &proof.base_opened_values, expected_opens)?;
+    for (r, round) in proof.rounds.iter().enumerate() {
+        check_round_shape(r + 1, &round.opened_values, expected_opens)?;
+    }
+
+    // The transcript is touched from here on: grind, then sample.
+    if !challenger.check_witness(config.pow_bits(), proof.pow_witness) {
+        return Err(BinaryPcsError::InvalidPowWitness);
+    }
+
+    let indices =
+        sample_query_indices::<_, BinaryField128>(domain_size, config.num_queries(), challenger);
+    debug_assert_eq!(indices.len(), target_queries);
+
+    // One Merkle multiproof per round.
+    let base_indices = flat_pair_indices(&indices, 0);
+    let base_dims = [Dimensions {
+        width: 1,
+        height: domain_size,
+    }];
+    mmcs.verify_multi_batch(
+        base_commitment,
+        &base_dims,
+        &base_indices,
+        &wrap_rows(&proof.base_opened_values),
+        &proof.base_multi_proof,
+    )
+    .map_err(|source| BinaryPcsError::MerkleFailed { round: 0, source })?;
+
+    for (r, round) in proof.rounds.iter().enumerate() {
+        let round_number = r + 1;
+        let round_indices = flat_pair_indices(&indices, round_number);
+        let dims = [Dimensions {
+            width: 1,
+            height: domain_size >> round_number,
+        }];
+        mmcs.verify_multi_batch(
+            &round.commitment,
+            &dims,
+            &round_indices,
+            &wrap_rows(&round.opened_values),
+            &round.multi_proof,
+        )
+        .map_err(|source| BinaryPcsError::MerkleFailed {
+            round: round_number,
+            source,
+        })?;
+    }
+
+    // Fold-chain consistency, one query at a time.
+    let round_values = |round: usize| -> &[Vec<BinaryField128>] {
+        if round == 0 {
+            &proof.base_opened_values
+        } else {
+            &proof.rounds[round - 1].opened_values
+        }
+    };
+
+    for (q, &index) in indices.iter().enumerate() {
+        // The bound is `num_fold_rounds`, checked against `betas.len()` above, rather than
+        // `betas.len()` itself, so an inconsistent `betas` cannot silently shrink or grow this
+        // loop; `r` also indexes `index >> r` and both `round_values` calls, not just `betas`.
+        #[allow(clippy::needless_range_loop)]
+        for r in 0..num_fold_rounds {
+            let beta = betas[r];
+            let position = index >> r;
+            let lo = round_values(r)[2 * q][0];
+            let hi = round_values(r)[2 * q + 1][0];
+            let folded = fold_pair(position >> 1, beta, lo, hi);
+
+            let expected = if r + 1 < num_fold_rounds {
+                let parity = (position >> 1) & 1;
+                round_values(r + 1)[2 * q + parity][0]
+            } else {
+                proof.final_codeword.as_slice()[position >> 1]
+            };
+
+            if folded != expected {
+                return Err(BinaryPcsError::FoldMismatch {
+                    round: r + 1,
+                    query: q,
+                });
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::ToString;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_binary_dft::{AdditiveRsEncoder, NaiveAdditiveNtt};
+    use p3_binary_field::BinaryField128;
+    use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
+    use p3_matrix::dense::RowMajorMatrix;
+    use p3_multilinear_util::poly::Poly;
+    use p3_sumcheck::layout::{Layout, SuffixProver, Table};
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::{BinaryPcsError, sample_query_indices, verify_query_paths};
+    use crate::params::{BinaryPcsConfig, BinaryPcsParams};
+    use crate::proof::BinaryPcsProof;
+    use crate::prover::{commit, fold_rounds, open_queries};
+    use crate::test_util::{challenger, mmcs};
+
+    type F = BinaryField128;
+
+    const NUM_VARIABLES: usize = 8;
+    const LOG_INV_RATE: usize = 2;
+
+    const fn params() -> BinaryPcsParams {
+        BinaryPcsParams {
+            log_inv_rate: LOG_INV_RATE,
+            pow_bits: 4,
+            security_level: 40,
+        }
+    }
+
+    #[test]
+    fn query_indices_are_distinct_sorted_and_in_range() {
+        let mut c = challenger();
+        let indices = sample_query_indices::<_, BinaryField128>(1 << 10, 12, &mut c);
+        assert_eq!(indices.len(), 12);
+        assert!(
+            indices.windows(2).all(|w| w[0] < w[1]),
+            "sorted and distinct"
+        );
+        assert!(indices.iter().all(|&i| i < 1 << 10), "in range");
+    }
+
+    #[test]
+    fn a_request_larger_than_the_domain_returns_the_whole_domain() {
+        let mut c = challenger();
+        let indices = sample_query_indices::<_, BinaryField128>(8, 100, &mut c);
+        assert_eq!(indices, (0..8).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn sampling_is_transcript_dependent() {
+        let mut a = challenger();
+        let mut b = challenger();
+        assert_eq!(
+            sample_query_indices::<_, BinaryField128>(1 << 10, 4, &mut a),
+            sample_query_indices::<_, BinaryField128>(1 << 10, 4, &mut b),
+        );
+    }
+
+    #[test]
+    fn round_count_mismatch_is_typed_not_a_panic() {
+        // A proof claiming fewer rounds than the config must be rejected before any
+        // indexing, so a malformed proof is a rejection rather than an abort.
+        let err: BinaryPcsError<()> = BinaryPcsError::RoundCountMismatch {
+            expected: 8,
+            actual: 3,
+        };
+        assert!(err.to_string().contains('8'));
+    }
+
+    /// Commits, folds, and opens a genuine proof, then checks that `verify_query_paths`
+    /// accepts it end to end: every round's Merkle multiproof and every query's fold chain,
+    /// through the final codeword.
+    #[test]
+    fn a_genuine_proof_verifies() {
+        let mut rng = SmallRng::seed_from_u64(7);
+        let poly = Poly::<F>::rand(&mut rng, NUM_VARIABLES);
+        let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
+        let mmcs_instance = mmcs();
+
+        let mut prover_ch = challenger();
+        let (base_commitment, prover_data) = commit::<SuffixProver<F, F>, _, _, _>(
+            &config,
+            &encoder,
+            &mmcs_instance,
+            &mut prover_ch,
+            witness,
+        );
+        let (base_merkle_data, sumcheck_data, rounds, randomness, final_codeword) =
+            fold_rounds(prover_data, &config, &mmcs_instance, &mut prover_ch);
+
+        let mut verifier_ch = prover_ch.clone();
+
+        let query_proofs = open_queries(
+            &config,
+            &mmcs_instance,
+            &mut prover_ch,
+            &base_merkle_data,
+            &rounds,
+        );
+
+        let proof = BinaryPcsProof {
+            sumcheck: sumcheck_data,
+            rounds: query_proofs.rounds,
+            base_opened_values: query_proofs.base_opened_values,
+            base_multi_proof: query_proofs.base_multi_proof,
+            final_codeword: Poly::new(final_codeword),
+            pow_witness: query_proofs.pow_witness,
+            evals: Vec::new(),
+        };
+
+        let result = verify_query_paths(
+            &config,
+            &mmcs_instance,
+            &base_commitment,
+            randomness.as_slice(),
+            &proof,
+            &mut verifier_ch,
+        );
+        assert!(result.is_ok(), "{result:?}");
+    }
+
+    /// A fresh verifier challenger, seeded identically to the prover's but touched only by
+    /// what the proof carries, must sample the same query indices the prover did.
+    ///
+    /// `a_genuine_proof_verifies` clones the prover's own challenger after `fold_rounds`
+    /// returns, so its `verifier_ch` already carries every observation the prover made,
+    /// correct or not — it can never disagree with the prover, so it cannot catch a mismatch
+    /// between what `fold_rounds` observes and what the proof actually carries. This test
+    /// instead rebuilds the verifier's side of the transcript from an empty challenger: the
+    /// base commitment, the batching challenge `into_sumcheck` samples even though it consumes
+    /// zero preprocessing rounds, each fold round's polynomial and challenge (from
+    /// `proof.sumcheck`), and each intermediate round's commitment (one per fold round except
+    /// the last). If `fold_rounds` observes one more or one fewer commitment than this replay
+    /// does, the two challengers desync and the sampled indices diverge.
+    #[test]
+    fn a_fresh_verifier_challenger_samples_the_same_query_indices() {
+        let mut rng = SmallRng::seed_from_u64(0x5EED);
+        let poly = Poly::<F>::rand(&mut rng, NUM_VARIABLES);
+        let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
+        let mmcs_instance = mmcs();
+
+        let mut prover_ch = challenger();
+        let (base_commitment, prover_data) = commit::<SuffixProver<F, F>, _, _, _>(
+            &config,
+            &encoder,
+            &mmcs_instance,
+            &mut prover_ch,
+            witness,
+        );
+        let (base_merkle_data, sumcheck_data, rounds, randomness, _final_codeword) =
+            fold_rounds(prover_data, &config, &mmcs_instance, &mut prover_ch);
+
+        // The prover's own transcript state, snapshotted right before the query phase, gives
+        // an independent readout of the indices `open_queries` samples: replaying the actual
+        // grinding witness it found and sampling from there reaches the same query phase by a
+        // second path. This checks the witness rather than re-grinding: with the `parallel`
+        // feature, `grind`'s search returns any witness that satisfies the difficulty, not a
+        // deterministic one, so a second independent grind could legitimately land on a
+        // different valid witness and desync the two readouts for a reason unrelated to what
+        // this test is checking.
+        let mut prover_snapshot = prover_ch.clone();
+
+        let query_proofs = open_queries(
+            &config,
+            &mmcs_instance,
+            &mut prover_ch,
+            &base_merkle_data,
+            &rounds,
+        );
+
+        assert!(prover_snapshot.check_witness(config.pow_bits(), query_proofs.pow_witness));
+        let domain_size = config.domain_size();
+        let prover_indices = sample_query_indices::<_, BinaryField128>(
+            domain_size,
+            config.num_queries(),
+            &mut prover_snapshot,
+        );
+
+        // A fresh, independently constructed challenger — the empty transcript, exactly like
+        // `challenger()` gave the prover — touched only by what a verifier can read off the
+        // proof and the config.
+        let mut verifier_ch = challenger();
+        verifier_ch.observe(base_commitment);
+        let _alpha: F = verifier_ch.sample_algebra_element();
+
+        let num_fold_rounds = config.num_fold_rounds();
+        // `r` indexes three collections of two different lengths (`rounds` holds one fewer
+        // entry than `num_fold_rounds`), so no single `.iter().enumerate()` covers the loop.
+        #[allow(clippy::needless_range_loop)]
+        for r in 0..num_fold_rounds {
+            let [c0, c_inf] = sumcheck_data.polynomial_evaluations()[r];
+            verifier_ch.observe_algebra_slice(&[c0, c_inf]);
+            let beta: F = verifier_ch.sample_algebra_element();
+            assert_eq!(beta, randomness.as_slice()[r], "round {r} challenge");
+            if r + 1 < num_fold_rounds {
+                verifier_ch.observe(rounds[r].commitment.clone());
+            }
+        }
+
+        assert!(verifier_ch.check_witness(config.pow_bits(), query_proofs.pow_witness));
+        let verifier_indices = sample_query_indices::<_, BinaryField128>(
+            domain_size,
+            config.num_queries(),
+            &mut verifier_ch,
+        );
+
+        assert_eq!(verifier_indices, prover_indices);
+    }
+}

--- a/binary-pcs/src/verifier.rs
+++ b/binary-pcs/src/verifier.rs
@@ -359,18 +359,13 @@ mod tests {
         let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
         let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
 
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params()).unwrap();
         let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
         let mmcs_instance = mmcs();
 
         let mut prover_ch = challenger();
-        let (base_commitment, prover_data) = commit::<SuffixProver<F, F>, _, _, _>(
-            &config,
-            &encoder,
-            &mmcs_instance,
-            &mut prover_ch,
-            witness,
-        );
+        let (base_commitment, prover_data) =
+            commit(&config, &encoder, &mmcs_instance, &mut prover_ch, witness);
         let (base_merkle_data, sumcheck_data, rounds, randomness, final_codeword) =
             fold_rounds(prover_data, &config, &mmcs_instance, &mut prover_ch);
 
@@ -425,18 +420,13 @@ mod tests {
         let table = Table::new(RowMajorMatrix::new(poly.into_evals(), 1 << NUM_VARIABLES));
         let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
 
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, 0, params()).unwrap();
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params()).unwrap();
         let encoder = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default();
         let mmcs_instance = mmcs();
 
         let mut prover_ch = challenger();
-        let (base_commitment, prover_data) = commit::<SuffixProver<F, F>, _, _, _>(
-            &config,
-            &encoder,
-            &mmcs_instance,
-            &mut prover_ch,
-            witness,
-        );
+        let (base_commitment, prover_data) =
+            commit(&config, &encoder, &mmcs_instance, &mut prover_ch, witness);
         let (base_merkle_data, sumcheck_data, rounds, randomness, _final_codeword) =
             fold_rounds(prover_data, &config, &mmcs_instance, &mut prover_ch);
 

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -3,12 +3,11 @@
 //! rather than only failing. Everything here goes through `p3-binary-pcs`'s public
 //! `MultilinearPcs`/`PrescribedPointPcs` surface, exactly as an external caller would.
 //!
-//! Every genuine proof is produced with `SuffixProver` and `folding = 0`, the only
-//! configuration this crate's commit phase accepts, and every prover/verifier pair uses two
-//! independently constructed challengers seeded identically rather than one challenger cloned
-//! after proving: a challenger cloned from the prover's own transcript already carries every
-//! observation the prover made, correct or not, so it can never disagree with a proof that
-//! desyncs the transcript from what the prover actually produced.
+//! Every prover/verifier pair uses two independently constructed challengers seeded
+//! identically rather than one challenger cloned after proving: a challenger cloned from the
+//! prover's own transcript already carries every observation the prover made, correct or not,
+//! so it can never disagree with a proof that desyncs the transcript from what the prover
+//! actually produced.
 
 use p3_binary_field::{BinaryChallenger, BinaryField128};
 use p3_binary_pcs::{BinaryPcs, BinaryPcsConfig, BinaryPcsError, BinaryPcsParams, BinaryPcsProof};
@@ -30,7 +29,7 @@ type MyHash = SerializingHasher<Keccak256Hash>;
 type MyCompress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
 type MyMmcs = MerkleTreeMmcs<F, u8, MyHash, MyCompress, 2, 32>;
 type MyChallenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
-type MyPcs = BinaryPcs<MyMmcs, SuffixProver<F, F>>;
+type MyPcs = BinaryPcs<MyMmcs>;
 
 /// Default shape shared by every negative test: enough intermediate rounds
 /// (`num_fold_rounds - 1 == 7`) to truncate or permute, and `pow_bits > 0` so the grinding
@@ -87,7 +86,6 @@ fn run_lifecycle(
 
     let config = BinaryPcsConfig::try_new(
         num_variables,
-        0,
         params(log_inv_rate, pow_bits, security_level),
     )
     .unwrap();
@@ -113,9 +111,9 @@ fn assert_round_trips(num_variables: usize, log_inv_rate: usize, seed: u64) {
         });
 }
 
-/// The configuration sweep, `SuffixProver` / `folding = 0` only: `PrefixProver` does not stay
-/// in lockstep with the codeword fold (covered in `prover.rs`'s unit tests), and `folding > 0`
-/// is rejected by `BinaryPcsConfig::try_new`.
+/// The configuration sweep over the two knobs a caller has: the polynomial's arity and the
+/// code rate. The binding order is not a knob — the codeword fold only matches suffix binding,
+/// which `prover.rs`'s unit tests pin — so the type fixes it rather than the sweep covering it.
 #[test]
 fn small_configurations_round_trip() {
     for &num_variables in &[6usize, 8, 10, 12] {
@@ -269,7 +267,6 @@ fn a_proof_checked_against_a_different_protocol_is_rejected() {
 
     let config = BinaryPcsConfig::try_new(
         NUM_VARIABLES,
-        0,
         params(LOG_INV_RATE, POW_BITS, SECURITY_LEVEL),
     )
     .unwrap();
@@ -427,7 +424,6 @@ fn zero_claim_lifecycle(
 
     let config = BinaryPcsConfig::try_new(
         num_variables,
-        0,
         params(LOG_INV_RATE, POW_BITS, SECURITY_LEVEL),
     )
     .unwrap();

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -19,7 +19,9 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::layout::{Layout, SuffixProver, Table};
-use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
+use p3_sumcheck::{
+    OpeningBatch, OpeningEvals, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec,
+};
 use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
@@ -597,5 +599,63 @@ fn a_short_evals_vector_is_rejected() {
             }
         ),
         "expected OpeningBatchCountMismatch, got {err:?}"
+    );
+}
+
+/// The evaluation claim is what makes this a commitment and not merely a proximity test, and
+/// this is the test that holds it to that: a proof carrying a wrong evaluation of the committed
+/// polynomial must be rejected.
+///
+/// Nothing else in this file covers it. Every other negative test perturbs the proof's
+/// *structure* — a codeword symbol, an opened row, a round count, a witness — and the closest
+/// one, `a_proof_checked_against_a_different_protocol_is_rejected`, swaps which column is
+/// opened rather than what it evaluates to. Deleting the final check's product clause would
+/// leave all of them passing.
+///
+/// The claimed evaluations are absorbed as each claim is recorded, so tampering one both
+/// desyncs every challenge drawn afterwards and breaks the claim the sumcheck rounds reduce.
+/// The final check is where the reduced claim meets the codeword, and so where it surfaces.
+#[test]
+fn a_false_evaluation_claim_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 17);
+
+    let genuine = proof.evals[0].current()[0];
+    proof.evals[0] = OpeningEvals::new(vec![genuine + F::ONE], Vec::new());
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
+    );
+}
+
+/// A tampered sumcheck round message must be rejected. The sumcheck is the leg that reduces
+/// the opening claim to a single scalar, so a prover free to rewrite a round message is free to
+/// reduce a false claim to a true one.
+///
+/// Each round's `[h(0), h(inf)]` pair is observed before that round's challenge is sampled, so
+/// altering one both changes every later fold challenge and breaks the running claim. Round 3
+/// is interior — neither the first, which no earlier round feeds, nor the last, which the final
+/// check reads directly — so the rejection cannot be an artifact of a boundary the round loop
+/// treats specially.
+#[test]
+fn a_tampered_sumcheck_round_message_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 18);
+
+    assert!(proof.sumcheck.num_rounds() > 4);
+    proof.sumcheck.polynomial_evaluations[3][0] += F::ONE;
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
     );
 }

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -1,0 +1,605 @@
+//! Commit/open/verify round trips across the configuration sweep, and the negative tests that
+//! check the verifier rejects a malformed or mismatched proof for a specific typed reason
+//! rather than only failing. Everything here goes through `p3-binary-pcs`'s public
+//! `MultilinearPcs`/`PrescribedPointPcs` surface, exactly as an external caller would.
+//!
+//! Every genuine proof is produced with `SuffixProver` and `folding = 0`, the only
+//! configuration this crate's commit phase accepts, and every prover/verifier pair uses two
+//! independently constructed challengers seeded identically rather than one challenger cloned
+//! after proving: a challenger cloned from the prover's own transcript already carries every
+//! observation the prover made, correct or not, so it can never disagree with a proof that
+//! desyncs the transcript from what the prover actually produced.
+
+use p3_binary_field::{BinaryChallenger, BinaryField128};
+use p3_binary_pcs::{BinaryPcs, BinaryPcsConfig, BinaryPcsError, BinaryPcsParams, BinaryPcsProof};
+use p3_challenger::{FieldChallenger, HashChallenger};
+use p3_commit::{Mmcs, MultilinearPcs};
+use p3_field::PrimeCharacteristicRing;
+use p3_keccak::Keccak256Hash;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_multilinear_util::point::Point;
+use p3_multilinear_util::poly::Poly;
+use p3_sumcheck::layout::{Layout, SuffixProver, Table};
+use p3_sumcheck::{OpeningBatch, OpeningProtocol, PrescribedPointPcs, TableShape, TableSpec};
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
+use rand::SeedableRng;
+use rand::rngs::SmallRng;
+
+type F = BinaryField128;
+type MyHash = SerializingHasher<Keccak256Hash>;
+type MyCompress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
+type MyMmcs = MerkleTreeMmcs<F, u8, MyHash, MyCompress, 2, 32>;
+type MyChallenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
+type MyPcs = BinaryPcs<MyMmcs, SuffixProver<F, F>>;
+
+/// Default shape shared by every negative test: enough intermediate rounds
+/// (`num_fold_rounds - 1 == 7`) to truncate or permute, and `pow_bits > 0` so the grinding
+/// rejection has something to catch.
+const NUM_VARIABLES: usize = 8;
+const LOG_INV_RATE: usize = 2;
+const POW_BITS: usize = 4;
+const SECURITY_LEVEL: usize = 40;
+
+const fn mmcs() -> MyMmcs {
+    MyMmcs::new(
+        MyHash::new(Keccak256Hash),
+        MyCompress::new(Keccak256Hash),
+        0,
+    )
+}
+
+const fn challenger() -> MyChallenger {
+    MyChallenger::from_hasher(Vec::new(), Keccak256Hash)
+}
+
+const fn params(log_inv_rate: usize, pow_bits: usize, security_level: usize) -> BinaryPcsParams {
+    BinaryPcsParams {
+        log_inv_rate,
+        pow_bits,
+        security_level,
+    }
+}
+
+/// Commits a random single-column table, opens column 0 at a transcript-sampled point with a
+/// fresh prover challenger, and returns everything a negative test needs: the PCS instance
+/// (reusable for a fresh `verify` call), the commitment, the genuine proof, and the opening
+/// protocol that produced it.
+fn run_lifecycle(
+    num_variables: usize,
+    log_inv_rate: usize,
+    pow_bits: usize,
+    security_level: usize,
+    seed: u64,
+) -> (
+    MyPcs,
+    <MyMmcs as Mmcs<F>>::Commitment,
+    BinaryPcsProof<MyMmcs>,
+    OpeningProtocol,
+) {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let table = Table::rand(&mut rng, 1, num_variables);
+    let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+    let protocol = OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(num_variables, 1),
+        vec![OpeningBatch::new(vec![0], Vec::new())],
+    )]);
+
+    let config = BinaryPcsConfig::try_new(
+        num_variables,
+        0,
+        params(log_inv_rate, pow_bits, security_level),
+    )
+    .unwrap();
+    let pcs = BinaryPcs::new(config, mmcs());
+
+    let mut prover_challenger = challenger();
+    let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+    let proof = pcs.open(prover_data, protocol.clone(), &mut prover_challenger);
+
+    (pcs, commitment, proof, protocol)
+}
+
+/// Runs one commit/open/verify round trip at `num_variables` and `log_inv_rate`, with the
+/// prover and the verifier on two independently constructed challengers seeded identically.
+fn assert_round_trips(num_variables: usize, log_inv_rate: usize, seed: u64) {
+    let (pcs, commitment, proof, protocol) =
+        run_lifecycle(num_variables, log_inv_rate, POW_BITS, SECURITY_LEVEL, seed);
+
+    let mut verifier_challenger = challenger();
+    pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_or_else(|err| {
+            panic!("num_variables={num_variables} log_inv_rate={log_inv_rate}: {err:?}")
+        });
+}
+
+/// The configuration sweep, `SuffixProver` / `folding = 0` only: `PrefixProver` does not stay
+/// in lockstep with the codeword fold (covered in `prover.rs`'s unit tests), and `folding > 0`
+/// is rejected by `BinaryPcsConfig::try_new`.
+#[test]
+fn small_configurations_round_trip() {
+    for &num_variables in &[6usize, 8, 10, 12] {
+        for &log_inv_rate in &[1usize, 2, 3] {
+            let seed = (num_variables as u64) << 8 | log_inv_rate as u64;
+            assert_round_trips(num_variables, log_inv_rate, seed);
+        }
+    }
+}
+
+/// The degenerate edge below `small_configurations_round_trip`'s sweep: `num_variables = 1`
+/// gives `num_fold_rounds() == 1`, so `fold_rounds`'s `rounds` vector is empty and every
+/// `num_fold_rounds - 1` derivation in the verifier bottoms out at zero rather than
+/// underflowing.
+#[test]
+fn nv_1_round_trip() {
+    for &log_inv_rate in &[1usize, 2] {
+        let seed = 1u64 << 8 | log_inv_rate as u64;
+        assert_round_trips(1, log_inv_rate, seed);
+    }
+}
+
+/// This phase's exit criterion: a commit/open/verify round trip at `num_variables = 16`. The
+/// unoptimized fold and Merkle paths make a `2^16`-row codeword too slow for `cargo test`'s
+/// default debug profile, so this runs explicitly rather than in every default invocation:
+/// `cargo test --release -- --ignored` locally, or the `p3-binary-pcs` job in `ci-heavy.yml`.
+#[test]
+#[ignore = "commit/open/verify at num_variables = 16; run via `cargo test --release -- --ignored`, or through ci-heavy.yml's p3-binary-pcs job"]
+fn large_configuration_2_16_round_trips() {
+    for &log_inv_rate in &[1usize, 2, 3] {
+        let seed = 16u64 << 8 | log_inv_rate as u64;
+        assert_round_trips(16, log_inv_rate, seed);
+    }
+}
+
+/// A tampered `final_codeword` symbol is rejected: with `log_inv_rate = 2` the genuine final
+/// codeword has 4 symbols, all equal to the sumcheck's final value, so flipping one breaks the
+/// uniformity `verify_opening` checks before it ever reaches the query phase.
+///
+/// The tampered index is 1, not 0: index 0 also serves as `final_value` in the final check's
+/// product clause, so tampering it would be caught by that clause alone and this test would
+/// still pass with the uniformity check deleted. Tampering index 1 leaves `final_value`
+/// correct, so only the uniformity check can catch it.
+#[test]
+fn tampered_final_codeword_symbol_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 1);
+
+    let symbol = &mut proof.final_codeword.as_mut_slice()[1];
+    *symbol += F::ONE;
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
+    );
+}
+
+/// A tampered `opened_values` entry in an intermediate round breaks that round's Merkle
+/// multiproof, which is checked before the fold-consistency chain that reads the row's content.
+#[test]
+fn tampered_round_opened_value_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 2);
+
+    assert!(!proof.rounds.is_empty());
+    proof.rounds[0].opened_values[0][0] += F::ONE;
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::MerkleFailed { round: 1, .. }),
+        "expected MerkleFailed at round 1, got {err:?}"
+    );
+}
+
+/// A truncated `rounds` vector is rejected by a structural check — `proof.rounds.len()` against
+/// `config.num_fold_rounds() - 1` — that runs before any transcript operation. `verify_at` is
+/// used rather than `verify` because `verify` unconditionally observes the commitment as its
+/// first step regardless of the proof's validity; `verify_at` leaves that to the caller, so a
+/// challenger that never called it is the correct "untouched" baseline to compare against.
+#[test]
+fn truncated_rounds_vector_is_rejected_without_touching_the_challenger() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 3);
+
+    let expected_rounds = proof.rounds.len();
+    assert!(expected_rounds > 0);
+    proof.rounds.truncate(expected_rounds - 1);
+
+    let points = [Point::<F>::rand(
+        &mut SmallRng::seed_from_u64(4),
+        NUM_VARIABLES,
+    )];
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify_at(
+            &commitment,
+            &proof,
+            &protocol,
+            &points,
+            &mut verifier_challenger,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BinaryPcsError::RoundCountMismatch { expected, actual }
+                if expected == expected_rounds && actual == expected_rounds - 1
+        ),
+        "expected RoundCountMismatch, got {err:?}"
+    );
+
+    // The rejection above must not have touched `verifier_challenger` at all: sampling from it
+    // now must agree with sampling from a challenger that never saw `verify_at` in the first
+    // place, and disagree only if some transcript operation ran before the structural check.
+    let actual: F = verifier_challenger.sample_algebra_element();
+    let expected: F = challenger().sample_algebra_element();
+    assert_eq!(
+        actual, expected,
+        "a malformed proof must not become a transcript oracle"
+    );
+}
+
+/// A proof verified against a different, equally valid `OpeningProtocol` of the same table
+/// shape — opening column 1 of a two-column table instead of column 0 — must not verify: the
+/// evaluations the proof actually carries are claims about the wrong column.
+#[test]
+fn a_proof_checked_against_a_different_protocol_is_rejected() {
+    // A two-column table costs one selector bit for the extra column, so its per-column arity
+    // must be one less than the committed witness's `num_variables` for the two to match.
+    let column_arity = NUM_VARIABLES - 1;
+    let mut rng = SmallRng::seed_from_u64(5);
+    let table = Table::rand(&mut rng, 2, column_arity);
+    let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+    let opens_column = |col: usize| {
+        OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(column_arity, 2),
+            vec![OpeningBatch::new(vec![col], Vec::new())],
+        )])
+    };
+    let protocol_a = opens_column(0);
+    let protocol_b = opens_column(1);
+
+    let config = BinaryPcsConfig::try_new(
+        NUM_VARIABLES,
+        0,
+        params(LOG_INV_RATE, POW_BITS, SECURITY_LEVEL),
+    )
+    .unwrap();
+    let pcs: MyPcs = BinaryPcs::new(config, mmcs());
+
+    let mut prover_challenger = challenger();
+    let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+    let proof = pcs.open(prover_data, protocol_a, &mut prover_challenger);
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol_b)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
+    );
+}
+
+/// A proof verified against the commitment of a different polynomial must not verify: the
+/// commitment the verifier observes drives the batching challenge and the query positions, so a
+/// swapped commitment desyncs both from what the proof actually carries.
+#[test]
+fn a_proof_checked_against_a_different_commitment_is_rejected() {
+    let (pcs, _commitment, proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 6);
+
+    let mut rng = SmallRng::seed_from_u64(7);
+    let other_table = Table::rand(&mut rng, 1, NUM_VARIABLES);
+    let other_witness = SuffixProver::<F, F>::new_witness(vec![other_table], 0);
+    let mut other_challenger = challenger();
+    let (other_commitment, _other_prover_data) = pcs.commit(other_witness, &mut other_challenger);
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(
+            &other_commitment,
+            &proof,
+            &mut verifier_challenger,
+            protocol,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
+    );
+}
+
+/// `pow_bits > 0` with a corrupted `pow_witness` is rejected by the grinding check. The
+/// witness is corrupted by perturbing the genuine one, never by grinding a second time: under
+/// `--features parallel`, `GrindingChallenger::grind`'s search can legitimately return a
+/// different valid witness on a second call, which would make a re-grinding test
+/// non-deterministic for a reason unrelated to what it is checking.
+#[test]
+fn corrupted_pow_witness_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 8);
+
+    proof.pow_witness += F::ONE;
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::InvalidPowWitness),
+        "expected InvalidPowWitness, got {err:?}"
+    );
+}
+
+/// A proof carrying PoW witnesses is rejected outright: every fold round replays with a
+/// freshly built, always-empty `pow_witnesses` vector (see `BinaryPcs::verify_opening`), so
+/// nothing in the proof's own transcript reads or binds the ones this test appends. Without
+/// this guard such a proof would still verify, so a third party could mutate those bytes and
+/// keep a valid proof.
+#[test]
+fn nonempty_sumcheck_pow_witnesses_are_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 10);
+
+    proof.sumcheck.pow_witnesses.push(F::ONE);
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::NonEmptyPowWitnesses { actual: 1 }),
+        "expected NonEmptyPowWitnesses, got {err:?}"
+    );
+}
+
+/// An honest proof whose intermediate round entries are permuted must not verify.
+///
+/// Every intermediate round's commitment is observed into the transcript between two
+/// sumcheck-round replays (`verify_opening` interleaves them), so permuting `proof.rounds`
+/// changes which commitment is observed at which point in the sequence and desyncs every fold
+/// challenge sampled afterwards. That surfaces at the final check — the sumcheck's claimed sum
+/// no longer matches the alpha-batched weight polynomial evaluated at the (now wrong) fold
+/// point — before the query phase, where `FoldMismatch` lives, is ever reached.
+///
+/// `FoldMismatch` itself guards a different failure mode: a prover who commits genuinely
+/// inconsistent codewords from round to round while still producing sumcheck messages and a
+/// final codeword that satisfy the final check on their own. That is a property of what gets
+/// committed, not of the order proof fields are read back in, so no post-hoc permutation of an
+/// otherwise honest proof reaches it: swapping whole `RoundProof` entries (this test) desyncs
+/// the transcript and lands on `FinalCheck`; swapping only the opened values and multiproof
+/// between two rounds while leaving commitments in place instead breaks that round's own Merkle
+/// check, landing on `MerkleFailed`.
+#[test]
+fn permuted_round_commitments_are_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 9);
+
+    assert!(proof.rounds.len() >= 2);
+    proof.rounds.swap(0, 1);
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
+    );
+}
+
+/// Commits a random single-column table against a **zero-claim** `OpeningProtocol` —
+/// `TableSpec::new(shape, Vec::new())`, legal on the public API — and returns everything a test
+/// needs to replay or mutate the proof.
+///
+/// With no claim recorded, `Verifier::constraint`'s alpha-batched weight has no terms, so
+/// `claimed_sum` and its evaluation at the fold point both collapse to zero; the final check's
+/// product clause, `claimed_sum == w(r) * final_value`, then reads `0 == 0` regardless of what
+/// `final_value` is. The only thing standing between a proximity-only commitment and an
+/// arbitrary uniform final codeword in that branch is the fold-consistency chain
+/// `verify_query_paths` walks.
+fn zero_claim_lifecycle(
+    num_variables: usize,
+    seed: u64,
+) -> (
+    MyPcs,
+    <MyMmcs as Mmcs<F>>::Commitment,
+    BinaryPcsProof<MyMmcs>,
+    OpeningProtocol,
+) {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let table = Table::rand(&mut rng, 1, num_variables);
+    let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+
+    let protocol = OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(num_variables, 1),
+        Vec::new(),
+    )]);
+
+    let config = BinaryPcsConfig::try_new(
+        num_variables,
+        0,
+        params(LOG_INV_RATE, POW_BITS, SECURITY_LEVEL),
+    )
+    .unwrap();
+    let pcs = BinaryPcs::new(config, mmcs());
+
+    let mut prover_challenger = challenger();
+    let (commitment, prover_data) = pcs.commit(witness, &mut prover_challenger);
+    let proof = pcs.open(prover_data, protocol.clone(), &mut prover_challenger);
+
+    (pcs, commitment, proof, protocol)
+}
+
+/// A single tampered final-codeword symbol is caught by the final check's uniformity clause
+/// even with a zero-claim protocol, independent of the (here vacuous) product clause — the
+/// zero-claim configuration alone is not what is under test.
+///
+/// Shifting every symbol by the same constant instead keeps the codeword uniform, so both the
+/// product clause and the uniformity check pass; `FoldMismatch` is the only remaining check
+/// that ties the final codeword to the rounds committed before it, and it is what catches this.
+#[test]
+fn a_zero_claim_proof_with_a_uniformly_shifted_final_codeword_is_rejected_by_the_fold_chain() {
+    let (pcs, commitment, proof, protocol) = zero_claim_lifecycle(NUM_VARIABLES, 11);
+
+    let mut honest_challenger = challenger();
+    pcs.verify(
+        &commitment,
+        &proof,
+        &mut honest_challenger,
+        protocol.clone(),
+    )
+    .unwrap();
+
+    let mut single_symbol = proof.clone();
+    single_symbol.final_codeword.as_mut_slice()[1] += F::ONE;
+    let mut single_symbol_challenger = challenger();
+    let err = pcs
+        .verify(
+            &commitment,
+            &single_symbol,
+            &mut single_symbol_challenger,
+            protocol.clone(),
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FinalCheck),
+        "expected FinalCheck, got {err:?}"
+    );
+
+    let mut uniform_shift = proof;
+    for v in uniform_shift.final_codeword.as_mut_slice() {
+        *v += F::ONE;
+    }
+    let mut uniform_shift_challenger = challenger();
+    let err = pcs
+        .verify(
+            &commitment,
+            &uniform_shift,
+            &mut uniform_shift_challenger,
+            protocol,
+        )
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::FoldMismatch { round, query: 0 } if round == NUM_VARIABLES),
+        "expected FoldMismatch at round {NUM_VARIABLES} query 0, got {err:?}"
+    );
+}
+
+/// The different-commitment test desyncs the whole transcript, so `FinalCheck` fires long
+/// before the base Merkle check ever runs — it proves transcript binding, not commitment
+/// binding. Tampering an opened value directly is what exercises `verify_multi_batch` against
+/// the base commitment itself.
+#[test]
+fn tampered_base_opened_value_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 12);
+
+    proof.base_opened_values[0][0] += F::ONE;
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::MerkleFailed { round: 0, .. }),
+        "expected MerkleFailed at round 0, got {err:?}"
+    );
+}
+
+/// A `base_opened_values` entry short of what the sampled query count demands is rejected by
+/// the structural row-count check.
+#[test]
+fn a_short_base_opened_values_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 13);
+
+    proof.base_opened_values.pop();
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::OpeningCountMismatch { round: 0, .. }),
+        "expected OpeningCountMismatch at round 0, got {err:?}"
+    );
+}
+
+/// An opened base row wider than the width-1 codeword every round commits is rejected before
+/// the fold chain ever reads it.
+#[test]
+fn a_wide_base_opened_row_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 14);
+
+    proof.base_opened_values[0].push(F::ONE);
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(err, BinaryPcsError::RowWidthMismatch { round: 0, .. }),
+        "expected RowWidthMismatch at round 0, got {err:?}"
+    );
+}
+
+/// A final codeword of the wrong length is rejected before any transcript operation the proof
+/// could otherwise ride along with.
+#[test]
+fn a_wrong_length_final_codeword_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 15);
+
+    proof.final_codeword = Poly::new(vec![F::ZERO; 8]);
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BinaryPcsError::FinalCodewordLengthMismatch {
+                expected: 4,
+                actual: 8
+            }
+        ),
+        "expected FinalCodewordLengthMismatch, got {err:?}"
+    );
+}
+
+/// Fewer evaluation batches than the protocol schedules is rejected before any claim is
+/// recorded against the transcript.
+#[test]
+fn a_short_evals_vector_is_rejected() {
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, POW_BITS, SECURITY_LEVEL, 16);
+
+    proof.evals.pop();
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BinaryPcsError::OpeningBatchCountMismatch {
+                expected: 1,
+                actual: 0
+            }
+        ),
+        "expected OpeningBatchCountMismatch, got {err:?}"
+    );
+}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,6 +25,10 @@ name = "p3-binary-field"
 version_group = "plonky3"
 
 [[package]]
+name = "p3-binary-pcs"
+version_group = "plonky3"
+
+[[package]]
 name = "p3-blake3"
 version_group = "plonky3"
 


### PR DESCRIPTION
Adds `p3-binary-pcs`: a multilinear polynomial commitment scheme over `BinaryField128`, closing Phase 3 of the binary-field work on top of `p3-binary-field` (#2001), `p3-binary-dft` (#2003) and ring switching (#2006).

## Construction

The committed object is the stacked multilinear that `p3_sumcheck::layout` already produces. It is encoded as a single Reed-Solomon codeword column over the Cantor `F_2`-subspace domain, via `AdditiveRsEncoder`, and Merkle-committed.

Opening is BaseFold-shaped. The residual sumcheck runs one round per variable, and each round's challenge is used twice: it binds one multilinear variable, and it folds the codeword 2-to-1 through `W_1(x) = x^2 + x`. The two stay in correspondence because the fold is the evaluation-basis combination `(1 - b) * f_0 + b * f_1`, which is exactly what `Poly::fix_suffix_var` computes on the message.

Two structural facts make the fold cheap, and both are pinned by tests:

- `W_1(domain_point(i)) == domain_point(i >> 1)`, so the folded domain is the same function at a halved index. There are no per-round twiddle tables and no domain type.
- `domain_point(2j + 1) == domain_point(2j) + 1`, so folding partners are adjacent in memory.

Verification replays the transcript, checks one Merkle multiproof per round, and checks that consecutive rounds are related by `fold_pair`. The claim closes by requiring the final codeword to be uniform and to satisfy `claimed_sum == w(r) * constant`.

## Soundness

Parameters are derived only in the **unique-decoding** regime, and `SecurityAssumption` is deliberately not re-exported, so the refuted capacity bound is unreachable rather than runtime-rejected. Capacity-rate list decodability is refuted over characteristic 2 with `F_2`-subspace domains (BGKS20 App. B, BCHKS25 Thm 1.6 / Cor 1.7), and the Cantor domain is exactly that case. The Johnson bound is *not* refuted, but `p3-security` documents it as resting on a correlated-agreement conjecture, so it is excluded here by choice. The cost is honest and large: more queries than WHIR or STIR report for the same target.

`security_level` is capped against what the alphabet can deliver. Queries buy back only the proximity term; the commit phase costs `(n + 1)/|F|` per round at arity 2 and each sumcheck round costs `2/|F|`, and no query count recovers either. `BinaryPcsConfig::field_security_bits` charges both, `try_new` rejects a target above it, and a test pins the value against `p3_security::fri::commit_phase_error_udr` so the two cannot drift. At `2^20` variables and rate `2^-2` that ceiling is 105 bits.

Query indices are drawn with `CanSampleUniformBits`, never by bit-decomposing a sampled field element.

## Benchmarks

Serial, on `aarch64-apple-darwin`, where `PMULL` is in the baseline. On x86_64 these need `-C target-feature=+pclmulqdq` or the 128-bit multiply falls back to the recursive tower path.

| variables | commit | open | verify | proof size |
|---|---|---|---|---|
| 16 | 171 ms | 206 ms | 4.4 ms | 291,116 B |
| 18 | 841 ms | 760 ms | 5.6 ms | 393,810 B |
| 20 | 3.03 s | 4.22 s | 7.1 ms | 514,147 B |

Proof size is dominated by the query count, which is the price of unique decoding rather than of the polynomial's arity.

The codeword fold chains `domain_point` across each parallel task by an XOR recurrence instead of recomputing it per output symbol. Measured against the per-call form: 1.6x to 2.1x, with the tightest measurement at 18 variables, 31.9 ms against 50.7 ms.

## Design notes

- **The layout is a fixed type, not a parameter.** The fold merges adjacent pairs, which only suffix-order binding matches; prefix binding merges halves and does not stay in lockstep. `prefix_layout_does_not_stay_in_lockstep` pins that as a property of the two binding orders rather than a tuning detail.
- **There is no folding knob.** The commit phase lays the polynomial out as a single column, so every variable folds. Binding a prefix inside a committed row is a deferred prover-cost optimisation; an exhaustive search over 128 order, orientation and bind-rule combinations found none that composes with the subsequent folds, so it is not on the path to a correct PCS.
- **The final codeword is not absorbed into the transcript.** Uniformity forces all `2^log_inv_rate` symbols to one value, and any single query's last fold step pins that value against a Merkle-authenticated, transcript-bound round codeword. Late adaptivity therefore buys nothing. Weaken either half and the absorption has to come back.

## Test plan

- [x] `cargo test -p p3-binary-pcs`, with and without `--features parallel`: 35 lib + 18 integration tests.
- [x] The `2^16` round trip in release, which is this phase's exit criterion. Wired into `ci-heavy.yml`, now built with carry-less multiply.
- [x] The fold identity is proptested against `NaiveAdditiveNtt` as an independent oracle, over generated message lengths and blowup rates.
- [x] Negative tests: every one asserts a *named* typed error, not just `is_err()`. They cover a tampered final-codeword symbol, a tampered opened value at the base and at an intermediate round, a truncated round vector reached without touching the challenger, a mismatched opening protocol, a mismatched commitment, a corrupted grinding witness, non-empty sumcheck PoW witnesses, permuted round commitments, and malformed shapes.
- [x] Evaluation binding: a false claimed evaluation and a tampered sumcheck round message are each rejected.
- [x] Fold-chain reachability: a round committed as a valid codeword that is not the fold of its predecessor is caught only by the fold chain.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`, `cargo +nightly fmt --check`, `cargo machete --with-metadata`, rustdoc with `--document-private-items`, and a `thumbv7em-none-eabi` no_std build.
