### PR TITLE
perf(sumcheck): bind and measure in one pass

### DIFF
--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -169,6 +169,30 @@ impl<F> Poly<F> {
         self.0
     }
 
+    /// Keeps the lower half of the evaluation table and drops the upper half.
+    ///
+    /// Binding the first variable writes its result over the lower half.
+    ///
+    /// The upper half is dead once that is done.
+    /// Dropping it is what takes the arity down by one.
+    ///
+    /// This is that second step on its own.
+    /// A caller whose own pass wrote the lower half calls it to finish the binding.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the polynomial is constant.
+    #[inline]
+    pub fn truncate_to_half(&mut self) {
+        let num_evals = self.num_evals();
+
+        // A constant has no variable to bind, so there is no upper half to drop.
+        assert!(num_evals > 1, "no free variables");
+
+        // The lower half already holds the bound values.
+        self.0.truncate(num_evals / 2);
+    }
+
     /// Pads the evaluation vector with zeros up to `num_variables`.
     ///
     /// # Panics

--- a/multilinear-util/src/poly/mod.rs
+++ b/multilinear-util/src/poly/mod.rs
@@ -176,12 +176,14 @@ impl<F> Poly<F> {
     /// The upper half is dead once that is done.
     /// Dropping it is what takes the arity down by one.
     ///
-    /// This is that second step on its own.
-    /// A caller whose own pass wrote the lower half calls it to finish the binding.
+    /// This is that second step alone, for a pass that wrote the lower half itself.
+    /// On a table nobody bound it silently returns the restriction to the first
+    /// variable at zero, so it is hidden rather than offered.
     ///
     /// # Panics
     ///
     /// Panics if the polynomial is constant.
+    #[doc(hidden)]
     #[inline]
     pub fn truncate_to_half(&mut self) {
         let num_evals = self.num_evals();

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -29,7 +29,7 @@ use tracing::instrument;
 
 use crate::SumcheckData;
 use crate::constraints::Constraint;
-use crate::strategy::{Basis, RoundMessage, VariableOrder};
+use crate::strategy::{Basis, RoundMessage, VariableOrder, fold_and_round_coefficients_prefix};
 
 /// A paired representation of evaluation and weight polynomials for quadratic sumcheck.
 ///
@@ -456,6 +456,78 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
             }
         };
         (msg.c_a, msg.c_inf)
+    }
+
+    /// Binds the round variable and measures the next round's message in one pass.
+    ///
+    /// # Overview
+    ///
+    /// Binding writes the bound tables out and measuring reads them straight back.
+    /// One pass does both instead.
+    ///
+    /// Each bound entry then crosses the memory hierarchy once per round, not twice.
+    /// The multiply count is unchanged.
+    ///
+    /// # Returns
+    ///
+    /// The bound pair's round polynomial at 0, and its leading coefficient.
+    ///
+    /// # Why two states fall back
+    ///
+    /// - Suffix binding pairs adjacent entries, not half-apart faces.
+    ///   An in-place write would race its own reads.
+    /// - A table below four entries leaves the bound half with nothing to sum over.
+    pub(crate) fn fold_round_coefficients(&mut self, r: EF) -> (EF, EF) {
+        // The fused pass binds a prefix variable and needs the bound table to keep one.
+        // That is four entries in the table it starts from.
+        let fusable = self.order == VariableOrder::Prefix
+            && match &self.inner {
+                MaybePacked::Packed { evals, .. } => evals.num_evals() >= 4,
+                MaybePacked::Unpacked { evals, .. } => evals.num_evals() >= 4,
+            };
+
+        // Bind and measure as two separate passes, exactly as a plain round does.
+        if !fusable {
+            self.fold_round(r);
+            return self.round_coefficients();
+        }
+
+        let RoundMessage { c_a, c_inf } = match &mut self.inner {
+            MaybePacked::Packed { evals, weights } => {
+                let msg = fold_and_round_coefficients_prefix(
+                    evals.as_mut_slice(),
+                    weights.as_mut_slice(),
+                    r,
+                );
+
+                // The bound table is the lower half of each buffer.
+                evals.truncate_to_half();
+                weights.truncate_to_half();
+
+                // Horizontal reduction across SIMD lanes, as in the unfused round.
+                RoundMessage {
+                    c_a: EF::ExtensionPacking::to_ext_iter([msg.c_a]).sum(),
+                    c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
+                }
+            }
+            MaybePacked::Unpacked { evals, weights } => {
+                let msg = fold_and_round_coefficients_prefix(
+                    evals.as_mut_slice(),
+                    weights.as_mut_slice(),
+                    r,
+                );
+
+                // Scalar storage needs no lane reduction.
+                evals.truncate_to_half();
+                weights.truncate_to_half();
+                msg
+            }
+        };
+
+        // The bound tables may now be small enough that scalar storage is faster.
+        self.transition();
+
+        (c_a, c_inf)
     }
 
     /// Folds both product-polynomial sides by one verifier challenge.

