### PR TITLE
fix(binary-pcs): query at pair granularity, fold without copying

### DIFF
--- a/binary-pcs/README.md
+++ b/binary-pcs/README.md
@@ -12,4 +12,11 @@ domain is one. The Johnson bound is not refuted — it is an unconditional theor
 those same counterexamples show to be tight — but `p3-security` documents it as resting on a
 correlated-agreement conjecture, and it is excluded here by choice, not by mathematics.
 
+Two obligations the types do not carry:
+
+- **Binding, not hiding.** The final codeword travels in the clear and every query opening is a
+  raw codeword symbol, so this must not be used where zero-knowledge is required.
+- **Collision resistance is the caller's.** The derived schedule prices the field's width and
+  the query count, never the Merkle tree it is paired with.
+
 Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -79,13 +79,16 @@ fn gray_chain_steps(num_pairs: usize) -> Vec<BinaryField128> {
 ///
 /// # Panics
 ///
-/// Panics if `codeword` has odd length. A codeword always has a power-of-two length, so an odd
-/// one means the caller has lost track of the round schedule.
+/// Panics unless the codeword is empty or has a power-of-two length.
+/// That is the shape every round schedule produces.
+///
+/// The chained step table itself covers any even length, so this is a deliberate
+/// narrowing of the contract rather than a limit of the method.
 #[must_use]
 pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<BinaryField128> {
     assert!(
-        codeword.len().is_multiple_of(2),
-        "codeword length must be even"
+        codeword.is_empty() || codeword.len().is_power_of_two(),
+        "codeword length must be a power of two"
     );
 
     let num_pairs = codeword.len() / 2;
@@ -225,10 +228,25 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "codeword length must be even")]
+    #[should_panic(expected = "codeword length must be a power of two")]
     fn an_odd_length_codeword_is_rejected() {
         let odd = [BinaryField128::ONE; 3];
         let _ = fold_codeword(&odd, BinaryField128::ONE);
+    }
+
+    #[test]
+    #[should_panic(expected = "codeword length must be a power of two")]
+    fn an_even_non_power_of_two_codeword_is_rejected() {
+        // Even is not enough: the per-level step table is sized for a power of two.
+        // Six symbols is three pairs, which no round schedule produces.
+        let six = [BinaryField128::ONE; 6];
+        let _ = fold_codeword(&six, BinaryField128::ONE);
+    }
+
+    #[test]
+    fn an_empty_codeword_folds_to_an_empty_one() {
+        // Zero pairs to fold, and zero levels to index, so the empty input is not a panic.
+        assert!(fold_codeword(&[], BinaryField128::ONE).is_empty());
     }
 
     /// `f_0 + beta * f_1`, the novel-basis combination, is a different operation from

--- a/binary-pcs/src/params.rs
+++ b/binary-pcs/src/params.rs
@@ -33,6 +33,11 @@ const ALPHABET_BITS: usize = 128;
 /// caller, which is why this crate does not re-export `SecurityAssumption`.
 const REGIME: SecurityAssumption = SecurityAssumption::UniqueDecoding;
 
+// A change of regime must fail to compile, not fail at run time.
+// The other regimes are refuted over `F_2`-subspace domains.
+// No configuration should accept them, so there is nothing to report as an error.
+const _: () = assert!(matches!(REGIME, SecurityAssumption::UniqueDecoding));
+
 /// `ceil(log2(value))`.
 ///
 /// For `value >= 2` the highest set bit of `value - 1` sits one below the ceiling at a power
