### PR TITLE
perf(sumcheck): bind and measure in one pass in the hiding driver

### DIFF
--- a/sumcheck/benches/sumcheck.rs
+++ b/sumcheck/benches/sumcheck.rs
@@ -20,11 +20,14 @@ use std::hint::black_box;
 use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{DuplexChallenger, FieldChallenger, GrindingChallenger};
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DFTSmallBatch;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{
     Algebra, ExtensionField, Field, PackedValue, PrimeCharacteristicRing, TwoAdicField,
 };
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
+use p3_merkle_tree::MerkleTreeMmcs;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::constraints::statement::{EqStatement, SelectStatement};
@@ -35,7 +38,10 @@ use p3_sumcheck::strategy::{
     RoundMessage, SumcheckProver, VariableOrder, sumcheck_coefficients_prefix,
     sumcheck_coefficients_prefix_projective, sumcheck_coefficients_suffix,
 };
+use p3_sumcheck::zk::ZkSumcheckData;
 use p3_sumcheck::{OpeningBatch, SumcheckData};
+use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+use p3_zk_codes::reed_solomon::ReedSolomonZkEncoding;
 use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
@@ -681,6 +687,104 @@ where
     black_box((data, residual, randomness));
 }
 
+/// Variable count for the hiding residual driver.
+///
+/// Matches the largest plain-prover case, so the two curves are read side by side.
+const ZK_RESIDUAL_SIZE: usize = 20;
+
+/// Message length of the mask code.
+///
+/// Section 2.7 of eprint 2026/391 sizes masks at `O(lambda / log log lambda)`.
+/// Sixteen is the value the hiding WHIR benches use, so the mask cost is realistic.
+const ZK_ELL: usize = 16;
+
+/// Randomness symbols appended to each mask before encoding.
+const ZK_T: usize = 2;
+
+/// Benches the hiding residual driver folding one batch of rounds.
+///
+/// The hiding prover reaches this driver once per WHIR round.
+/// Its plain counterpart is the multi-round driver benched above.
+fn bench_zk_residual(c: &mut Criterion) {
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type Hash = PaddingFreeSponge<Perm, 16, 8, 8>;
+    type Compress = TruncatedPermutation<Perm, 2, 8, 16>;
+    type BaseMmcs =
+        MerkleTreeMmcs<<F as Field>::Packing, <F as Field>::Packing, Hash, Compress, 2, 8>;
+    type Mmcs = ExtensionMmcs<F, EF, BaseMmcs>;
+    type Dft = Radix2DFTSmallBatch<EF>;
+    type Enc = ReedSolomonZkEncoding<EF, Dft>;
+    type Challenger = DuplexChallenger<F, Perm, 16, 8>;
+
+    let mut group = c.benchmark_group("sumcheck/babybear/zk_residual");
+
+    // The hiding path commits a mask oracle per batch, so keep the sample count low.
+    group.sample_size(10);
+
+    let mut rng = rng_for(0x000D, ZK_RESIDUAL_SIZE);
+    let perm = Perm::new_from_rng_128(&mut SmallRng::seed_from_u64(42));
+
+    // Mask commitment scheme and code, sized as the hiding WHIR prover sizes them.
+    let mmcs = Mmcs::new(BaseMmcs::new(
+        Hash::new(perm.clone()),
+        Compress::new(perm.clone()),
+        0,
+    ));
+    let encoding = Enc::new(
+        ZK_T,
+        ZK_ELL,
+        (ZK_ELL + ZK_T).next_power_of_two(),
+        Dft::default(),
+    );
+
+    // The pair the driver folds, with the claim it starts from.
+    let evals = Poly::<EF>::rand(&mut rng, ZK_RESIDUAL_SIZE);
+    let weights = Poly::<EF>::rand(&mut rng, ZK_RESIDUAL_SIZE);
+    let poly = ProductPolynomial::<F, EF>::new_packed(
+        VariableOrder::Prefix,
+        evals.pack::<F, EF>(),
+        weights.pack::<F, EF>(),
+    );
+    let sum = poly.dot_product();
+
+    group.throughput(Throughput::Elements(1 << ZK_RESIDUAL_SIZE));
+    group.bench_function(
+        BenchmarkId::from_parameter(format!("k{ZK_RESIDUAL_SIZE}")),
+        |b| {
+            b.iter_batched(
+                // Setup (untimed): the driver consumes the prover and the transcript.
+                || {
+                    (
+                        SumcheckProver::new(poly.clone(), sum),
+                        Challenger::new(perm.clone()),
+                        SmallRng::seed_from_u64(7),
+                    )
+                },
+                // Routine (timed): one batch of rounds, grinding disabled.
+                |(prover, mut challenger, mut mask_rng)| {
+                    let mut data = ZkSumcheckData::<F, EF>::default();
+                    let handoff = prover.into_zk_sumcheck(
+                        &mut data,
+                        &encoding,
+                        &mmcs,
+                        FOLDING,
+                        0,
+                        EF::ZERO,
+                        &mut challenger,
+                        &mut mask_rng,
+                    );
+                    black_box((data, handoff));
+                },
+                BatchSize::LargeInput,
+            );
+        },
+    );
+
+    group.finish();
+}
+
 /// Coefficient kernel for every field.
 fn round_coefficients(c: &mut Criterion) {
     bench_round_coefficients::<BabyBear4>(c);
@@ -732,5 +836,6 @@ criterion_group!(
     prover,
     combine,
     layout,
+    bench_zk_residual,
 );
 criterion_main!(benches);

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -905,17 +905,45 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
         self.poly.eval(point)
     }
 