--- a/sumcheck/src/product_polynomial.rs
+++ b/sumcheck/src/product_polynomial.rs
@@ -494,15 +494,7 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
 
         let RoundMessage { c_a, c_inf } = match &mut self.inner {
             MaybePacked::Packed { evals, weights } => {
-                let msg = fold_and_round_coefficients_prefix(
-                    evals.as_mut_slice(),
-                    weights.as_mut_slice(),
-                    r,
-                );
-
-                // The bound table is the lower half of each buffer.
-                evals.truncate_to_half();
-                weights.truncate_to_half();
+                let msg = fold_and_round_coefficients_prefix(evals, weights, r);
 
                 // Horizontal reduction across SIMD lanes, as in the unfused round.
                 RoundMessage {
@@ -510,17 +502,9 @@ impl<F: Field, EF: ExtensionField<F>> ProductPolynomial<F, EF> {
                     c_inf: EF::ExtensionPacking::to_ext_iter([msg.c_inf]).sum(),
                 }
             }
+            // Scalar storage needs no lane reduction.
             MaybePacked::Unpacked { evals, weights } => {
-                let msg = fold_and_round_coefficients_prefix(
-                    evals.as_mut_slice(),
-                    weights.as_mut_slice(),
-                    r,
-                );
-
-                // Scalar storage needs no lane reduction.
-                evals.truncate_to_half();
-                weights.truncate_to_half();
-                msg
+                fold_and_round_coefficients_prefix(evals, weights, r)
             }
         };
 

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -6,6 +6,8 @@
 //! - `VariableOrder`: tag enum carrying inherent methods that dispatch to either routine.
 //! - `SumcheckProver`: drives rounds over a paired product polynomial.
 
+use alloc::vec::Vec;
+
 use p3_challenger::{FieldChallenger, GrindingChallenger};
 use p3_field::{Algebra, ExtensionField, Field, PrimeCharacteristicRing, dot_product};
 use p3_maybe_rayon::prelude::*;
@@ -297,6 +299,228 @@ where
         chunk_round_step_projective::<B, A>,
         round_step_projective::<B, A>,
     );