@@ -60,6 +65,24 @@ const fn log2_ceil_u128(value: u128) -> usize {
 /// Their sum is `n + 1 + 2 * num_fold_rounds` over `|F|`. The sum cannot overflow: `try_new`
 /// admits `log_domain_size` only below `usize::BITS`, so `n` stays below `2^64`.
 ///
+/// The two terms compose under different conventions:
+///
+/// - The commit term is a per-round bound, charged once.
+/// - The sumcheck term is union-bounded over every round.
+///
+/// Charging a per-round bound once is the round-by-round convention.
+/// The security crate composes the same way, taking the worst term rather than summing errors.
+/// The mixture here is conservative, never optimistic.
+///
+/// At arity 2 the choice is numerically inert:
+///
+/// ```text
+///     commit    n + 1      = 2^22   at the largest shape benched here
+///     sumcheck  2 * rounds = 40
+/// ```
+///
+/// Raising the arity shrinks the round count without shrinking `n`, so the two stay far apart.
+///
 /// Taking the ceiling of the logarithm rounds the result **down**, so this understates the
 /// achieved security by up to one bit rather than overstating it.
 const fn field_security_bits_at(log_domain_size: usize, num_fold_rounds: usize) -> usize {
@@ -79,6 +102,11 @@ pub struct BinaryPcsParams {
 }
 
 /// The round schedule derived from [`BinaryPcsParams`] and the polynomial's arity.
+///
+/// The schedule prices the field's width and the query count, and nothing else.
+/// In particular it does not price the commitment scheme, which is supplied separately.
+/// A digest narrower than `2 * security_level` bits leaves the reported level undeliverable.
+/// Supplying one wide enough is the caller's obligation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct BinaryPcsConfig {
     params: BinaryPcsParams,
@@ -127,13 +155,6 @@ pub enum BinaryPcsConfigError {
     /// The derived query count was zero, which would accept any codeword.
     #[error("derived a query count of zero")]
     ZeroQueries,
-
-    /// Reached with a regime other than unique decoding.
-    ///
-    /// Unreachable through the public API, which exposes no regime knob; this guards the
-    /// private core against a future caller.
-    #[error("only the unique-decoding regime is supported over F_2-subspace domains")]
-    UnsupportedSoundnessRegime,
 }
 
 impl BinaryPcsConfig {
@@ -154,10 +175,6 @@ impl BinaryPcsConfig {
         num_variables: usize,
         params: BinaryPcsParams,
     ) -> Result<Self, BinaryPcsConfigError> {
-        if !matches!(REGIME, SecurityAssumption::UniqueDecoding) {
-            return Err(BinaryPcsConfigError::UnsupportedSoundnessRegime);
-        }
-
         // The codeword length is computed downstream as `1usize << log_len`, so `log_len`
         // must stay below `usize::BITS` or that shift is already invalid. `checked_add`
         // guards the sum itself: an adversarial `num_variables` and `log_inv_rate` must not
@@ -262,6 +279,14 @@ impl BinaryPcsConfig {
     }
 
     /// Bits of security the sampled queries deliver.
+    ///
+    /// The query phase runs one test per distinct fold pair.
+    /// It therefore executes at most half the domain's worth of tests, however many
+    /// the derivation asked for.
+    ///
+    /// Where the derived count exceeds that, this figure is a lower bound.
+    /// Opening every pair checks every fold at every position of every round, and the
+    /// query-phase error of that is zero rather than a power of the proximity gap.
     #[must_use]
     pub fn query_security_bits(&self) -> f64 {
         REGIME.queries_error(self.params.log_inv_rate, self.num_queries)

--- a/binary-pcs/src/pcs.rs
+++ b/binary-pcs/src/pcs.rs
@@ -119,14 +119,14 @@ where
     /// point the fold challenges define, times the final codeword's (uniform) value equals the
     /// running sumcheck claim; `verify_query_paths` then ties every sampled query's fold chain
     /// to that same codeword.
-    fn verify_opening<Challenger>(
+    fn verify_opening<'p, Challenger>(
         &self,
         commitment: &MT::Commitment,
-        proof: &BinaryPcsProof<MT>,
+        proof: &'p BinaryPcsProof<MT>,
         protocol: &OpeningProtocol,
         points: Option<&[Point<BinaryField128>]>,
         challenger: &mut Challenger,
-    ) -> Result<Vec<OpeningEvals<BinaryField128>>, BinaryPcsError<MT::Error>>
+    ) -> Result<&'p [OpeningEvals<BinaryField128>], BinaryPcsError<MT::Error>>
     where
         Challenger: FieldChallenger<BinaryField128>
             + GrindingChallenger<Witness = BinaryField128>
@@ -239,7 +239,7 @@ where
             challenger,
         )?;
 
-        Ok(proof.evals.clone())
+        Ok(&proof.evals)
     }
 }
 
@@ -352,6 +352,7 @@ where
     ) -> Result<Vec<OpeningEvals<BinaryField128>>, Self::Error> {
         assert_eq!(protocol.num_openings(), points.len());
         self.verify_opening(commitment, proof, protocol, Some(points), challenger)
+            .map(<[_]>::to_vec)
     }
 }
 