-    /// Computes the current round's plain quadratic coefficients without
-    /// touching the transcript or folding the polynomial.
-    pub(crate) fn round_coefficients(&self) -> (EF, EF) {
-        self.poly.round_coefficients()
+    /// Measures the current round, first applying a binding held back from the last one.
+    ///
+    /// A held-back binding is absorbed into the measuring pass.
+    /// The round then reads its tables once instead of twice.
+    ///
+    /// The slot is cleared here.
+    /// The caller puts this round's own challenge back into it.
+    pub(crate) fn measure_round(&mut self, pending: &mut Option<EF>) -> (EF, EF) {
+        match pending.take() {
+            // A challenge is waiting, so bind and measure in one pass.
+            Some(r) => self.poly.fold_round_coefficients(r),
+            // Nothing waiting, so this is a plain measuring pass.
+            None => self.poly.round_coefficients(),
+        }
     }
 
-    /// Folds the residual product polynomial by one challenge and updates the
-    /// claimed sum with the same quadratic extrapolation as the plain path.
-    pub(crate) fn fold_round_with_coefficients(&mut self, c0: EF, c_inf: EF, gamma: EF) {
+    /// Applies a binding that no measuring pass absorbed.
+    ///
+    /// The last round of a batch has no successor to fuse with.
+    /// Any later reader of the tables must still see them bound.
+    pub(crate) fn bind_pending(&mut self, pending: Option<EF>) {
+        if let Some(r) = pending {
+            self.poly.fold_round(r);
+        }
+    }
+
+    /// Advances the running claim to the round polynomial at the challenge.
+    ///
+    /// This is the quadratic extrapolation through 0, 1 and infinity the verifier applies.
+    /// The binding itself is left to the caller.
+    pub(crate) fn reduce_claim_with_coefficients(&mut self, c0: EF, c_inf: EF, gamma: EF) {
         self.sum = extrapolate_01inf(c0, self.sum - c0, c_inf, gamma);
-        self.poly.fold_round(gamma);
+    }
+
+    /// Asserts that the claim is the inner product of the bound pair.
+    ///
+    /// Only meaningful once every binding has been applied.
+    /// A driver that holds bindings back therefore calls this at the end, not per round.
+    pub(crate) fn debug_assert_claim(&self) {
         debug_assert_eq!(self.sum, self.poly.dot_product());
     }
 
@@ -988,10 +1016,7 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
 
         for _ in 0..folding_factor {
             // Measure this round, absorbing whatever binding the last one left behind.
-            let (c_a, c_inf) = match pending {
-                Some(r) => self.poly.fold_round_coefficients(r),
-                None => self.poly.round_coefficients(),
-            };
+            let (c_a, c_inf) = self.measure_round(&mut pending);
 
             // Commit to the transcript, do the optional grinding, take the challenge.
             let r = sumcheck_data.observe_and_sample(challenger, c_a, c_inf, pow_bits);
@@ -1006,12 +1031,10 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
         }
 
         // The last challenge has no successor to fuse with, so it binds on its own.
-        if let Some(r) = pending {
-            self.poly.fold_round(r);
-        }
+        self.bind_pending(pending);
 
         // Invariant: the claim is the inner product of the bound pair.
-        debug_assert_eq!(self.sum, self.poly.dot_product());
+        self.debug_assert_claim();
 
         Point::new(challenges)
     }

--- a/sumcheck/src/strategy.rs
+++ b/sumcheck/src/strategy.rs
@@ -925,8 +925,10 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
     ///
     /// The last round of a batch has no successor to fuse with.
     /// Any later reader of the tables must still see them bound.
-    pub(crate) fn bind_pending(&mut self, pending: Option<EF>) {
-        if let Some(r) = pending {
+    ///
+    /// The slot is cleared, so a second call binds nothing.
+    pub(crate) fn bind_pending(&mut self, pending: &mut Option<EF>) {
+        if let Some(r) = pending.take() {
             self.poly.fold_round(r);
         }
     }
@@ -1031,7 +1033,7 @@ impl<F: Field, EF: ExtensionField<F>> SumcheckProver<F, EF> {
         }
 
         // The last challenge has no successor to fuse with, so it binds on its own.
-        self.bind_pending(pending);
+        self.bind_pending(&mut pending);
 
         // Invariant: the claim is the inner product of the bound pair.
         self.debug_assert_claim();

--- a/sumcheck/src/zk/prover/residual.rs
+++ b/sumcheck/src/zk/prover/residual.rs
@@ -118,13 +118,22 @@ where
         let half = EF::TWO.inverse();
         let mut aux_carry = aux_claim;
 
+        // A challenge is not applied on the spot.
+        // It is handed to the next round, which binds and measures in one pass.
+        //
+        // Everything the loop does between the two is scalar work.
+        // Assembling the round polynomial, the transcript, the grinding and the mask
+        // evaluation never read the tables.
+        let mut pending: Option<EF> = None;
+
         for (round_idx, mask) in masks.iter().enumerate() {
             let j = round_idx + 1;
             let mask_endpoints = mask[0].double() + mask[1..].iter().copied().sum::<EF>();
             sum_future_endpoints -= mask_endpoints;
             aux_carry *= half;
 
-            let (plain_c0, plain_c_inf) = self.round_coefficients();
+            // Measure this round, absorbing whatever binding the last one left behind.
+            let (plain_c0, plain_c_inf) = self.measure_round(&mut pending);
             // The aux carry enters only the transmitted constant slot; the
             // source-side fold below keeps the raw coefficients.
             let h = round_ctx.assemble(
@@ -151,9 +160,19 @@ where
             let mask_at_gamma = mask.iter().copied().horner(gamma);
             mask_evals_at_gamma.push(mask_at_gamma);
 
-            self.fold_round_with_coefficients(plain_c0, plain_c_inf, gamma);
+            // Advance the claim now; the binding waits for the next round's pass.
+            self.reduce_claim_with_coefficients(plain_c0, plain_c_inf, gamma);
+            pending = Some(gamma);
+
             rs.push(gamma);
         }
+
+        // The last challenge has no successor to fuse with.
+        // The weight scaling below reads the tables, so it binds here.
+        self.bind_pending(pending);
+
+        // Invariant: the claim is the inner product of the bound pair.
+        self.debug_assert_claim();
 
         self.scale_weights_and_claim(eps);
 

--- a/sumcheck/src/zk/prover/residual.rs
+++ b/sumcheck/src/zk/prover/residual.rs
@@ -169,7 +169,7 @@ where
 
         // The last challenge has no successor to fuse with.
         // The weight scaling below reads the tables, so it binds here.
-        self.bind_pending(pending);
+        self.bind_pending(&mut pending);
 
         // Invariant: the claim is the inner product of the bound pair.
         self.debug_assert_claim();
@@ -189,14 +189,15 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloc::vec;
     use alloc::vec::Vec;
+    use alloc::{format, vec};
 
     use p3_baby_bear::BabyBear;
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::{PrimeCharacteristicRing, dot_product};
+    use p3_field::{Field, PackedValue, PrimeCharacteristicRing, dot_product};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_multilinear_util::poly::Poly;
+    use p3_util::log2_strict_usize;
     use p3_zk_codes::{ZkEncoding, ZkEncodingWithRandomness};
     use rand::rngs::SmallRng;
     use rand::{Rng, SeedableRng};
@@ -319,6 +320,101 @@ mod tests {
             verifier_handoff.claimed_residual,
             prover_handoff.residual_prover.claimed_sum() + final_mask_residual,
         );
+    }
+
+    #[test]
+    fn deferred_binding_drives_the_same_hiding_rounds_as_binding_on_the_spot() {
+        // Invariant: holding a binding back a round changes nothing this driver produces.
+        //
+        // Fixture state: five shapes, both binding orders, a non-zero auxiliary claim.
+        //
+        //     (2, 1)   one round, so the fused branch is never taken
+        //     (4, 4)   every variable bound, the terminal case
+        //     (9, 3)   packed storage, then the unpacking handoff
+        //     (9, 9)   packed storage bound all the way down
+        //     (15, 3)  large enough to reach the threaded branch of the fused pass
+        let log_width = log2_strict_usize(<F as Field>::Packing::WIDTH);
+
+        for (n_vars, folding_factor) in [(2usize, 1usize), (4, 4), (9, 3), (9, 9), (15, 3)] {
+            for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
+                let mut rng = SmallRng::seed_from_u64(0x5EED + n_vars as u64);
+                let evals = Poly::<EF>::rand(&mut rng, n_vars);
+                let weights = Poly::<EF>::rand(&mut rng, n_vars);
+                let claimed_sum = dot_product::<EF, _, _>(
+                    evals.as_slice().iter().copied(),
+                    weights.as_slice().iter().copied(),
+                );
+
+                // A pair below one SIMD lane group has nothing to pack.
+                let build = || {
+                    if n_vars >= log_width {
+                        ProductPolynomial::<F, EF>::new_packed(
+                            order,
+                            evals.pack::<F, EF>(),
+                            weights.pack::<F, EF>(),
+                        )
+                    } else {
+                        ProductPolynomial::<F, EF>::new_unpacked(
+                            order,
+                            evals.clone(),
+                            weights.clone(),
+                        )
+                    }
+                };
+
+                // The auxiliary claim rides the transmitted constant slot only.
+                // A non-zero one would show up here if it ever reached the binding.
+                let aux_claim = EF::from_u64(7);
+
+                let ell_zk = 4;
+                let (perm, mmcs, encoding) = make_setup(31, ell_zk);
+                let mut challenger = MyChallenger::new(perm);
+                let mut mask_rng = SmallRng::seed_from_u64(37);
+                let mut zk_data = ZkSumcheckData::<F, EF>::default();
+
+                // Arm under test: the driver, which holds each binding back a round.
+                let handoff = SumcheckProver::new(build(), claimed_sum).into_zk_sumcheck(
+                    &mut zk_data,
+                    &encoding,
+                    &mmcs,
+                    folding_factor,
+                    0,
+                    aux_claim,
+                    &mut challenger,
+                    &mut mask_rng,
+                );
+
+                // Reference arm: replay the same challenges, binding each on the spot.
+                let mut reference = SumcheckProver::new(build(), claimed_sum);
+                for &gamma in handoff.randomness.iter() {
+                    let (c0, c_inf) = reference.measure_round(&mut None);
+                    reference.reduce_claim_with_coefficients(c0, c_inf, gamma);
+                    reference.bind_pending(&mut Some(gamma));
+                }
+                reference.scale_weights_and_claim(handoff.eps);
+
+                let shape = format!("{order:?}, {n_vars} variables, {folding_factor} rounds");
+
+                // The claim chains every round message, so a drift in any of them shows here.
+                assert_eq!(
+                    handoff.residual_prover.claimed_sum(),
+                    reference.claimed_sum(),
+                    "{shape}"
+                );
+
+                // Both bound tables, entry for entry.
+                assert_eq!(
+                    handoff.residual_prover.evals().as_slice(),
+                    reference.evals().as_slice(),
+                    "{shape}"
+                );
+                assert_eq!(
+                    handoff.residual_prover.weights().as_slice(),
+                    reference.weights().as_slice(),
+                    "{shape}"
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Follows #2036, now merged, and rebased onto it.

#2036 fuses the binding into the next round's measuring pass in the plain sumcheck
driver. The hiding residual driver runs the same round loop and did not get it.
This gives it the same treatment.

No transcript change: the round polynomials, the challenges and the bound tables are
unchanged.

## The problem

The hiding residual driver measures, samples, then binds:

```
measure   read evals, read weights                    -> (c0, c_inf)
           ... assemble h_j, transcript, grind, gamma ...
bind      read evals, read weights, write both halves
```

Two passes over the same two tables, the second reading back what the first wrote.
That is exactly the shape #2036 removed from the plain driver, on the same
`ProductPolynomial` and the same kernel.

## The change

Hold the challenge back one round, so the binding rides into the next round's
measuring pass:

```
round j:  bind gamma_{j-1}  +  measure round j      (one pass)
after:    bind gamma_{k-1}                          (one pass)
```

Nothing the loop does between the measurement and the binding touches the tables.
Assembling the round polynomial, absorbing it, grinding, sampling and evaluating the
mask at the challenge are all scalar work.

The last challenge has no successor to fuse with, and the weight scaling after the
loop reads the tables, so it binds there.

## One shape instead of two

Both drivers now go through the same three helpers rather than hand-rolling the
claim-and-bind step twice:

- measure the round, absorbing whatever binding the last one left behind;
- advance the claim through the round identity, leaving the binding pending;
- apply a binding that no measuring pass absorbed.

The plain driver switches to them in this commit too, so the deferral is written once.

## Benchmark

`sumcheck/benches/sumcheck.rs` gains a `zk_residual` arm driving this driver directly
at `n = 20`, `k = 4`, with the mask code and Merkle commitment sized as the hiding
WHIR prover sizes them.

A/B by swapping only the deferral in the driver, two alternated pairs in one process,
`-Ctarget-cpu=native`, `--features parallel`, 32 threads:

| | bind on the spot | deferred | speedup |
|---|---|---|---|
| pair 1 | 5.49 ms | 3.83 ms | 1.43x |
| pair 2 | 5.57 ms | 3.71 ms | 1.50x |

Both `p < 0.05`. The figure sits below the plain driver's 1.7x because the timed
region also commits the mask oracle, which the fusion does not touch.

Two notes on why the pre-existing benches were not used:

- `whir/benches/sumcheck.rs`'s `zk_prefix` / `zk_suffix` arms drive the accumulator
  loop of the hiding prover, not this driver.
- `whir/benches/zk_overhead.rs`'s tighter `whir_zk_open_no_pow` group panics at setup
  on `main` (`RandomnessExceedsSlack { round: 1, randomness: 256, slack: 240 }` at
  `n = 20`). That is a pre-existing failure, unrelated to this change, and worth its
  own issue.

## Scope

- **changed:** the hiding residual driver defers its bindings; the claim reduction and
  the binding become separate steps.
- **new:** four crate-private helpers on the prover, shared by both drivers; a
  differential test for this driver; a criterion arm that drives it directly.
- **removed:** a thin wrapper that no longer had a caller.
- **untouched:** the accumulator loop of the hiding prover, which drives its rounds
  off precomputed accumulators and never passes over the tables.

## Test plan

- [x] `deferred_binding_drives_the_same_hiding_rounds_as_binding_on_the_spot`: the
      driver's bound tables and claim match a bind-on-the-spot replay of the same
      challenges, over five shapes and both binding orders, with a non-zero auxiliary
      claim. Mutation-checked: dropping the final binding fails it under `--release`,
      where the debug assertion is gone.
- [x] `cargo test -p p3-sumcheck --features parallel` under `+avx2`, `+avx512f` and no
      target features — 286 tests each. The hiding verifier and simulator suites
      replay the whole transcript, so a drift in any round polynomial fails them.
- [x] `cargo test -p p3-whir` — proves and verifies through the hiding PCS.
- [x] `cargo clippy -p p3-sumcheck --all-targets --features parallel`.
- [x] `cargo +nightly fmt --all -- --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