+    RoundMessage { c_a, c_inf }
+}
+
+/// Target byte size of one bound face inside a fused block.
+///
+/// A block binds four faces, then measures them straight afterwards.
+/// All four have to stay in first-level cache across those two steps.
+///
+/// The budget is in bytes rather than elements.
+/// A SIMD-packed element is an order of magnitude wider than a scalar one.
+const FUSED_BLOCK_BYTES: usize = 4096;
+
+/// Number of index positions one fused block binds before measuring them.
+///
+/// Never below the tile width, so a measurement always gets one full tile.
+#[inline]
+const fn fused_block<A>() -> usize {
+    // Positions that fit the byte budget at this element width.
+    let by_bytes = FUSED_BLOCK_BYTES / core::mem::size_of::<A>();
+
+    // A wide element can exhaust the budget below one tile.
+    // The tile width wins there.
+    if by_bytes < K { K } else { by_bytes }
+}
+
+/// Binds one face of a table in place.
+///
+/// The destination holds the round variable at 0.
+/// The source holds it at 1.
+///
+/// Each entry becomes the line through the two, sampled at the challenge.
+#[inline]
+fn bind_face<A, Ch>(dst: &mut [A], src: &[A], r: Ch)
+where
+    A: Algebra<Ch> + Copy,
+    Ch: Copy,
+{
+    // The bound value overwrites the 0 face.
+    // The 1 face is only read.
+    for (lo, &hi) in dst.iter_mut().zip(src) {
+        *lo += (hi - *lo) * r;
+    }
+}
+
+/// Round message of a pair already split into the two faces of the round variable.
+///
+/// The measuring scaffold with the split hoisted out.
+/// Parallelism is left to the caller, which owns the outer loop.
+///
+/// The tiled body and the streaming tail are the ones the unsplit routine uses.
+#[inline]
+fn round_coefficients_faces<A>(e_lo: &[A], e_hi: &[A], w_lo: &[A], w_hi: &[A]) -> (A, A)
+where
+    A: Algebra<A> + Copy,
+{
+    // Whole tiles first, leftovers after.
+    // The four faces split at the same place.
+    let (e_lo_main, e_lo_tail) = e_lo.as_chunks::<K>();
+    let (e_hi_main, e_hi_tail) = e_hi.as_chunks::<K>();
+    let (w_lo_main, w_lo_tail) = w_lo.as_chunks::<K>();
+    let (w_hi_main, w_hi_tail) = w_hi.as_chunks::<K>();
+
+    // Main loop: K pairs per iteration through delayed-reduction dot products.
+    let main = e_lo_main
+        .iter()
+        .zip(e_hi_main)
+        .zip(w_lo_main.iter().zip(w_hi_main))
+        .fold(
+            (A::ZERO, A::ZERO),
+            |acc, ((e_lo_c, e_hi_c), (w_lo_c, w_hi_c))| {
+                round_reduce(acc, chunk_round_step(e_lo_c, e_hi_c, w_lo_c, w_hi_c))
+            },
+        );
+
+    // Tail: fewer than K pairs, so a streaming fold with eager reduction is fine.
+    let tail = e_lo_tail
+        .iter()
+        .zip(e_hi_tail)
+        .zip(w_lo_tail.iter().zip(w_hi_tail))
+        .fold((A::ZERO, A::ZERO), |acc, ((&e0, &e1), (&w0, &w1))| {
+            round_step(acc, e0, e1, w0, w1)
+        });
+
+    round_reduce(main, tail)
+}
+
+/// Binds a prefix variable and measures the bound pair's round message in one pass.
+///
+/// # Overview
+///
+/// The bound tables land in the lower half of each input.
+/// The inputs keep their original length, so the caller drops the upper halves itself.
+///
+/// The message is the one a separate measuring pass over the bound tables returns.
+///
+/// # Algorithm
+///
+/// The pass touches two variables at once.
+/// One is bound now.
+/// The other is the one the returned message sums over.
+///
+/// Together they cut each table into four quadrants:
+///
+/// ```text
+///     bound = 0, summed = 0 : q0        bound = 1, summed = 0 : q2
+///     bound = 0, summed = 1 : q1        bound = 1, summed = 1 : q3
+/// ```
+///
+/// Binding leaves the two faces of the variable still to be summed:
+///
+/// ```text
+///     lo = q0 + (q2 - q0) * r     written back over q0
+///     hi = q1 + (q3 - q1) * r     written back over q1
+/// ```
+///
+/// Those two faces are what the message needs.
+/// Working a block at a time keeps them in cache across the two steps.
+///
+/// The bound table is therefore written once and never read back from memory.
+///
+/// # Arguments
+///
+/// - `evals` - evaluation table, before this binding.
+/// - `weights` - weight table, before this binding.
+/// - `r` - challenge the round variable binds to.
+///
+/// # Returns
+///
+/// - `c_a` - the bound pair's round polynomial at 0.
+/// - `c_inf` - its leading coefficient.
+///
+/// # Performance
+///
+/// O(2^n), at the same multiply count as binding and measuring separately.
+/// What it saves is one pass over the bound tables.
+///
+/// # Panics
+///
+/// - The two tables must have the same length.
+/// - The length must be a multiple of four.
+///   The bound table then keeps the variable the message sums over.
+pub fn fold_and_round_coefficients_prefix<A, Ch>(
+    evals: &mut [A],
+    weights: &mut [A],
+    r: Ch,
+) -> RoundMessage<A>
+where
+    A: Algebra<Ch> + Copy + Send + Sync,
+    Ch: Copy + Send + Sync,
+{
+    // Precondition: paired tables, with a variable left over for the message.
+    assert_eq!(evals.len(), weights.len());
+    assert!(evals.len().is_multiple_of(4));
+    let evals_len = evals.len();
+
+    // Cut each table into the four quadrants of the two variables this pass touches.
+    //
+    //     [ q0 | q1 | q2 | q3 ]
+    //       written   only read
+    let quarter = evals.len() / 4;
+    let (e_bound, e_free) = evals.split_at_mut(2 * quarter);
+    let (e_q0, e_q1) = e_bound.split_at_mut(quarter);
+    let (e_q2, e_q3) = e_free.split_at(quarter);
+    let (w_bound, w_free) = weights.split_at_mut(2 * quarter);
+    let (w_q0, w_q1) = w_bound.split_at_mut(quarter);
+    let (w_q2, w_q3) = w_free.split_at(quarter);
+
+    // One block: bind the four faces, then measure them while they are still hot.
+    let block = |e_q0: &mut [A],
+                 e_q1: &mut [A],
+                 e_q2: &[A],
+                 e_q3: &[A],
+                 w_q0: &mut [A],
+                 w_q1: &mut [A],
+                 w_q2: &[A],
+                 w_q3: &[A]| {
+        bind_face(e_q0, e_q2, r);
+        bind_face(e_q1, e_q3, r);
+        bind_face(w_q0, w_q2, r);
+        bind_face(w_q1, w_q3, r);
+        round_coefficients_faces(e_q0, e_q1, w_q0, w_q1)
+    };
+
+    let len = fused_block::<A>();
+
+    // The pass covers the whole table, not just the bound half.
+    //
+    // So the par-vs-serial split is gated on the whole table.
+    // That puts about as much work in one task as a measuring pass does at its own gate.
+    let (c_a, c_inf) = if evals_len > PAR_THRESHOLD {
+        e_q0.par_chunks_mut(len)
+            .zip(e_q1.par_chunks_mut(len))
+            .zip(e_q2.par_chunks(len))
+            .zip(e_q3.par_chunks(len))
+            .zip(w_q0.par_chunks_mut(len))
+            .zip(w_q1.par_chunks_mut(len))
+            .zip(w_q2.par_chunks(len))
+            .zip(w_q3.par_chunks(len))
+            .par_fold_reduce(
+                || (A::ZERO, A::ZERO),
+                |acc, (((((((e0, e1), e2), e3), w0), w1), w2), w3)| {
+                    round_reduce(acc, block(e0, e1, e2, e3, w0, w1, w2, w3))
+                },
+                round_reduce,
+            )
+    } else {
+        e_q0.chunks_mut(len)
+            .zip(e_q1.chunks_mut(len))
+            .zip(e_q2.chunks(len))
+            .zip(e_q3.chunks(len))
+            .zip(w_q0.chunks_mut(len))
+            .zip(w_q1.chunks_mut(len))
+            .zip(w_q2.chunks(len))
+            .zip(w_q3.chunks(len))
+            .fold(
+                (A::ZERO, A::ZERO),
+                |acc, (((((((e0, e1), e2), e3), w0), w1), w2), w3)| {
+                    round_reduce(acc, block(e0, e1, e2, e3, w0, w1, w2, w3))
+                },
+            )
+    };
+
     RoundMessage { c_a, c_inf }
 }
 