--- a/binary-pcs/src/prover.rs
+++ b/binary-pcs/src/prover.rs
@@ -145,39 +145,57 @@ where
         "the commit phase runs at zero preprocessing depth, so the sumcheck consumes no head rounds"
     );
 
-    // The base commitment is a width-1 codeword: the starting point for the fold loop below.
-    let base_matrix = mmcs.get_matrices(&merkle_data)[0];
     assert_eq!(
-        base_matrix.width, 1,
+        mmcs.get_matrices(&merkle_data)[0].width,
+        1,
         "zero preprocessing depth commits a width-1 codeword"
     );
-    let mut codeword = base_matrix.values.clone();
 
-    // One sumcheck round, one codeword fold, per iteration. The last fold's codeword is not
-    // committed: it is returned as the final codeword, so the round loop only commits the
-    // folds a `RoundCommitment` actually needs.
+    // One sumcheck round, one codeword fold, per iteration.
+    //
+    //     round r < last:  challenge beta_r -> fold 2-to-1 -> commit -> observe root
+    //     round r = last:  challenge beta_r -> fold 2-to-1 -> return in the clear
+    //
+    // The last fold's codeword is never committed.
+    // It travels in the proof as the final codeword instead.
     let num_fold_rounds = config.num_fold_rounds();
-    let mut rounds = Vec::with_capacity(num_fold_rounds - 1);
+    let mut rounds: Vec<RoundCommitment<MT>> = Vec::with_capacity(num_fold_rounds - 1);
+    let mut final_codeword = Vec::new();
     for round in 0..num_fold_rounds {
         let challenge =
             sumcheck.compute_sumcheck_polynomials(&mut sumcheck_data, challenger, 1, 0, None);
         let beta = challenge.as_slice()[0];
         randomness.extend(&challenge);
 
-        codeword = fold_codeword(&codeword, beta);
+        // Fold out of the previous round's Merkle leaves, never out of a copy of them.
+        // The commitment scheme already owns every codeword it committed.
+        // The fold allocates its own output, so this borrow ends before the push below.
+        let source = if round == 0 {
+            &merkle_data
+        } else {
+            &rounds[round - 1].merkle_data
+        };
+        let folded = fold_codeword(&mmcs.get_matrices(source)[0].values, beta);
 
         if round + 1 < num_fold_rounds {
-            let (commitment, round_data) =
-                mmcs.commit_matrix(RowMajorMatrix::new(codeword.clone(), 1));
+            let (commitment, round_data) = mmcs.commit_matrix(RowMajorMatrix::new(folded, 1));
             challenger.observe(commitment.clone());
             rounds.push(RoundCommitment {
                 commitment,
                 merkle_data: round_data,
             });
+        } else {
+            final_codeword = folded;
         }
     }
 
-    (merkle_data, sumcheck_data, rounds, randomness, codeword)
+    (
+        merkle_data,
+        sumcheck_data,
+        rounds,
+        randomness,
+        final_codeword,
+    )
 }
 
 /// The query phase's prover-side output: every opening `verifier::verify_query_paths` needs,

--- a/binary-pcs/src/verifier.rs
+++ b/binary-pcs/src/verifier.rs
@@ -6,7 +6,18 @@
 //! the base codeword's domain, addresses position `i >> r` at round `r`; folding that
 //! position's pair with round `r`'s challenge must reproduce the value read at position
 //! `i >> (r + 1)` of round `r + 1`.
