### PR TITLE
refactor(stir): share the commitment absorption between challenger backends

### DIFF
--- a/examples/examples/prove_prime_field_31.rs
+++ b/examples/examples/prove_prime_field_31.rs
@@ -324,6 +324,14 @@ fn main() {
             };
         }
         FieldOptions::Mersenne31 => {
+            // Mersenne31 has no two-adic subgroup, so it proves through the circle STARK.
+            // Reject the combination before any setup work rather than after it.
+            assert!(
+                args.pcs != PcsOptions::Stir,
+                "--pcs stir needs a two-adic field; Mersenne31 proves through the circle STARK. \
+                 Drop --pcs, or pick koala-bear or baby-bear."
+            );
+
             type EF = QM31;
 
             let proof_goal = match args.objective {
@@ -382,12 +390,6 @@ fn main() {
                     "Currently there are no available DFT options when using Mersenne31. Please remove the --discrete_fourier_transform flag."
                 ),
             };
-
-            if args.pcs == PcsOptions::Stir {
-                panic!(
-                    "STIR is only wired into the two-adic (KoalaBear/BabyBear) pipeline. Mersenne31 uses the circle STARK with FRI; remove --pcs or pick a two-adic field."
-                );
-            }
 
             match args.merkle_hash {
                 MerkleHashOptions::KeccakF => {

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -439,16 +439,18 @@ where
     );
 }
 
-/// Report the security level STIR's low-degree test was configured to target.
+/// Report the security level the low-degree test was configured to target.
 ///
-/// This is a PCS/LDT-level target, not the end-to-end STARK figure `report_parameter_security`
-/// prints for FRI: it excludes the DEEP-ALI, batching, and collision-resistance terms that
-/// figure folds in, so the two numbers are not directly comparable. Unlike FRI's `num_queries`,
-/// which the caller chooses and whose achieved security level is only knowable after the fact,
-/// every STIR round's query count and grinding difficulty is derived up front from
-/// `security_level`/`max_pow_bits`, so there is nothing left to measure about the low-degree
-/// test once the config exists — but there is no STIR counterpart here to the STARK-level
-/// figure `report_parameter_security` computes for FRI.
+/// This is a commitment-scheme-level target, not the end-to-end figure the FRI path prints.
+/// It excludes the DEEP-ALI, batching, and collision-resistance terms that figure folds in.
+/// The two numbers are therefore not comparable.
+///
+/// The FRI path has a query count the caller picks, whose level is known after the fact.
+/// Here every round's query count and grinding difficulty is derived from the target up front.
+/// Nothing about the low-degree test is left to measure once the config exists.
+///
+/// What is missing is the whole-proof figure, which needs a proximity regime the STARK-level
+/// accounting can consume.
 #[inline]
 pub fn report_stir_security_level(security_level: usize, max_pow_bits: usize) {
     println!(

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -36,6 +36,7 @@ p3-baby-bear = { path = "../baby-bear" }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
 p3-goldilocks = { path = "../goldilocks" }
+p3-keccak = { path = "../keccak" }
 p3-koala-bear = { path = "../koala-bear" }
 p3-merkle-tree = { path = "../merkle-tree" }
 p3-uni-stark = { path = "../uni-stark" }

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -190,15 +190,32 @@ impl<C> Deref for StirCommitment<C> {
     }
 }
 
-/// `StirCommitment<C>`'s `CanObserve` impl is written once per challenger backend rather than
-/// as a single generic impl: a blanket `impl<Ch: CanObserve<F> + CanObserve<C>, F, C>
-/// CanObserve<StirCommitment<C>> for Ch` would leave `F` unconstrained by `Ch`, which Rust
-/// rejects. Each impl below observes the group count as a length prefix (so a challenger
-/// cannot confuse two commitments with different group counts), then each root, in the same
-/// order every backend uses.
+/// Absorbs a commitment's group count, then each of its roots.
 ///
-/// `SerializingChallenger64` has the identical gap (no impl here) — left out under YAGNI, since
-/// nothing in this crate or its dependents currently pairs `TwoAdicStirPcs` with it.
+/// The count goes in first, as one fixed-width field element.
+/// Two commitments with different group counts therefore cannot produce the same transcript.
+/// Absorbing three roots as one commitment also stays distinct from absorbing them as two.
+///
+/// Every challenger backend routes here rather than writing the sequence out again.
+/// A backend that absorbed a commitment differently would not fail a test: prover and verifier
+/// share one challenger type, so both would be wrong together.
+fn observe_stir_commitment<Ch, F, C>(challenger: &mut Ch, commitment: StirCommitment<C>)
+where
+    Ch: CanObserve<F> + CanObserve<C>,
+    F: PrimeCharacteristicRing,
+{
+    challenger.observe(F::from_usize(commitment.0.len()));
+    for root in commitment.0 {
+        challenger.observe(root);
+    }
+}
+
+// The shared body above is a free function rather than a blanket impl.
+// A blanket impl would leave the field type constrained only by the where clause, which Rust
+// rejects as an unconstrained parameter, so each backend needs its own impl regardless.
+//
+// A backend with no impl here cannot be paired with this commitment scheme at all.
+// The 64-bit serializing challenger has none, since nothing pairs it with this scheme today.
 impl<F, P, C, const WIDTH: usize, const RATE: usize> CanObserve<StirCommitment<C>>
     for DuplexChallenger<F, P, WIDTH, RATE>
 where
@@ -207,10 +224,7 @@ where
     Self: CanObserve<C>,
 {
     fn observe(&mut self, commitment: StirCommitment<C>) {
-        <Self as CanObserve<F>>::observe(self, F::from_usize(commitment.0.len()));
-        for root in commitment.0 {
-            self.observe(root);
-        }
+        observe_stir_commitment::<_, F, _>(self, commitment);
     }
 }
 
@@ -221,10 +235,7 @@ where
     Self: CanObserve<C>,
 {
     fn observe(&mut self, commitment: StirCommitment<C>) {
-        <Self as CanObserve<F>>::observe(self, F::from_usize(commitment.0.len()));
-        for root in commitment.0 {
-            self.observe(root);
-        }
+        observe_stir_commitment::<_, F, _>(self, commitment);
     }
 }
 
@@ -1950,18 +1961,20 @@ fn compute_inverse_denominators<'a, F: TwoAdicField, EF: ExtensionField<F>>(
 
 #[cfg(test)]
 mod tests {
-    use alloc::format;
+    use alloc::{format, vec};
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-    use p3_challenger::DuplexChallenger;
+    use p3_challenger::{CanSampleBits, DuplexChallenger, HashChallenger};
     use p3_commit::ExtensionMmcs;
     use p3_dft::Radix2DitParallel;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_keccak::Keccak256Hash;
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_security::whir::SecurityAssumption;
-    use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
+    use p3_symmetric::{Hash, PaddingFreeSponge, TruncatedPermutation};
     use proptest::prelude::*;
+    use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
     use super::*;
@@ -1994,6 +2007,95 @@ mod tests {
         // soundness accounting is charged at.
         let ell: usize = coeffs.iter().map(|&(_, gap)| gap + 1).sum();
         assert_eq!(ell, 13);
+    }
+
+    // A digest that the serializing challenger can absorb byte by byte.
+    fn digest(byte: u8) -> Hash<BabyBear, u8, 32> {
+        Hash::from([byte; 32])
+    }
+
+    // The serializing backend, over the byte hasher the Keccak-Merkle configurations use.
+    fn byte_challenger() -> SerializingChallenger32<BabyBear, HashChallenger<u8, Keccak256Hash, 32>>
+    {
+        SerializingChallenger32::from_hasher(Vec::new(), Keccak256Hash {})
+    }
+
+    #[test]
+    fn the_group_count_separates_one_commitment_from_two() {
+        // Invariant: the group count is absorbed as a length prefix, so a commitment cannot
+        // be split or merged without changing the transcript.
+        //
+        //     one commitment : len=2 | root_a | root_b
+        //     two commitments: len=1 | root_a | len=1 | root_b
+        //
+        // Without the prefix both flatten to `root_a | root_b` and sample the same challenge.
+        let (root_a, root_b) = (digest(0xAA), digest(0xBB));
+
+        let mut merged = byte_challenger();
+        merged.observe(StirCommitment(vec![root_a, root_b]));
+
+        let mut split = byte_challenger();
+        split.observe(StirCommitment(vec![root_a]));
+        split.observe(StirCommitment(vec![root_b]));
+
+        assert_ne!(
+            merged.sample_bits(24),
+            split.sample_bits(24),
+            "the length prefix must separate these two absorptions"
+        );
+    }
+
+    #[test]
+    fn the_root_order_is_part_of_the_transcript() {
+        // Two commitments over the same roots in opposite order must not collide: the roots
+        // are absorbed in sequence, never as an order-insensitive set.
+        let (root_a, root_b) = (digest(0xAA), digest(0xBB));
+
+        let mut forward = byte_challenger();
+        forward.observe(StirCommitment(vec![root_a, root_b]));
+
+        let mut reversed = byte_challenger();
+        reversed.observe(StirCommitment(vec![root_b, root_a]));
+
+        assert_ne!(forward.sample_bits(24), reversed.sample_bits(24));
+    }
+
+    #[test]
+    fn every_backend_absorbs_a_commitment_the_same_way() {
+        // Invariant: a backend's impl is the shared sequence, never a hand-written variant.
+        //
+        //     observe(commitment)  ==  observe(len) then observe(each root)
+        //
+        // Checked per backend against the sequence spelled out by hand, since prover and
+        // verifier share one challenger type and would be wrong together if it drifted.
+        let roots = vec![digest(0x01), digest(0x02), digest(0x03)];
+
+        let mut via_commitment = byte_challenger();
+        via_commitment.observe(StirCommitment(roots.clone()));
+
+        let mut by_hand = byte_challenger();
+        by_hand.observe(BabyBear::from_usize(roots.len()));
+        for root in roots {
+            by_hand.observe(root);
+        }
+
+        assert_eq!(via_commitment.sample_bits(24), by_hand.sample_bits(24));
+
+        // The same obligation, for the duplex backend the Poseidon2 configurations use.
+        let perm = TestPerm::new_from_rng_128(&mut SmallRng::seed_from_u64(1));
+
+        let mut duplex_via_commitment = TestChallenger::new(perm.clone());
+        duplex_via_commitment.observe(StirCommitment(vec![BabyBear::ONE, BabyBear::TWO]));
+
+        let mut duplex_by_hand = TestChallenger::new(perm);
+        duplex_by_hand.observe(BabyBear::TWO);
+        duplex_by_hand.observe(BabyBear::ONE);
+        duplex_by_hand.observe(BabyBear::TWO);
+
+        assert_eq!(
+            duplex_via_commitment.sample_bits(24),
+            duplex_by_hand.sample_bits(24)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to the review on #2037. All minors from that review; the three larger items are named at the bottom and left alone.

**No transcript change.** The absorbed byte sequence is identical, and a test now pins that.

## One body instead of two

Both `CanObserve<StirCommitment<C>>` impls carried the same five-line body, hand-duplicated. They agreed — I diffed them — but nothing held them there, and a divergence would be silent in the worst possible way: prover and verifier share one challenger type, so a backend that absorbed a commitment differently would leave *both* sides consistently wrong rather than failing a test.

The body moves to a free function both impls call. The blanket impl the old comment reached for is genuinely impossible — the field type would be constrained only by the where clause, which Rust rejects as an unconstrained parameter — but that restriction applies to impls, not to functions, so a plain generic function is the whole fix:

```rust
fn observe_stir_commitment<Ch, F, C>(challenger: &mut Ch, commitment: StirCommitment<C>)
where
    Ch: CanObserve<F> + CanObserve<C>,
    F: PrimeCharacteristicRing,
{
    challenger.observe(F::from_usize(commitment.0.len()));
    for root in commitment.0 {
        challenger.observe(root);
    }
}
```

Each impl is now one line, and adding the 64-bit serializing backend later is a stanza rather than a third copy.

## Tests that reach the code they cover

Before this, `cargo test -p p3-stir` could not exercise the serializing backend's impl at all — `grep -rn SerializingChallenger32 stir/` returned the import and the impl, nothing else. Its only coverage was end-to-end, in `p3-examples`, a crate nobody editing `p3-stir` would think to run.

Three tests now cover the absorption. Each was verified to fail under the mutation it exists to catch:

| mutation | caught by |
|---|---|
| drop the length prefix | `the_group_count_separates_one_commitment_from_two` |
| reverse the root order | `every_backend_absorbs_a_commitment_the_same_way` |
| — | `the_root_order_is_part_of_the_transcript` survives a *global* reversal, as it should: it pins that order matters, not which order |

The first is the one that matters. Without the prefix, one commitment of two roots absorbs byte-for-byte identically to two commitments of one root each — the classic concatenation ambiguity. That was the property the old comment claimed and nothing checked.

## Docs

- The block above the impls was a `///` comment on an `impl` block, so rustdoc attached it to the `DuplexChallenger` impl while the text described that impl, the serializing one, and the absent third. It is now a plain comment, and the parts describing the absorbed sequence moved onto the function that performs it — where they are also checked by a test.
- That block and `report_stir_security_level` were both wrapped prose paragraphs with sentences running across `///` lines. Rewritten one sentence per line, per the repo's `/doc` conventions. Every fact kept; the security-reporting one carries four distinct claims that are much easier to find as four lines.

## CLI

`--pcs stir` on Mersenne31 was rejected *after* the AIR was built. The check moves to the top of that arm. Both paths verified by hand:

```
$ ... -f mersenne-31 --pcs stir
--pcs stir needs a two-adic field; Mersenne31 proves through the circle STARK.
Drop --pcs, or pick koala-bear or baby-bear.

$ ... -f koala-bear --pcs stir
STIR low-degree test configured to target 100 bits of conjectured security ...
Proof Verified Successfully
```

It is still an assertion rather than a clap-level usage error — expressing it declaratively across the three field arms was more contortion than it was worth — but the ordering is now right.

## Left for their own PRs

Named in the review, deliberately not swept in here:

1. **A benchmark-parameter constructor.** The six-field STIR parameter literal appears three times (`examples/src/proofs.rs` twice, `uni-stark/tests/stir_fibonacci.rs` once). The FRI path next to it calls `FriParameters::new_benchmark_high_arity`. A matching constructor would collapse all three — but that is new public API on `p3-stir`, so it is the author's call.
2. **A shared test module.** 168 of `stir_fibonacci.rs`'s 211 non-blank lines are verbatim from `fib_air.rs`. A `uni-stark/tests/common/mod.rs` would leave each file as its own PCS-specific part.
3. **A proximity regime the STARK accounting can consume.** `StarkSecurityParams::from_air` takes a concrete `FriRegime`, and `p3-stir` has no counterpart to `fri/src/config.rs`'s `security_regime()`. `p3-security` already has a `LowDegreeTest` trait that `FriRegime` implements, so implementing it for a STIR regime and generalizing `from_air` would let `--pcs stir` print the same two numbers `--pcs fri` does. That is what makes the flag actually comparable.

## Test plan

- [x] `cargo test -p p3-stir`: 60 lib tests.
- [x] `cargo test -p p3-uni-stark --test stir_fibonacci`: 5 passed, 1 ignored.
- [x] `cargo test -p p3-examples stir --release`: 2 passed.
- [x] Each new test verified to fail under its own mutation.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`, `cargo +nightly fmt --check`, `cargo machete --with-metadata`.
- [x] Both CLI paths run by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)