@@ -730,15 +954,42 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
             self.poly.combine(&mut self.sum, &constraint);
         }
 
-        // Drive `folding_factor` standard rounds, collecting each round's challenge.
-        let res = (0..folding_factor)
-            .map(|_| {
-                self.poly
-                    .round(sumcheck_data, challenger, &mut self.sum, pow_bits)
-            })
-            .collect();
+        // A challenge is not applied on the spot.
+        // It is handed to the next round, which binds and measures in one pass.
+        //
+        //     round i:  bind r_{i-1}  +  measure h_i     (one pass)
+        //     after:    bind r_{k-1}                     (one pass)
+        let mut pending: Option<EF> = None;
+        let mut challenges = Vec::with_capacity(folding_factor);
 
-        Point::new(res)
+        for _ in 0..folding_factor {
+            // Measure this round, absorbing whatever binding the last one left behind.
+            let (c_a, c_inf) = match pending {
+                Some(r) => self.poly.fold_round_coefficients(r),
+                None => self.poly.round_coefficients(),
+            };
+
+            // Commit to the transcript, do the optional grinding, take the challenge.
+            let r = sumcheck_data.observe_and_sample(challenger, c_a, c_inf, pow_bits);
+
+            // Advance the claim through the round identity the verifier applies.
+            self.sum = Basis::Evaluation.reduce_claim(c_a, c_inf, r, self.sum);
+
+            challenges.push(r);
+
+            // Hand this round's challenge to the next one.
+            pending = Some(r);
+        }
+
+        // The last challenge has no successor to fuse with, so it binds on its own.
+        if let Some(r) = pending {
+            self.poly.fold_round(r);
+        }
+
+        // Invariant: the claim is the inner product of the bound pair.
+        debug_assert_eq!(self.sum, self.poly.dot_product());
+
+        Point::new(challenges)
     }
 }
 
