### PR TITLE
fix(fri)!: derive the folding schedule instead of accepting the prover's

### DIFF
--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -1235,6 +1235,29 @@ mod tests {
     }
 
     #[test]
+    fn reject_folding_cap_above_two() {
+        // Invariant: a cap above one is refused before any proof data is read.
+        //
+        // Circle folding halves the domain and nothing else.
+        // A larger cap once reached a bare assert deep in the query loop.
+        // That aborted on an honest proof as readily as on a forged one.
+        //
+        // Fixture state: a valid proof, then a cap of 3 on the verifier.
+        let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof();
+
+        let mut wide = pcs;
+        wide.fri_params.max_log_arity = 3;
+
+        let err = try_verify(&wide, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect_err("a cap above one must be refused");
+
+        let FriError::UnsupportedFoldingCap { max_log_arity } = err else {
+            panic!("expected UnsupportedFoldingCap, got {err:?}");
+        };
+        assert_eq!(max_log_arity, 3);
+    }
+
+    #[test]
     fn reject_commit_pow_witness_count_mismatch() {
         let (pcs, byte_hash, comm, d, zeta, values, mut proof) = setup_valid_proof();
         let num_rounds = proof.fri_proof.commit_phase_commits.len();

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -41,6 +41,18 @@ where
         return Err(FriError::ZeroQueries);
     }
 
+    // Circle folding halves the domain and nothing else.
+    //
+    // Capping the arity at one forces every per-round arity to one.
+    // The pinned height sum then determines the schedule uniquely.
+    //
+    // A larger cap would let a proof declare an arity this fold cannot apply.
+    if params.max_log_arity != 1 {
+        return Err(FriError::UnsupportedFoldingCap {
+            max_log_arity: params.max_log_arity,
+        });
+    }
+
     // There must be exactly one commit-phase proof-of-work witness per round.
     if proof.commit_pow_witnesses.len() != proof.commit_phase_commits.len() {
         return Err(FriError::CommitPowWitnessCountMismatch {
@@ -359,11 +371,9 @@ where
 
         // Fold the full sibling group down to a single evaluation using the random
         // challenge beta. Borrowing the row leaves it owned for the collector below.
-        // Circle PCS only ever folds by arity 2 (`CircleFriFolding::fold_row`
-        // asserts this too); the twiddle for this round was already precomputed for the
-        // whole query chain, so this is now pure arithmetic with no domain construction,
-        // scalar multiplication, or inversion left to do.
-        assert_eq!(log_arity, 1, "Circle PCS currently only supports arity 2");
+        //
+        // The cap is one on entry, so this is always a halving.
+        debug_assert_eq!(log_arity, 1, "circle folding is always a halving");
         folded_eval = fold_row_with_inv_twiddle(x_twiddle_inv[round], beta, evals.iter().copied());
 
         // Hand this query's group index and reconstructed row to the round's shared

--- a/fri/src/config.rs
+++ b/fri/src/config.rs
@@ -206,9 +206,145 @@ pub fn compute_log_arity_for_round(
     max_fold.min(max_log_arity)
 }
 
+/// Derive the whole folding schedule before any folding happens.
+///
+/// # Overview
+///
+/// A round's arity is capped by three things:
+///
+/// - distance left to the final height,
+/// - distance down to where the next input joins,
+/// - the configured maximum.
+///
+/// All three are known before folding starts.
+/// So the schedule is known too, and neither side reads it from a proof.
+///
+/// # Arguments
+///
+/// - `input_log_heights`: log-heights of the folding inputs, strictly decreasing.
+/// - `log_final_height`: log-height at which folding stops.
+/// - `max_log_arity`: largest arity any single round may use.
+///
+/// # Returns
+///
+/// One log-arity per commit round, in round order.
+///
+/// Empty when nothing sits above the final height.
+/// A verifier derives this from untrusted heights, so it returns rather than panics.
+///
+/// # Panics
+///
+/// When the input heights are not strictly decreasing.
+#[must_use]
+pub fn fold_schedule(
+    input_log_heights: &[usize],
+    log_final_height: usize,
+    max_log_arity: usize,
+) -> Vec<usize> {
+    assert!(
+        input_log_heights.windows(2).all(|pair| pair[0] > pair[1]),
+        "input log-heights must be strictly decreasing",
+    );
+
+    // Folding starts at the tallest input and stops at the final height.
+    let Some(&tallest) = input_log_heights.first() else {
+        return Vec::new();
+    };
+    if tallest <= log_final_height {
+        return Vec::new();
+    }
+    let mut log_height = tallest;
+
+    // Index of the next input still waiting to be rolled in.
+    let mut next_input = 1;
+    let mut schedule = Vec::new();
+
+    while log_height > log_final_height {
+        // Cap by the final height, the next input, and the configured maximum.
+        let log_arity = compute_log_arity_for_round(
+            log_height,
+            input_log_heights.get(next_input).copied(),
+            log_final_height,
+            max_log_arity,
+        );
+        schedule.push(log_arity);
+        log_height -= log_arity;
+
+        // An input whose height the fold just reached is rolled in here.
+        // The next round then folds the combined codeword.
+        if input_log_heights.get(next_input) == Some(&log_height) {
+            next_input += 1;
+        }
+    }
+
+    schedule
+}
+
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use super::*;
+
+    #[test]
+    fn schedule_folds_the_whole_way_down() {
+        // Invariant: the arities sum to the distance the codeword has to travel.
+        //
+        // Fixture state: one input at height 2^10, folding down to 2^2.
+        //
+        //     10 -> 2 is 8 levels, in steps of at most 3
+        //     8 = 3 + 3 + 2
+        assert_eq!(fold_schedule(&[10], 2, 3), vec![3, 3, 2]);
+
+        // Binary folding takes one level per round.
+        assert_eq!(fold_schedule(&[10], 2, 1), vec![1; 8]);
+    }
+
+    #[test]
+    fn schedule_pauses_where_an_input_joins() {
+        // Invariant: a round never folds past the height of the next input.
+        //
+        // An input joins only once the codeword reaches its height.
+        // A round that overshot would leave it nowhere to join.
+        //
+        // Fixture state: inputs at 2^10 and 2^6, final height 2^2, max arity 3.
+        //
+        //     10 --3--> 7 --1--> 6   <- input joins here
+        //      6 --3--> 3 --1--> 2   <- final height
+        assert_eq!(fold_schedule(&[10, 6], 2, 3), vec![3, 1, 3, 1]);
+    }
+
+    #[test]
+    fn schedule_is_empty_without_inputs() {
+        // Boundary: nothing to fold means no commit rounds.
+        assert_eq!(fold_schedule(&[], 2, 3), Vec::<usize>::new());
+    }
+
+    #[test]
+    fn every_schedule_lands_exactly_on_the_final_height() {
+        // Invariant: folding never overshoots or stops short.
+        //
+        // Overshooting loses the evaluations the query phase needs.
+        for max_log_arity in 1..=4 {
+            for log_final_height in 0..4 {
+                for tall in (log_final_height + 1)..12 {
+                    // A second input somewhere strictly between the two ends.
+                    for short in (log_final_height + 1)..tall {
+                        let schedule =
+                            fold_schedule(&[tall, short], log_final_height, max_log_arity);
+                        assert_eq!(
+                            schedule.iter().sum::<usize>(),
+                            tall - log_final_height,
+                            "max_log_arity={max_log_arity} final={log_final_height} \
+                             inputs=[{tall}, {short}]",
+                        );
+                        // No round may exceed the configured maximum.
+                        assert!(schedule.iter().all(|&a| a <= max_log_arity && a > 0));
+                    }
+                }
+            }
+        }
+    }
 
     /// Pins the field-by-field mapping in [`FriParameters::security_regime`].
     /// Distinct values per field catch a mis-wired mapping (e.g. swapping the

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -14,7 +14,7 @@ use tracing::{debug_span, info_span, instrument};
 
 use crate::{
     BatchMultiOpening, CommitPhaseMultiStep, FriFoldingStrategy, FriParameters, FriProof,
-    ProverDataWithOpeningPoints, compute_log_arity_for_round,
+    ProverDataWithOpeningPoints, fold_schedule,
 };
 
 /// Create a proof that an opening `f(zeta)` is correct by proving that the
@@ -208,28 +208,26 @@ where
         "max_log_arity must be at least 1 to guarantee folding progress"
     );
 
+    let log_final_height = params.log_blowup + params.log_final_poly_len;
+
+    // Derive the whole folding schedule before folding anything.
+    //
+    // The verifier derives the identical one from the committed heights.
+    // Nothing about it is read from the proof.
+    let input_log_heights: Vec<usize> = inputs
+        .iter()
+        .map(|input| log2_strict_usize(input.len()))
+        .collect();
+    let log_arities = fold_schedule(&input_log_heights, log_final_height, params.max_log_arity);
+
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();
     let mut commits = vec![];
     let mut data = vec![];
-    let mut log_arities = vec![];
     let mut pow_witnesses = vec![];
 
-    let log_final_height = params.log_blowup + params.log_final_poly_len;
-
-    while folded.len() > params.blowup() * params.final_poly_len() {
-        let log_current_height = log2_strict_usize(folded.len());
-        let next_input_log_height = inputs_iter.peek().map(|v| log2_strict_usize(v.len()));
-
-        //Compute the arity for this round
-        let log_arity = compute_log_arity_for_round(
-            log_current_height,
-            next_input_log_height,
-            log_final_height,
-            params.max_log_arity,
-        );
+    for &log_arity in &log_arities {
         let arity = 1 << log_arity;
-        log_arities.push(log_arity);
 
         // As folded is in bit reversed order, the evaluations at conjugate points are adjacent.
         // We reinterpret the vector as a matrix of width `arity`.

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -63,6 +63,48 @@ where
     Folding:
         FriFoldingStrategy<Val, Challenge, InputProof = Vec<BatchMultiOpening<Val, InputMmcs>>>,
 {
+    prove_fri_with_schedule(
+        folding,
+        params,
+        inputs,
+        challenger,
+        log_global_max_height,
+        prover_data_with_opening_points,
+        input_mmcs,
+        None,
+    )
+}
+
+/// Prove with a caller-supplied folding schedule.
+///
+/// An honest prover passes `None` and the schedule is derived.
+///
+/// A test passes `Some` to forge a schedule the verifier will not derive.
+/// Every commitment, opening and transcript value then agrees with the forgery.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn prove_fri_with_schedule<Folding, Val, Challenge, InputMmcs, FriMmcs, Challenger>(
+    folding: &Folding,
+    params: &FriParameters<FriMmcs>,
+    inputs: Vec<Vec<Challenge>>,
+    challenger: &mut Challenger,
+    log_global_max_height: usize,
+    prover_data_with_opening_points: &[ProverDataWithOpeningPoints<
+        '_,
+        Challenge,
+        InputMmcs::ProverData<RowMajorMatrix<Val>>,
+    >],
+    input_mmcs: &InputMmcs,
+    schedule: Option<Vec<usize>>,
+) -> FriProof<Challenge, FriMmcs, Challenger::Witness, Folding::InputProof>
+where
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val>,
+    InputMmcs: Mmcs<Val>,
+    FriMmcs: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<FriMmcs::Commitment>,
+    Folding:
+        FriFoldingStrategy<Val, Challenge, InputProof = Vec<BatchMultiOpening<Val, InputMmcs>>>,
+{
     assert!(!inputs.is_empty());
     assert!(
         params.num_queries > 0,
@@ -97,7 +139,7 @@ where
     // themselves and the final polynomial.
     // Note that the challenger observes the commitments and the final polynomial inside this function so we don't
     // need to observe the output of this function here.
-    let commit_phase_result = commit_phase(folding, params, inputs, challenger);
+    let commit_phase_result = commit_phase(folding, params, inputs, challenger, schedule);
 
     // Bind the chosen folding arities into the transcript.
     for &log_arity in &commit_phase_result.log_arities {
@@ -195,6 +237,7 @@ fn commit_phase<Folding, Val, Challenge, M, Challenger>(
     params: &FriParameters<M>,
     inputs: Vec<Vec<Challenge>>,
     challenger: &mut Challenger,
+    schedule: Option<Vec<usize>>,
 ) -> CommitPhaseResult<Challenge, M, <Challenger as GrindingChallenger>::Witness>
 where
     Val: TwoAdicField,
@@ -214,11 +257,13 @@ where
     //
     // The verifier derives the identical one from the committed heights.
     // Nothing about it is read from the proof.
-    let input_log_heights: Vec<usize> = inputs
-        .iter()
-        .map(|input| log2_strict_usize(input.len()))
-        .collect();
-    let log_arities = fold_schedule(&input_log_heights, log_final_height, params.max_log_arity);
+    let log_arities = schedule.unwrap_or_else(|| {
+        let input_log_heights: Vec<usize> = inputs
+            .iter()
+            .map(|input| log2_strict_usize(input.len()))
+            .collect();
+        fold_schedule(&input_log_heights, log_final_height, params.max_log_arity)
+    });
 
     let mut inputs_iter = inputs.into_iter().peekable();
     let mut folded = inputs_iter.next().unwrap();

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -50,6 +50,13 @@ pub struct TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
     pub(crate) dft: Dft,
     pub(crate) mmcs: InputMmcs,
     pub(crate) fri: FriParameters<FriMmcs>,
+    /// Folding schedule to use instead of the derived one.
+    ///
+    /// Only a test sets this.
+    /// It lets a test forge a schedule the verifier will not derive.
+    /// Every commitment and opening then agrees with the forgery.
+    #[cfg(test)]
+    pub(crate) forged_fold_schedule: Option<Vec<usize>>,
     _phantom: PhantomData<Val>,
 }
 
@@ -59,6 +66,8 @@ impl<Val, Dft, InputMmcs, FriMmcs> TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
             dft,
             mmcs,
             fri,
+            #[cfg(test)]
+            forged_fold_schedule: None,
             _phantom: PhantomData,
         }
     }
@@ -684,6 +693,18 @@ where
         let folding: TwoAdicFriFoldingForMmcs<Val, InputMmcs> = TwoAdicFriFolding(PhantomData);
 
         // Produce the FRI proof.
+        #[cfg(test)]
+        let fri_proof = prover::prove_fri_with_schedule(
+            &folding,
+            &self.fri,
+            fri_input,
+            challenger,
+            log_global_max_height,
+            &commitment_data_with_opening_points,
+            &self.mmcs,
+            self.forged_fold_schedule.clone(),
+        );
+        #[cfg(not(test))]
         let fri_proof = prover::prove_fri(
             &folding,
             &self.fri,

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 
 use crate::{
     BatchMultiOpening, CommitPhaseMultiStep, CommitmentWithOpeningPoints, FriFoldingStrategy,
-    FriParameters, FriProof,
+    FriParameters, FriProof, fold_schedule,
 };
 
 #[derive(Debug, Error)]
@@ -73,6 +73,16 @@ where
         round: usize,
         log_arity: usize,
         max: usize,
+    },
+    /// The proof folded on a different schedule than the committed heights dictate.
+    ///
+    /// Both sides derive the schedule; it is never agreed over the wire.
+    #[error("fold schedule mismatch: expected {expected:?}, got {got:?}")]
+    FoldScheduleMismatch {
+        /// Schedule derived from the committed heights and the parameters.
+        expected: Vec<usize>,
+        /// Schedule the proof folded on.
+        got: Vec<usize>,
     },
     #[error("final folded height mismatch: expected {expected}, got {got}")]
     FinalFoldHeightMismatch { expected: usize, got: usize },
@@ -282,6 +292,35 @@ where
             expected,
             got: log_global_max_height,
         });
+    }
+
+    // Pin the whole schedule, not just the height it sums to.
+    //
+    // The cross-check above constrains only the sum.
+    // Two schedules summing alike would both pass it.
+    let mut input_log_heights: Vec<usize> = commitments_with_opening_points
+        .iter()
+        .flat_map(|(_, mats)| {
+            mats.iter()
+                .map(|(domain, _)| log2_strict_usize(domain.size()) + params.log_blowup)
+        })
+        .collect();
+    // Folding sees one input per distinct height, tallest first.
+    input_log_heights.sort_unstable_by(|a, b| b.cmp(a));
+    input_log_heights.dedup();
+
+    if !input_log_heights.is_empty() {
+        let expected_schedule = fold_schedule(
+            &input_log_heights,
+            params.log_blowup + params.log_final_poly_len,
+            params.max_log_arity,
+        );
+        if expected_schedule != log_arities {
+            return Err(FriError::FoldScheduleMismatch {
+                expected: expected_schedule,
+                got: log_arities,
+            });
+        }
     }
 
     if proof.commit_pow_witnesses.len() != proof.commit_phase_commits.len() {
@@ -1049,6 +1088,18 @@ mod tests {
     /// The challenger is advanced past the opened-values observation,
     /// ready for the verification entry point.
     fn make_test_fixture_with_queries(num_queries: usize) -> TestFixture {
+        make_test_fixture_with(num_queries, 1, 3)
+    }
+
+    /// Build a fixture with a chosen query count, folding cap, and trace height.
+    ///
+    /// A cap above one lets a single input fold non-uniformly.
+    /// That is what separates two schedules sharing a height sum.
+    fn make_test_fixture_with(
+        num_queries: usize,
+        max_log_arity: usize,
+        log_degree: usize,
+    ) -> TestFixture {
         // Use a fixed seed so every test run is deterministic.
         let mut rng = SmallRng::seed_from_u64(42);
 
@@ -1073,7 +1124,7 @@ mod tests {
         let fri_params = FriParameters {
             log_blowup: 1,
             log_final_poly_len: 0,
-            max_log_arity: 1,
+            max_log_arity,
             num_queries,
             commit_proof_of_work_bits: 0,
             query_proof_of_work_bits: 0,
@@ -1083,10 +1134,9 @@ mod tests {
         // Wrap the parameters and commitment scheme into a PCS instance.
         let pcs = TwoAdicFriPcs::new(Radix2Dit::default(), input_mmcs.clone(), fri_params.clone());
 
-        // Commit to a single 8-row, 2-column trace matrix.
-        // With blowup 2 the evaluation domain has 16 points (log height 4).
-        // Binary folding produces 3 rounds: 16 -> 8 -> 4 -> 2.
-        let log_degree = 3;
+        // Commit to a single 2-column trace matrix of the requested height.
+        // With blowup 2 the evaluation domain is twice as tall.
+        // The default of 8 rows gives log height 4, folded binary in 3 rounds.
         let width = 2;
         let domain = <TwoAdicFriPcs<Val, Radix2Dit<Val>, ValMmcs, ChallengeMmcs> as Pcs<
             Challenge,
@@ -1585,6 +1635,56 @@ mod tests {
                 assert_eq!(round, 0);
                 assert_eq!(log_arity, 0);
                 assert_eq!(max, f.fri_params.max_log_arity);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reordered_fold_schedule_rejected() {
+        // Invariant: the schedule is derived, not accepted.
+        //
+        // Fixture state: one input at log height 5, final height 1, cap 3.
+        //
+        // Mutation: swap the two arities.
+        //
+        //     honest:    [3, 1]   folds 5 -> 2 -> 1
+        //     tampered:  [1, 3]   folds 5 -> 4 -> 1
+        //
+        // Every earlier guard still passes:
+        //
+        //     round count      unchanged
+        //     each arity <= 3  yes
+        //     sum of arities   4, matching the height cross-check
+        //
+        // Only the derived schedule separates them.
+        let f = make_test_fixture_with(2, 3, 4);
+        let mut proof = f.proof.clone();
+
+        let honest: Vec<usize> = proof
+            .commit_phase_openings
+            .iter()
+            .map(|opening| opening.log_arity as usize)
+            .collect();
+        assert_eq!(honest, vec![3, 1], "fixture must fold non-uniformly");
+
+        proof.commit_phase_openings[0].log_arity = 1;
+        proof.commit_phase_openings[1].log_arity = 3;
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect_err("should reject a reordered fold schedule");
+
+        match err {
+            FriError::FoldScheduleMismatch { expected, got } => {
+                assert_eq!(expected, vec![3, 1]);
+                assert_eq!(got, vec![1, 3]);
             }
             other => panic!("wrong error variant: {other:?}"),
         }

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -49,6 +49,21 @@ where
     /// - At least one query is required for the protocol to prove anything.
     #[error("FRI instance has zero queries; at least one is required for soundness")]
     ZeroQueries,
+    /// The instance commits to no matrices.
+    ///
+    /// - Every derived quantity comes from the committed heights.
+    /// - With none, each guard would compare against nothing and pass.
+    #[error("FRI instance commits to no matrices; at least one is required")]
+    NoCommittedMatrices,
+    /// The folding cap exceeds what this verifier can fold.
+    ///
+    /// Circle FRI folds two points at a time and nothing else.
+    /// A larger cap would let a proof declare an arity its fold cannot apply.
+    #[error("folding cap 2^{max_log_arity} exceeds the supported arity 2")]
+    UnsupportedFoldingCap {
+        /// The configured cap, in log form.
+        max_log_arity: usize,
+    },
     #[error("missing initial reduced opening at log height {expected}")]
     MissingInitialReducedOpening { expected: usize },
     #[error("initial reduced opening height mismatch: expected {expected}, got {got}")]
@@ -211,6 +226,17 @@ where
         return Err(FriError::ZeroQueries);
     }
 
+    // Reject an instance with nothing committed.
+    //
+    // Every derived quantity below comes from the committed heights.
+    // With none, each guard would compare against nothing and pass.
+    if commitments_with_opening_points
+        .iter()
+        .all(|(_, mats)| mats.is_empty())
+    {
+        return Err(FriError::NoCommittedMatrices);
+    }
+
     // Generate the Batch combination challenge
     // Soundness Error: `|f|/|EF|` where `|f|` is the number of different functions of the form
     // `(f(zeta) - fi(x))/(zeta - x)` which need to be checked.
@@ -273,23 +299,28 @@ where
         });
     }
 
-    // Cross-check: the global log-height has two independent derivations which must agree.
-    // Ref: Ben-Sasson et al., "Fast RS IOPP", ICALP 2018, §2.1.1.
+    // Heights of the folding inputs, derived once and used by both guards below.
     //
-    //     H_in   = max committed log_2(domain.size) + log_blowup
-    //     H_fold = sum(per-round log-arities) + log_blowup + log_final_poly_len
-    let expected_log_global_max_height = commitments_with_opening_points
+    // Folding sees one input per distinct height, tallest first.
+    let mut input_log_heights: Vec<usize> = commitments_with_opening_points
         .iter()
         .flat_map(|(_, mats)| {
             mats.iter()
                 .map(|(domain, _)| log2_strict_usize(domain.size()) + params.log_blowup)
         })
-        .max();
-    if let Some(expected) = expected_log_global_max_height
-        && log_global_max_height != expected
-    {
+        .collect();
+    input_log_heights.sort_unstable_by(|a, b| b.cmp(a));
+    input_log_heights.dedup();
+
+    // Cross-check: the global log-height has two independent derivations which must agree.
+    // Ref: Ben-Sasson et al., "Fast RS IOPP", ICALP 2018, §2.1.1.
+    //
+    //     H_in   = max committed log_2(domain.size) + log_blowup
+    //     H_fold = sum(per-round log-arities) + log_blowup + log_final_poly_len
+    let expected_log_global_max_height = input_log_heights[0];
+    if log_global_max_height != expected_log_global_max_height {
         return Err(FriError::GlobalMaxHeightMismatch {
-            expected,
+            expected: expected_log_global_max_height,
             got: log_global_max_height,
         });
     }
@@ -298,29 +329,16 @@ where
     //
     // The cross-check above constrains only the sum.
     // Two schedules summing alike would both pass it.
-    let mut input_log_heights: Vec<usize> = commitments_with_opening_points
-        .iter()
-        .flat_map(|(_, mats)| {
-            mats.iter()
-                .map(|(domain, _)| log2_strict_usize(domain.size()) + params.log_blowup)
-        })
-        .collect();
-    // Folding sees one input per distinct height, tallest first.
-    input_log_heights.sort_unstable_by(|a, b| b.cmp(a));
-    input_log_heights.dedup();
-
-    if !input_log_heights.is_empty() {
-        let expected_schedule = fold_schedule(
-            &input_log_heights,
-            params.log_blowup + params.log_final_poly_len,
-            params.max_log_arity,
-        );
-        if expected_schedule != log_arities {
-            return Err(FriError::FoldScheduleMismatch {
-                expected: expected_schedule,
-                got: log_arities,
-            });
-        }
+    let expected_schedule = fold_schedule(
+        &input_log_heights,
+        params.log_blowup + params.log_final_poly_len,
+        params.max_log_arity,
+    );
+    if expected_schedule != log_arities {
+        return Err(FriError::FoldScheduleMismatch {
+            expected: expected_schedule,
+            got: log_arities,
+        });
     }
 
     if proof.commit_pow_witnesses.len() != proof.commit_phase_commits.len() {
@@ -1525,21 +1543,21 @@ mod tests {
     }
 
     #[test]
-    fn missing_initial_reduced_opening() {
+    fn instance_with_nothing_committed_rejected() {
         let f = make_test_fixture();
         let mut proof = f.proof.clone();
 
-        // The QUERY phase fold chain needs a seed: the combined evaluation
-        // of all input polynomials at the queried index. It must live at
-        // the maximum domain height. No committed polynomials → no seed.
+        // Invariant: an instance that commits to nothing proves nothing.
         //
-        // Fixture state: 1 committed polynomial → 1 seed expected.
+        // Every derived guard compares against the committed heights.
+        // With none, each would compare against nothing and pass.
         //
-        // Mutation: clear input openings + external commitment data → no seed.
+        // Fixture state: 1 committed polynomial.
+        //
+        // Mutation: clear input openings and commitment data.
         //
         //     input openings:    []   (was [batch_0])
         //     commitment data:   []   (was [(commit, mats)])
-        //     → reduced openings = [] → fold chain has no starting value
         proof.input_openings = vec![];
         let empty_cwop: Vec<
             CommitmentWithOpeningPoints<
@@ -1559,10 +1577,10 @@ mod tests {
         )
         .expect_err("should reject proof with no committed polynomials");
 
-        match err {
-            FriError::MissingInitialReducedOpening { .. } => {}
-            other => panic!("wrong error variant: {other:?}"),
-        }
+        assert!(
+            matches!(err, FriError::NoCommittedMatrices),
+            "wrong error variant: {err:?}"
+        );
     }
 
     #[test]
@@ -1638,6 +1656,147 @@ mod tests {
             }
             other => panic!("wrong error variant: {other:?}"),
         }
+    }
+
+    /// Build a fixture whose proof folded on `forged` instead of the derived schedule.
+    ///
+    /// Every commitment, sibling row and opening proof agrees with `forged`.
+    /// That is what a malicious prover would emit, not a field tamper.
+    fn make_forged_schedule_fixture(
+        num_queries: usize,
+        max_log_arity: usize,
+        log_degree: usize,
+        forged: Vec<usize>,
+    ) -> TestFixture {
+        let mut rng = SmallRng::seed_from_u64(42);
+        let perm = Perm::new_from_rng_128(&mut rng);
+        let hash = MyHash::new(perm.clone());
+        let compress = MyCompress::new(perm.clone());
+
+        let input_mmcs = ValMmcs::new(hash.clone(), compress.clone(), 0);
+        let challenge_mmcs = ChallengeMmcs::new(ValMmcs::new(hash, compress, 0));
+
+        let fri_params = FriParameters {
+            log_blowup: 1,
+            log_final_poly_len: 0,
+            max_log_arity,
+            num_queries,
+            commit_proof_of_work_bits: 0,
+            query_proof_of_work_bits: 0,
+            mmcs: challenge_mmcs,
+        };
+
+        // The seam that makes this proof forged rather than merely tampered.
+        let mut pcs =
+            TwoAdicFriPcs::new(Radix2Dit::default(), input_mmcs.clone(), fri_params.clone());
+        pcs.forged_fold_schedule = Some(forged);
+
+        let width = 2;
+        let domain = <TwoAdicFriPcs<Val, Radix2Dit<Val>, ValMmcs, ChallengeMmcs> as Pcs<
+            Challenge,
+            Challenger,
+        >>::natural_domain_for_degree(&pcs, 1 << log_degree);
+        let trace = RowMajorMatrix::<Val>::rand_nonzero(&mut rng, 1 << log_degree, width);
+
+        let (commitment, prover_data) =
+            <TwoAdicFriPcs<Val, Radix2Dit<Val>, ValMmcs, ChallengeMmcs> as Pcs<
+                Challenge,
+                Challenger,
+            >>::commit(&pcs, [(domain, trace)]);
+
+        let mut p_challenger = Challenger::new(perm.clone());
+        p_challenger.observe(&commitment);
+        let zeta: Challenge = p_challenger.sample_algebra_element();
+        let (opened_values, proof) =
+            pcs.open(vec![(&prover_data, vec![vec![zeta]])], &mut p_challenger);
+
+        let mut v_challenger = Challenger::new(perm);
+        v_challenger.observe(&commitment);
+        let _: Challenge = v_challenger.sample_algebra_element();
+
+        let cwop = vec![(
+            commitment,
+            vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
+        )];
+        for (_, round) in &cwop {
+            for (_, mat) in round {
+                for (_, point) in mat {
+                    v_challenger.observe_algebra_slice(point);
+                }
+            }
+        }
+
+        TestFixture {
+            fri_params,
+            input_mmcs,
+            proof,
+            challenger: v_challenger,
+            commitments_with_opening_points: cwop,
+        }
+    }
+
+    #[test]
+    fn forged_fold_schedule_rejected() {
+        // Invariant: a proof that folded on an underived schedule is rejected.
+        //
+        // This is the regression the derivation closes.
+        // Every part of the proof agrees with the forged schedule.
+        // No other guard has anything to catch.
+        //
+        // Fixture state: one input at log height 5, final height 1, cap 3.
+        //
+        //     derived:  [3, 1]   folds 5 -> 2 -> 1
+        //     forged:   [1, 3]   folds 5 -> 4 -> 1
+        //
+        // Both fold the same total distance, so the height cross-check agrees.
+        let f = make_forged_schedule_fixture(2, 3, 4, vec![1, 3]);
+
+        let forged: Vec<usize> = f
+            .proof
+            .commit_phase_openings
+            .iter()
+            .map(|opening| opening.log_arity as usize)
+            .collect();
+        assert_eq!(
+            forged,
+            vec![1, 3],
+            "the prover must have folded on the forgery"
+        );
+
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &f.proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect_err("a forged fold schedule must be rejected");
+
+        match err {
+            FriError::FoldScheduleMismatch { expected, got } => {
+                assert_eq!(expected, vec![3, 1]);
+                assert_eq!(got, vec![1, 3]);
+            }
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn honest_high_arity_proof_accepted() {
+        // Invariant: the derivation accepts what an honest prover folds.
+        //
+        // Guards the forgery test above from passing for the wrong reason.
+        let f = make_test_fixture_with(2, 3, 4);
+        let mut challenger = f.challenger.clone();
+        run_verify_fri(
+            &f.fri_params,
+            &f.proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect("an honest non-uniform schedule must verify");
     }
 
     #[test]
@@ -1809,14 +1968,12 @@ mod tests {
         // Invariant: the global height cannot exceed the field two-adicity.
         // The final-poly point is a 2^height-th root of unity, absent past that.
         //
-        // With no input commitments the cross-check is skipped.
-        // A malicious proof could then inflate the fold schedule without bound.
-        // The dedicated guard must reject it instead of panicking in the generator.
+        // A malicious proof can inflate the fold schedule without bound.
+        // This guard runs before the height is used, so it rejects rather than panics.
         //
         // Fixture state: 3 rounds of arity 1.
         //
-        // Mutation: clone rounds until the schedule passes the two-adicity, then
-        // verify against an empty commitment set so only the guard stands.
+        // Mutation: clone rounds until the schedule passes the two-adicity.
         let f = make_test_fixture();
         let mut proof = f.proof.clone();
 
@@ -1833,9 +1990,15 @@ mod tests {
         }
 
         let mut challenger = f.challenger.clone();
-        // Empty commitments: the cross-check is skipped, leaving only the guard.
-        let err = run_verify_fri(&f.fri_params, &proof, &mut challenger, &[], &f.input_mmcs)
-            .expect_err("height above two-adicity must be rejected");
+        // The inflated sum trips this guard before the height cross-check sees it.
+        let err = run_verify_fri(
+            &f.fri_params,
+            &proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+        )
+        .expect_err("height above two-adicity must be rejected");
 
         match err {
             FriError::GlobalMaxHeightTooLarge {


### PR DESCRIPTION
## What this changes

The FRI folding schedule — which arity each commit round folds by — is now derived on both sides instead of being carried in the proof.

## The problem

The schedule is decided entirely by the committed heights and the parameters. Nothing about it is a choice.

The prover recomputed it round by round inside the fold loop. The verifier read it out of the proof and checked two things: that each arity was within the cap, and that the arities summed to the committed height.

A sum is a weak thing to check. Two different schedules can share one:

```
committed height 2^5, final height 2^1, arity cap 3

honest:  [3, 1]   folds 5 -> 2 -> 1
forged:  [1, 3]   folds 5 -> 4 -> 1
```

Both fold the same total distance, both stay within the cap, both have the same round count. So every guard the verifier ran passed either way.

## This was reachable, and the test now proves it

Demonstrated end-to-end, not argued: `forged_fold_schedule_rejected` builds a proof that folded on `[1, 3]` with every commitment, sibling row, opening proof and transcript value consistent with it — what a malicious prover would emit, not a field tamper.

```
with the derivation:     Err(FoldScheduleMismatch { expected: [3, 1], got: [1, 3] })
with it commented out:   Ok(())          <- the proof is accepted
```

So a prover could commit on a folding schedule the configuration never specifies and have it accepted. `prove_fri_with_schedule` is the test-only seam that makes this provable: an honest prover passes `None`.

The security model in `p3-security` derives its layer count from the arity cap alone (`security/src/fri.rs:147`), so it models a uniform max-arity schedule and does not describe a prover-chosen one in either direction. What this change delivers is that the protocol the verifier executes is the protocol the configuration specifies. I have not shown that a particular reordering is cryptographically weaker.

## The idea

Compute the schedule once, from the inputs, in a place both sides can call.

```rust
fold_schedule(input_log_heights, log_final_height, max_log_arity) -> Vec<usize>
```

A round's arity is capped by three things, all known before folding starts: the distance left to the final height, the distance down to where the next input joins, and the configured maximum.

The prover iterates that function's output rather than recomputing per round, so its schedule is the function's output by construction. The verifier derives the same schedule from the committed heights and rejects a proof that folded differently.

## Two guards no longer fail open

Both derived checks were skipped when the instance committed to no matrices, which left `log_arities` fully proof-controlled on that path. An instance with nothing committed is now rejected up front, next to the zero-queries guard, so both comparisons are unconditional and share one derivation of the committed heights.

`MissingInitialReducedOpening` becomes defensive only as a result: its former path is closed, and with at least one committed matrix every query gets at least one reduced opening. The check is kept, since I did not prove it unreachable.

## Circle had the same hole

`p3-circle`'s verifier read the per-round arity out of the proof and pinned only the sum, and it gated the rest on a bare `assert_eq!(log_arity, 1)` deep in the query loop — a panic on proof-controlled data, reachable for any configuration with `max_log_arity > 1`, where it also aborted on *honest* proofs.

Circle folding halves the domain and nothing else, so importing `fold_schedule` would hand it a schedule it cannot fold. The real constraint is arity one, and that is now checked on entry. Every per-round arity is then forced to one, so the pinned height sum determines the schedule uniquely, and the assert becomes a debug assertion.

## One robustness note

`fold_schedule` returns an empty schedule when nothing sits above the final height, rather than asserting. The verifier derives it from untrusted heights, so it must not panic there.

## Test plan

- [x] `cargo test -p p3-fri` — 77 pass across all targets
- [x] `cargo test -p p3-circle` — 45 pass
- [x] `cargo clippy -p p3-fri -p p3-circle --all-targets` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- New in FRI: four unit tests for the schedule including an exhaustive sweep over caps, final heights and input pairs; the forged-schedule rejection above; an honest non-uniform schedule accepted, so the forgery test cannot pass for the wrong reason; the empty-instance rejection.
- New in circle: a cap above one is refused on entry.

## Breaking changes

`FriError` gains `NoCommittedMatrices` and `UnsupportedFoldingCap`. A circle configuration with `max_log_arity > 1` is now rejected rather than aborting mid-verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