+//!
+//! Every one of those reads goes through `i >> 1`:
+//!
+//! - Round 0 opens the pair `[i & !1, (i & !1) + 1]`.
+//! - Round 0 folds that pair at the domain point of the pair's low position.
+//! - Round `r >= 1` sees only `i >> r`.
+//!
+//! So bit 0 of `i` selects nothing, and a query is a pair index.
+//! Sampling draws that pair index directly.
+//! That is what makes one distinct draw mean one distinct fold-chain test.
 
+use alloc::collections::BTreeSet;
 use alloc::vec;
 use alloc::vec::Vec;
 
@@ -22,19 +33,46 @@ use crate::fold::fold_pair;
 use crate::params::BinaryPcsConfig;
 use crate::proof::BinaryPcsProof;
 
-/// Samples `num_queries` distinct indices, uniformly at random, from `[0, domain_size)`.
+/// Number of distinct fold-chain tests a codeword of `domain_size` symbols admits.
 ///
-/// Indices come from `sample_uniform_bits::<true>`, which rejection-samples internally,
-/// rather than from the low bits of a sampled field element: the latter biases each draw and
-/// inflates the decoding radius the query bound is stated against.
+/// One per fold pair, so half the domain.
+/// Every check reads both symbols of a pair, so bit 0 of a position selects nothing.
+pub(crate) const fn num_distinct_queries(domain_size: usize, num_queries: usize) -> usize {
+    let num_pairs = domain_size / 2;
+    if num_queries < num_pairs {
+        num_queries
+    } else {
+        num_pairs
+    }
+}
+
+/// Samples distinct fold pairs from the base codeword's domain.
 ///
-/// Duplicates are rejected, so the output length is `min(num_queries, domain_size)`; a
-/// request for more indices than the domain holds returns the whole domain. Returns indices
-/// in ascending order.
+/// Returns each sampled pair's low-indexed position, in ascending order.
+/// Every returned position is even.
+///
+/// # Why a pair index
+///
+/// Both symbols of a pair are read and folded together at every round.
+/// Two symbol positions differing only in bit 0 therefore name the same test.
+/// Drawing one bit fewer and doubling aligns the enforced distinctness with the query bound.
+///
+/// # Why uniform bits
+///
+/// A uniform element of the codeword alphabet is already a uniform 128-bit string.
+/// Its low bits therefore carry no bias.
+/// The binary challenger's uniform sampler is itself a plain mask over transcript bytes.
+/// That sampler is used because it is the interface that states the guarantee.
+/// A challenger over a prime field then cannot silently reintroduce bias.
+///
+/// # Returns
+///
+/// One position per distinct pair, capped at the number of pairs the domain holds.
+/// A request for more pairs than exist returns every pair.
 ///
 /// # Panics
 ///