@@ -749,7 +1000,7 @@ mod tests {
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{PrimeCharacteristicRing, dot_product};
+    use p3_field::{Field, PackedValue, PrimeCharacteristicRing, dot_product};
     use p3_multilinear_util::point::Point;
     use p3_multilinear_util::poly::Poly;
     use proptest::prelude::*;
@@ -992,6 +1243,147 @@ mod tests {
                 Basis::Evaluation.reduce_claim(c_a, c_inf, r, claim),
                 Basis::Projective.reduce_claim(c_a, c_inf, r, claim),
             );
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn prop_fold_and_round_coefficients_prefix_matches_bind_then_measure(
+            k in 2usize..=16,
+            seed in any::<u64>(),
+        ) {
+            // Invariant: the fused pass is bind-then-measure, in one traversal.
+            //
+            //     two passes: bind the tables, then measure the bound pair
+            //     fused     : one pass doing both
+            //
+            // Both the bound tables and the message have to come out identical.
+            // A prover on the fused path would otherwise send a different transcript.
+            //
+            // Fixture state: 2^k paired random entries, one random challenge.
+            // The range straddles the 8-wide tiled body and the par-vs-serial split.
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let n = 1usize << k;
+            let evals: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let weights: Vec<EF> = (0..n).map(|_| rng.random()).collect();
+            let r: EF = rng.random();
+
+            // Reference arm: bind both tables, then measure the bound pair.
+            let mut want_evals = Poly::new(evals.clone());
+            let mut want_weights = Poly::new(weights.clone());
+            want_evals.fix_prefix_var_mut(r);
+            want_weights.fix_prefix_var_mut(r);
+            let want = super::sumcheck_coefficients_prefix(
+                want_evals.as_slice(),
+                want_weights.as_slice(),
+            );
+
+            // Fused arm: one pass writes the bound tables into the lower halves.
+            let mut got_evals = Poly::new(evals);
+            let mut got_weights = Poly::new(weights);
+            let got = super::fold_and_round_coefficients_prefix(
+                got_evals.as_mut_slice(),
+                got_weights.as_mut_slice(),
+                r,
+            );
+
+            // The fused pass leaves the upper halves in place, so drop them here.
+            got_evals.truncate_to_half();
+            got_weights.truncate_to_half();
+
+            // The bound tables must agree entry for entry.
+            prop_assert_eq!(got_evals.as_slice(), want_evals.as_slice());
+            prop_assert_eq!(got_weights.as_slice(), want_weights.as_slice());
+
+            // And so must the two values the round sends.
+            prop_assert_eq!(got.c_a, want.c_a);
+            prop_assert_eq!(got.c_inf, want.c_inf);
+        }
+    }
+
+    #[test]
+    fn deferred_binding_drives_the_same_rounds_as_round_at_a_time() {
+        use p3_baby_bear::Poseidon2BabyBear;
+        use p3_challenger::DuplexChallenger;
+        use p3_util::log2_strict_usize;
+
+        use crate::SumcheckData;
+        use crate::product_polynomial::ProductPolynomial;
+
+        type Perm = Poseidon2BabyBear<16>;
+        type TestChallenger = DuplexChallenger<F, Perm, 16, 8>;
+
+        // Both arms start from the same transcript.
+        // Their challenges can only differ if a round message did.
+        let challenger = || {
+            let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(42));
+            TestChallenger::new(perm)
+        };
+
+        let mut rng = SmallRng::seed_from_u64(0xD1FF);
+
+        // A pair below one SIMD lane group has nothing to pack, so it is built scalar.
+        // The lane count is a target property, so the split has to be computed, not fixed.
+        let log_width = log2_strict_usize(<F as Field>::Packing::WIDTH);
+
+        // Invariant: holding a binding back a round changes nothing the verifier sees.
+        //
+        // Fixture state: 1, 2, 4 and 9 variables, both binding orders.
+        // Nine covers the packed path, the unpacking handoff and the scalar tail.
+        // One and two land on the fallback that binds and measures separately.
+        for num_variables in [1usize, 2, 4, 9] {
+            for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
+                let evals = Poly::<EF>::rand(&mut rng, num_variables);
+                let weights = Poly::<EF>::rand(&mut rng, num_variables);
+                let poly = if num_variables >= log_width {
+                    ProductPolynomial::<F, EF>::new_packed(
+                        order,
+                        evals.pack::<F, EF>(),
+                        weights.pack::<F, EF>(),
+                    )
+                } else {
+                    ProductPolynomial::<F, EF>::new_unpacked(order, evals, weights)
+                };
+                let sum = poly.dot_product();
+
+                // Reference arm: bind on the spot, one round at a time.
+                let mut want_data = SumcheckData::<F, EF>::default();
+                let mut want_poly = poly.clone();
+                let mut want_sum = sum;
+                let mut want_challenger = challenger();
+                let want_challenges: Vec<EF> = (0..num_variables)
+                    .map(|_| {
+                        want_poly.round(&mut want_data, &mut want_challenger, &mut want_sum, 0)
+                    })
+                    .collect();
+
+                // Arm under test: the driver, which holds each binding back a round.
+                let mut got_data = SumcheckData::<F, EF>::default();
+                let mut prover = super::SumcheckProver::new(poly, sum);
+                let mut got_challenger = challenger();
+                let got_challenges = prover.compute_sumcheck_polynomials(
+                    &mut got_data,
+                    &mut got_challenger,
+                    num_variables,
+                    0,
+                    None,
+                );
+
+                // Every round message on the wire, not just the final claim.
+                assert_eq!(
+                    got_data.polynomial_evaluations(),
+                    want_data.polynomial_evaluations(),
+                    "{order:?}, {num_variables} variables"
+                );
+
+                // The transcript is shared, so the challenges follow the messages.
+                assert_eq!(got_challenges.as_slice(), want_challenges.as_slice());
+
+                // The prover state left behind must match too.
+                assert_eq!(prover.claimed_sum(), want_sum);
+                assert_eq!(prover.evals().as_slice(), want_poly.evals().as_slice());
+                assert_eq!(prover.weights().as_slice(), want_poly.weights().as_slice());
+            }
         }
     }
 

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -313,15 +313,18 @@ const FUSED_BLOCK_BYTES: usize = 4096;
 
 /// Number of index positions one fused block binds before measuring them.
 ///
-/// Never below the tile width, so a measurement always gets one full tile.
+/// Always a whole number of tiles.
+/// A block that ended mid-tile would send its remainder down the eager per-pair path.
+///
+/// That remainder is paid once per block, not once per table, so it has to be zero.
 #[inline]
 const fn fused_block<A>() -> usize {
-    // Positions that fit the byte budget at this element width.
-    let by_bytes = FUSED_BLOCK_BYTES / core::mem::size_of::<A>();
+    // Whole tiles that fit the byte budget at this element width.
+    let whole_tiles = FUSED_BLOCK_BYTES / core::mem::size_of::<A>() / K * K;
 
     // A wide element can exhaust the budget below one tile.
-    // The tile width wins there.
-    if by_bytes < K { K } else { by_bytes }
+    // One tile is then the floor.
+    if whole_tiles == 0 { K } else { whole_tiles }
 }
 
 /// Binds one face of a table in place.
@@ -389,8 +392,8 @@ where
 ///
 /// # Overview
 ///
-/// The bound tables land in the lower half of each input.
-/// The inputs keep their original length, so the caller drops the upper halves itself.
+/// Both tables come back bound: the lower half holds the bound values, and the
+/// upper half is dropped before returning.
 ///
 /// The message is the one a separate measuring pass over the bound tables returns.
 ///
@@ -438,20 +441,41 @@ where
 /// # Panics
 ///
 /// - The two tables must have the same length.