-/// Panics if `domain_size` is not a power of two.
+/// Panics unless `domain_size` is a power of two of at least two.
 pub(crate) fn sample_query_indices<Challenger, F>(
     domain_size: usize,
     num_queries: usize,
@@ -44,21 +82,23 @@ where
     Challenger: FieldChallenger<F> + CanSampleUniformBits<F>,
     F: Field,
 {
-    let bits = log2_strict_usize(domain_size);
-    let target = num_queries.min(domain_size);
+    // One bit narrower than the domain: a sampled value indexes pairs, not symbols.
+    let pair_bits = log2_strict_usize(domain_size / 2);
+    let target = num_distinct_queries(domain_size, num_queries);
 
-    let mut indices: Vec<usize> = Vec::with_capacity(target);
-    while indices.len() < target {
-        let index = challenger
-            .sample_uniform_bits::<true>(bits)
+    // A set, not a linear scan over what has already been drawn.
+    // Once the target approaches the pair count, the draw count is a coupon-collector tail.
+    // The small-domain configurations reach exactly that.
+    let mut pairs = BTreeSet::new();
+    while pairs.len() < target {
+        let pair = challenger
+            .sample_uniform_bits::<true>(pair_bits)
             .expect("RESAMPLE = true: rejection loops internally, never errors");
-        if !indices.contains(&index) {
-            indices.push(index);
-        }
+        pairs.insert(pair);
     }
 
-    indices.sort_unstable();
-    indices
+    // `BTreeSet` iterates in ascending order, so doubling preserves it.
+    pairs.into_iter().map(|pair| pair << 1).collect()
 }
 
 /// The pair of positions round `round`'s codeword must supply to carry query `index` onward:
@@ -183,7 +223,7 @@ where
     check_round_and_final_lengths(config, proof)?;
 
     let domain_size = config.domain_size();
-    let target_queries = config.num_queries().min(domain_size);
+    let target_queries = num_distinct_queries(domain_size, config.num_queries());
     let expected_opens = 2 * target_queries;
 
     check_round_shape(0, &proof.base_opened_values, expected_opens)?;
@@ -312,7 +352,7 @@ mod tests {
     }
 
     #[test]
-    fn query_indices_are_distinct_sorted_and_in_range() {
+    fn query_indices_are_distinct_sorted_even_and_in_range() {
         let mut c = challenger();
         let indices = sample_query_indices::<_, BinaryField128>(1 << 10, 12, &mut c);
         assert_eq!(indices.len(), 12);
@@ -321,13 +361,22 @@ mod tests {
             "sorted and distinct"
         );
         assert!(indices.iter().all(|&i| i < 1 << 10), "in range");
+        // Each position is a pair's low symbol, so bit 0 is clear by construction.
+        // Distinct and even together mean no two draws are fold siblings.
+        assert!(indices.iter().all(|&i| i.is_multiple_of(2)), "pair-aligned");
     }
 
     #[test]
-    fn a_request_larger_than_the_domain_returns_the_whole_domain() {
+    fn a_request_larger_than_the_domain_returns_every_pair() {
+        // Invariant: a query is a pair, so an 8-symbol domain holds 4 tests, not 8.
+        //
+        //     symbols: 0 1 2 3 4 5 6 7
+        //     pairs:   |0| |2| |4| |6|
+        //
+        // Asking for 100 therefore yields the 4 low positions, not 8 indices.
         let mut c = challenger();
         let indices = sample_query_indices::<_, BinaryField128>(8, 100, &mut c);
-        assert_eq!(indices, (0..8).collect::<Vec<_>>());
+        assert_eq!(indices, alloc::vec![0, 2, 4, 6]);
     }
 
     #[test]

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -103,13 +103,22 @@ fn run_lifecycle(
 /// Runs one commit/open/verify round trip at `num_variables` and `log_inv_rate`, with the
 /// prover and the verifier on two independently constructed challengers seeded identically.
 fn assert_round_trips(num_variables: usize, log_inv_rate: usize, seed: u64) {
+    assert_round_trips_at(num_variables, log_inv_rate, POW_BITS, seed);
+}
+
+/// Runs one round trip with the grinding budget spelled out.
+///
+/// For the configurations whose point is the budget rather than the shape.
+fn assert_round_trips_at(num_variables: usize, log_inv_rate: usize, pow_bits: usize, seed: u64) {
     let (pcs, commitment, proof, protocol) =
-        run_lifecycle(num_variables, log_inv_rate, POW_BITS, SECURITY_LEVEL, seed);
+        run_lifecycle(num_variables, log_inv_rate, pow_bits, SECURITY_LEVEL, seed);
 
     let mut verifier_challenger = challenger();
     pcs.verify(&commitment, &proof, &mut verifier_challenger, protocol)
         .unwrap_or_else(|err| {
-            panic!("num_variables={num_variables} log_inv_rate={log_inv_rate}: {err:?}")
+            panic!(
+                "num_variables={num_variables} log_inv_rate={log_inv_rate} pow_bits={pow_bits}: {err:?}"
+            )
         });
 }
 
@@ -123,6 +132,24 @@ fn small_configurations_round_trip() {
             let seed = (num_variables as u64) << 8 | log_inv_rate as u64;
             assert_round_trips(num_variables, log_inv_rate, seed);
         }
+    }
+}
+
+#[test]
+fn a_zero_grinding_budget_round_trips() {
+    // Invariant: a zero grinding budget must leave both transcripts in the same state.
+    //
+    //     prover  : grind(0)         -> witness zero, transcript untouched
+    //     verifier: check_witness(0) -> accepts,      transcript untouched
+    //
+    // Both sides return early, and they agree only because both do.
+    // Drop either early return and the two desync at query sampling.
+    // Every honest proof would then stop verifying, at every shape.
+    //
+    // A zero budget is accepted for any positive security level, so it is reachable.
+    for &log_inv_rate in &[1usize, 2, 3] {
+        let seed = 0xB17_u64 << 8 | log_inv_rate as u64;
+        assert_round_trips_at(NUM_VARIABLES, log_inv_rate, 0, seed);
     }
 }
 


### PR DESCRIPTION
Follow-up to the review on #2032. Everything here is a minor from that review; the two substantive items are deliberately left out and named at the bottom.

The query phase's encoding changes, so proofs are not interchangeable across this commit. The crate is one commit old and unreleased, so no stored proof exists.

This is labelled `fix` rather than `refactor`: the old sampler was a small over-claim, not just waste. See below.

## Query sampling draws a pair index, not a symbol index

Every check in `verify_query_paths` goes through `index >> 1`:

- round `0` opens the pair `[index & !1, (index & !1) + 1]` and folds it at `domain_point(index & !1)`;
- round `r >= 1` sees only `index >> r`.

So bit `0` selected nothing. `index` and `index ^ 1` were byte-for-byte the same test, and two sampled indices that happened to be siblings named one test while costing two openings — which also meant `num_queries` distinct *indices* was not `num_queries` distinct *tests*, the thing the query bound is actually stated over.

Drawing `log_domain_size - 1` bits and doubling closes that. Expected wasted queries, before:

| config | domain | queries | expected sibling pairs |
|---|---|---|---|
| nv=8, rate 2^-2, sec 40 — this crate's test params | 2^10 | 54 | 1.40, i.e. 2.6% |
| nv=16, rate 2^-2, sec 100 | 2^18 | 136 | 0.035 |
| nv=20, rate 2^-2, sec 100 | 2^22 | 136 | 0.002 |

The old code enforced distinct *symbols* and charged the query bound for each. But `fold_pair_positions` masks bit 0 away at every round, so two symbols that are fold siblings run the same test — paid for twice and counted twice. Sampling `num_queries` distinct *pairs* without replacement is at least as strong as that many independent pairs, so the new scheme dominates both the old code and the bound it was priced against.

Expected sibling collisions, and what they cost of the claimed 36 bits:

| config | domain | queries | expected collisions | bits lost |
|---|---|---|---|---|
| nv=8, rate 2^-2 — this crate's test params | 2^10 | 54 | 1.4 | ~0.3 to 1 |
| nv=20, rate 2^-2, sec 100 | 2^22 | 136 | 0.002 | negligible |

Small, but a real over-claim rather than accounting. `BTreeSet` also replaces the linear `Vec::contains` scan, which the small-domain configurations (where the target saturates the pair count) drive into a coupon-collector tail.

## `fold_rounds` folds without copying

It cloned the base codeword once and every folded round once more — `2 * domain_size` element copies, about 134 MiB at `num_variables = 20`. The MMCS already owns every committed codeword and `fold_codeword` allocates its own output, so each round can fold straight out of the previous round's Merkle leaves; the borrow ends before `rounds` is pushed to.

Measured on `open/16`, `--features parallel`, `-C target-feature=+pclmulqdq`, against the merged baseline in a parallel worktree:

```
open/16   baseline   [45.6 ms  52.9 ms  57.6 ms]
open/16   this PR    [42.7 ms  48.5 ms  52.7 ms]
```

~8% on the median. The bench runs 10 samples so the intervals overlap; the copy elimination is exact and the direction matches. `commit/16` is unchanged, as expected — it never enters the fold loop.

## The rest

- **`fold_codeword` narrows its precondition to a power-of-two length**, where it previously checked only evenness. This is a deliberate tightening of a `pub` contract, not an assert catching up with the docs: `gray_chain_steps` sizes `levels = num_pairs.next_power_of_two().trailing_zeros()`, and the loop's maximum index is always `levels - 1`, so the step table covers any even length. At `num_pairs = 3` the chain is `domain_point(0)`, `domain_point(2)`, `domain_point(4)` — all correct. The doc no longer claims the step table as the reason.
- **`query_security_bits` is documented as a lower bound once the cap binds.** The query phase executes `min(num_queries, domain_size/2)` tests, and where the derived count exceeds that, opening every pair checks every fold at every position — a query-phase error of zero, not `(1-δ)^k`. The reported figure therefore understates rather than overstates.
- **`field_security_bits_at` records its composition convention.** The commit term is `p3-security`'s *per-round* bound charged once, which is the convention `RegimeReport::binding` composes under (minimum bits over terms); the sumcheck term is union-bounded over rounds. The mixture is conservative and, at arity 2, inert — `n + 1 = 2^22` against `2 * 20`. Written down so it stays legible if the arity ever moves.
- **The `REGIME` guard becomes a `const` assert.** It was a runtime branch on a compile-time constant, so `UnsupportedSoundnessRegime` was a public variant no caller could observe and no test could construct. Given the other regimes are *refuted* over `F_2`-subspace domains, a change to `REGIME` should fail to compile rather than return an error. The variant is removed; the enum is `#[non_exhaustive]` and unreleased, and the variant was unconstructible.
- **`sample_query_indices`' rationale is corrected.** It said the low bits of a sampled field element are biased. Over `GF(2^128)` they are not — a uniform element is a uniform 128-bit string — and `BinaryChallenger::sample_uniform_bits` is itself an unrejected mask over transcript bytes. The uniform API is right, for the different reason that it is the one that *states* the guarantee.
- **`verify_opening` returns a borrow.** Only `verify_at`, which owes its caller an owned value, clones.
- **The README states two obligations the types do not carry.** The scheme is binding, not hiding: the final codeword travels in the clear and openings are raw symbols. And `BinaryPcsConfig` prices the field's width and the query count but nothing the MMCS contributes, so collision resistance is the caller's to supply.
- **`pow_bits = 0` is covered.** It is the one budget where both `BinaryChallenger::grind` and `GrindingChallenger::check_witness` return early without touching the transcript. They agree only because *both* do; drop either and prover and verifier desync at query sampling, so every honest proof stops verifying. `try_new` accepts it for any `security_level >= 1`.

## Left out on purpose

Two items from the review are real but want their own PRs:

1. **FRI commit arity.** The commit phase commits a Merkle tree per fold round — arity 1. The message-side folding is genuinely forced by the sumcheck lockstep, but the commit arity is the ordinary FRI knob and is free: open a coset of `2^k`, apply `fold_pair` `k` times locally, compare against round `c + k`. `p3-fri` already has the machinery (`log_arities`, `fold_row`, `extra_query_index_bits`). binius64 runs the same construction over the same Gao–Mateer domain in the same regime and its proof-size DP lands on arity 4 at every shape it ships. This is the largest number in the crate and deserves a measured PR, not a rider.
2. **Dropping the symbol the verifier already computes.** At round `r + 1` one of the two opened symbols is exactly the fold of round `r`; `p3-fri` sends only `sibling_values` and reconstructs it. Worth ~8% of proof size, but it moves a `FoldMismatch` into the Merkle check and churns the negative tests' expected variants, so it should land on its own.

## Test plan

- [x] `cargo test -p p3-binary-pcs`, with and without `--features parallel`: 37 lib + 19 integration.
- [x] `cargo clippy -p p3-binary-pcs --all-targets --all-features -- -D warnings`.
- [x] `cargo +nightly fmt -p p3-binary-pcs -- --check`.
- [x] `thumbv7em-none-eabi` build.
- [x] `open/16` and `commit/16` benched against the merged baseline, numbers above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