-/// - The length must be a multiple of four.
+/// - The length must be at least four and a multiple of four.
 ///   The bound table then keeps the variable the message sums over.
 pub fn fold_and_round_coefficients_prefix<A, Ch>(
-    evals: &mut [A],
-    weights: &mut [A],
+    evals: &mut Poly<A>,
+    weights: &mut Poly<A>,
     r: Ch,
 ) -> RoundMessage<A>
 where
     A: Algebra<Ch> + Copy + Send + Sync,
     Ch: Copy + Send + Sync,
 {
+    let message = bind_and_measure(evals.as_mut_slice(), weights.as_mut_slice(), r);
+
+    // The bound values sit in the lower half of each table.
+    evals.truncate_to_half();
+    weights.truncate_to_half();
+
+    message
+}
+
+/// The pass behind the binding above, over the raw tables.
+///
+/// The lower half of each table is left holding the bound values.
+/// Dropping the upper half is the caller's, so the half-done state stays private.
+fn bind_and_measure<A, Ch>(evals: &mut [A], weights: &mut [A], r: Ch) -> RoundMessage<A>
+where
+    A: Algebra<Ch> + Copy + Send + Sync,
+    Ch: Copy + Send + Sync,
+{
     // Precondition: paired tables, with a variable left over for the message.
+    //
+    // Zero is a multiple of four, so an empty pair would otherwise pass here and
+    // return a zero message instead of panicking.
     assert_eq!(evals.len(), weights.len());
-    assert!(evals.len().is_multiple_of(4));
+    assert!(evals.len() >= 4 && evals.len().is_multiple_of(4));
     let evals_len = evals.len();
 
     // Cut each table into the four quadrants of the two variables this pass touches.
@@ -1278,18 +1302,14 @@ mod tests {
                 want_weights.as_slice(),
             );
 
-            // Fused arm: one pass writes the bound tables into the lower halves.
+            // Fused arm: one pass binds both tables and measures the bound pair.
             let mut got_evals = Poly::new(evals);
             let mut got_weights = Poly::new(weights);
             let got = super::fold_and_round_coefficients_prefix(
-                got_evals.as_mut_slice(),
-                got_weights.as_mut_slice(),
+                &mut got_evals,
+                &mut got_weights,
                 r,
             );
-
-            // The fused pass leaves the upper halves in place, so drop them here.
-            got_evals.truncate_to_half();
-            got_weights.truncate_to_half();
 
             // The bound tables must agree entry for entry.
             prop_assert_eq!(got_evals.as_slice(), want_evals.as_slice());
@@ -1299,6 +1319,38 @@ mod tests {
             prop_assert_eq!(got.c_a, want.c_a);
             prop_assert_eq!(got.c_inf, want.c_inf);
         }
+    }
+
+    #[test]
+    fn a_fused_block_is_a_whole_number_of_tiles() {
+        // Invariant: a block never ends mid-tile.
+        //
+        // The measurement splits a block into K-wide tiles and sends the remainder
+        // down the eager per-pair path.
+        // A block remainder would be paid once per block instead of once per table.
+        //
+        // Fixture state: element widths that do and do not divide the byte budget.
+        //
+        //     1 B   -> budget / 1  is already a multiple of K
+        //     320 B -> budget / 320 = 12, which is not
+        //     192 B -> budget / 192 = 21, which is not
+        //     8192B -> budget / 8192 = 0, so the tile width is the floor
+        assert!(super::fused_block::<u8>().is_multiple_of(super::K));
+        assert!(super::fused_block::<[u8; 320]>().is_multiple_of(super::K));
+        assert!(super::fused_block::<[u8; 192]>().is_multiple_of(super::K));
+        assert_eq!(super::fused_block::<[u8; 8192]>(), super::K);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion failed")]
+    fn binding_rejects_a_pair_with_nothing_left_to_measure() {
+        // Invariant: a pair too short to leave a variable is rejected, not measured.
+        //
+        // Two entries bind down to one, and a one-entry table has nothing to sum over.
+        // Producing no tiles and reporting a zero message would look like a real round.
+        let mut evals = Poly::new(vec![EF::ONE; 2]);
+        let mut weights = Poly::new(vec![EF::ONE; 2]);
+        let _ = super::fold_and_round_coefficients_prefix(&mut evals, &mut weights, EF::ONE);
     }
 
     #[test]


### PR DESCRIPTION
A sumcheck round makes two full passes over its two tables. This makes one.

No transcript change: the round messages, the challenges and the bound tables come
out bit-identical to what the round-at-a-time driver produces, and a test pins that.

## The problem

`SumcheckProver::compute_sumcheck_polynomials` drives its rounds one at a time:

```
measure   read evals, read weights                    -> (h(0), h(inf))
           ... transcript, challenge r ...
bind      read evals, read weights, write both halves
```

The binding writes the bound halves out, and the very next round's measurement reads
them straight back. At `num_variables = 20` over `BinomialExtensionField<BabyBear, 4>`
each table is 16 MiB, so nothing survives in cache between the two passes — the round
pays a memory round trip for data it had in registers one instruction earlier.

## The idea

Hold the challenge back one round, and bind inside the next round's measuring pass.

A fused pass touches two variables at once: `X`, bound now to the previous round's
challenge, and `Y`, the one the message it returns sums over. Together they cut each
table into four quadrants:

```
    X = 0, Y = 0 : q0        X = 1, Y = 0 : q2
    X = 0, Y = 1 : q1        X = 1, Y = 1 : q3
```

Binding `X = r` leaves the two faces of `Y`:

```
    lo = q0 + (q2 - q0) * r        (written back over q0)
    hi = q1 + (q3 - q1) * r        (written back over q1)
```

and those two faces are exactly what the round message needs:

```
    h(0)   = sum  w_lo * e_lo
    h(inf) = sum (w_hi - w_lo) * (e_hi - e_lo)
```

So the pass writes the bound table and measures it before the values leave L1. The
work goes a block at a time — four bound faces sized to stay resident — with the
existing `K`-tiled delayed-reduction dot products doing the measuring, unchanged.

The driver then looks like this:

```
round i:  bind r_{i-1}  +  measure h_i      (one pass)
after:    bind r_{k-1}                      (one pass)
```

Only the first measurement and the last binding are still stand-alone.

## Per table, over a whole `k`-round fold

Counting element accesses in units of the initial table length `N = 2^k`:

- **before:** `4N` reads + `N` writes
- **after:** `3N` reads + `N` writes

One read of every bound entry is gone. Multiply count is unchanged.

## Benchmark

`sumcheck/babybear/prover/plain_prefix`, `RUSTFLAGS=-Ctarget-cpu=native` (AVX-512),
40 samples, base and branch alternated in one process against the same criterion
baseline. `plain_suffix` is the control arm — it takes the fallback path and does not
move (`p = 0.69` and `p = 0.60` at `k16` / `k20`).

**32 threads, `--features parallel`:**

| variables | before | after | speedup |
|---|---|---|---|
| 12 | 23.98 µs | 19.40 µs | 1.24x |
| 16 | 412.7 µs | 215.2 µs | 1.92x |
| 20 | 5.85 ms | 3.41 ms | 1.72x |

**Single core, no `parallel` feature:**

| variables | before | after | speedup |
|---|---|---|---|
| 12 | 25.34 µs | 19.77 µs | 1.28x |
| 16 | 289.0 µs | 247.1 µs | 1.17x |
| 20 | 5.78 ms | 5.87 ms | 1.00x (`p = 0.99`) |

Reading the two together, because they say different things:

- **On one core the fusion pays where the tables fit in cache** and is neutral at 20
  variables, where a single core cannot saturate memory anyway and the pass is
  compute-bound. Same multiplies, fewer bytes, so this is the floor.
- **The larger parallel win at 16 and 20 variables is the round entering the thread
  pool once instead of twice**, and the fused pass parallelising the whole round
  rather than only its binding half. Under the current thresholds the baseline's
  measuring pass goes serial from round 1 at `k = 20` while its binding stays
  parallel; the fused pass keeps both together.

That second half of the win overlaps with any future work on rayon task sizing, and
would shrink if the thresholds were retuned. The first half would not.

A second alternated pair, run under heavy external load, reproduces the direction
(1.31x / 2.01x / 2.08x); its baseline arm is too noisy to quote, but the branch arm
lands within 0.5% of the table above at every size, which is itself the point — one
dispatch per round instead of two also makes the round much less load-sensitive.

## Scope

- **new:** `fold_and_round_coefficients_prefix` in `p3-sumcheck::strategy`, with the
  `bind_face` / `round_coefficients_faces` pieces it is built from, and
  `Poly::truncate_to_half` in `p3-multilinear-util`.
- **changed:** `SumcheckProver::compute_sumcheck_polynomials` defers its bindings;
  `ProductPolynomial::fold_round_coefficients` dispatches to the fused kernel.
- **untouched:** `ProductPolynomial::round`, which stays the reference the new driver
  is pinned against, and every kernel it calls.

Two states fall back to binding and measuring separately:

- **suffix binding**, whose bound entries are adjacent pairs rather than half-apart
  faces, so an in-place write would race its own reads;
- **fewer than four table entries**, where the bound half has no variable left for the
  message to sum over. That is also where the packed-to-scalar transition happens, so
  the fallback keeps the handoff exactly as it was.

## Prior art

This is `MleStore::map_reduce_with_fold` from binius64, ported to the shape
`ProductPolynomial` already has. Their measurement of the same change — a fused round
at 17.5 ms against 24.0 ms for the naive read-`2N`-write-`N` triad, both at ~46 GB/s
against a 47.4 GB/s streaming ceiling — is the reason to expect a bandwidth win rather
than an arithmetic one, and the serial-versus-parallel split above is that expectation
holding.

## Test plan

- [x] `prop_fold_and_round_coefficients_prefix_matches_bind_then_measure`: over
      `2..=16` variables, the fused pass produces the same bound tables *and* the same
      message as `fix_prefix_var_mut` followed by `sumcheck_coefficients_prefix`. The
      range straddles the `K`-tiled body and the par-vs-serial split.
- [x] `deferred_binding_drives_the_same_rounds_as_round_at_a_time`: the driver's
      recorded round messages, challenges, claim and both bound tables match a
      round-at-a-time drive, for both binding orders, across the packed path, the
      unpacking transition and the final scalar rounds.
- [x] `cargo test -p p3-sumcheck -p p3-multilinear-util`, with and without
      `--features parallel` — 285 + 148 tests.
- [x] `cargo test -p p3-whir -p p3-stir` — the WHIR PCS prover drives this loop.
- [x] `cargo clippy -p p3-sumcheck -p p3-multilinear-util --all-targets --features parallel`.
- [x] `cargo +nightly fmt --all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
