### PR TITLE
perf(binary-dft): incremental twiddles, tiled stages, and fused kernels

### DIFF
--- a/binary-dft/benches/ntt.rs
+++ b/binary-dft/benches/ntt.rs
@@ -100,5 +100,113 @@ fn bench_encode(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_ntt, bench_encode);
+/// Direct polynomial-backend workloads, including small later-round domains.
+fn bench_poly(c: &mut Criterion) {
+    eprintln!(
+        "binary-dft: parallel={}, threads={}, hardware_clmul={}",
+        cfg!(feature = "parallel"),
+        p3_maybe_rayon::prelude::current_num_threads(),
+        p3_binary_field::poly_basis::HAS_HARDWARE_CLMUL
+    );
+    let mut group = c.benchmark_group("poly");
+    group.sample_size(10);
+    let mut rng = SmallRng::seed_from_u64(7);
+    let ntt = PolyBasisNtt::default();
+    let encoder = AdditiveRsEncoder::<BinaryField128>::default();
+    let shift = BinaryField128::from_repr(1 << 127);
+    for log_height in [4, 8, 12, 16] {
+        for width in [1, 4, 16, 64] {
+            let mat = RowMajorMatrix::<BinaryField128>::rand(&mut rng, 1 << log_height, width);
+            let parameter = format!("h{log_height}/w{width}");
+            for op in ["forward", "inverse", "shifted"] {
+                group.bench_with_input(BenchmarkId::new(op, &parameter), &mat, |b, mat| {
+                    b.iter_batched(
+                        || mat.clone(),
+                        |m| match op {
+                            "forward" => ntt.ntt_batch(m),
+                            "inverse" => ntt.intt_batch(m),
+                            _ => ntt.shifted_ntt_batch(m, shift),
+                        },
+                        BatchSize::PerIteration,
+                    );
+                });
+            }
+            for added in [0, 1, 2, 3] {
+                group.bench_with_input(
+                    BenchmarkId::new(format!("lde/r{added}"), &parameter),
+                    &mat,
+                    |b, mat| {
+                        b.iter_batched(
+                            || mat.clone(),
+                            |m| ntt.shifted_lde_batch(m, added, shift),
+                            BatchSize::PerIteration,
+                        );
+                    },
+                );
+                group.bench_with_input(
+                    BenchmarkId::new(format!("encode/r{added}"), &parameter),
+                    &mat,
+                    |b, mat| {
+                        b.iter_batched(
+                            || mat.clone(),
+                            |m| encoder.encode_batch(m, added),
+                            BatchSize::PerIteration,
+                        );
+                    },
+                );
+            }
+        }
+    }
+    group.finish();
+}
+
+/// The production layout, encoder and Merkle commitment together.
+fn bench_commit(c: &mut Criterion) {
+    use p3_binary_field::BinaryChallenger;
+    use p3_challenger::HashChallenger;
+    use p3_keccak::Keccak256Hash;
+    use p3_merkle_tree::MerkleTreeMmcs;
+    use p3_multilinear_util::poly::Poly;
+    use p3_sumcheck::commit::commit_base;
+    use p3_sumcheck::strategy::VariableOrder;
+    use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
+
+    type Hash = SerializingHasher<Keccak256Hash>;
+    type Compress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
+    type Mmcs = MerkleTreeMmcs<BinaryField128, u8, Hash, Compress, 2, 32>;
+    type Challenger = BinaryChallenger<BinaryField128, HashChallenger<u8, Keccak256Hash, 32>>;
+    let mmcs = Mmcs::new(Hash::new(Keccak256Hash), Compress::new(Keccak256Hash), 0);
+    let encoder = AdditiveRsEncoder::<BinaryField128>::default();
+    let mut rng = SmallRng::seed_from_u64(11);
+    let mut group = c.benchmark_group("commit_base");
+    group.sample_size(10);
+    for log_height in [8, 12, 16] {
+        for folding in [0, 2, 4, 6] {
+            let matrix =
+                RowMajorMatrix::<BinaryField128>::rand(&mut rng, 1 << log_height, 1 << folding);
+            let poly = Poly::new(matrix.values);
+            for added in [1, 2, 3] {
+                for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
+                    let parameter = format!("{order:?}/h{log_height}/w{}/r{added}", 1 << folding);
+                    group.bench_function(parameter, |b| {
+                        b.iter(|| {
+                            commit_base(
+                                order,
+                                &encoder,
+                                &mmcs,
+                                &mut Challenger::from_hasher(Vec::new(), Keccak256Hash),
+                                &poly,
+                                folding,
+                                added,
+                            )
+                        });
+                    });
+                }
+            }
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(benches, bench_ntt, bench_encode, bench_poly, bench_commit);
 criterion_main!(benches);

--- a/binary-dft/benches/ntt.rs
+++ b/binary-dft/benches/ntt.rs
@@ -176,6 +176,17 @@ fn bench_commit(c: &mut Criterion) {
     type Mmcs = MerkleTreeMmcs<BinaryField128, u8, Hash, Compress, 2, 32>;
     type Challenger = BinaryChallenger<BinaryField128, HashChallenger<u8, Keccak256Hash, 32>>;
     let mmcs = Mmcs::new(Hash::new(Keccak256Hash), Compress::new(Keccak256Hash), 0);
+    // Retain the previous padded full transform as an allocation-matched comparison.
+    struct FullPaddedEncoder;
+    impl Encoder<BinaryField128> for FullPaddedEncoder {
+        fn encode_batch(
+            &self,
+            message: RowMajorMatrix<BinaryField128>,
+            rate: usize,
+        ) -> RowMajorMatrix<BinaryField128> {
+            AdditiveRsEncoder::<BinaryField128>::default().encode_batch(message, rate)
+        }
+    }
     let encoder = AdditiveRsEncoder::<BinaryField128>::default();
     let mut rng = SmallRng::seed_from_u64(11);
     let mut group = c.benchmark_group("commit_base");
@@ -188,6 +199,19 @@ fn bench_commit(c: &mut Criterion) {
             for added in [1, 2, 3] {
                 for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
                     let parameter = format!("{order:?}/h{log_height}/w{}/r{added}", 1 << folding);
+                    group.bench_function(format!("full/{parameter}"), |b| {
+                        b.iter(|| {
+                            commit_base(
+                                order,
+                                &FullPaddedEncoder,
+                                &mmcs,
+                                &mut Challenger::from_hasher(Vec::new(), Keccak256Hash),
+                                &poly,
+                                folding,
+                                added,
+                            )
+                        });
+                    });
                     group.bench_function(parameter, |b| {
                         b.iter(|| {
                             commit_base(

--- a/binary-dft/src/encoder.rs
+++ b/binary-dft/src/encoder.rs
@@ -55,6 +55,14 @@ impl<Ntt: AdditiveNtt<BinaryField128> + Sync> Encoder<BinaryField128>
         message.values.resize(padded_len, BinaryField128::ZERO);
         self.ntt.ntt_batch_padded(message, log_inv_rate)
     }
+
+    fn encode_batch_padded(
+        &self,
+        message: RowMajorMatrix<BinaryField128>,
+        log_inv_rate: usize,
+    ) -> RowMajorMatrix<BinaryField128> {
+        self.ntt.ntt_batch_padded(message, log_inv_rate)
+    }
 }
 
 #[cfg(test)]
@@ -123,6 +131,34 @@ mod tests {
     fn encode_batch_panics_when_the_codeword_length_overflows() {
         let message = RowMajorMatrix::new(vec![F::ZERO; 2], 1);
         let _ = AdditiveRsEncoder::<F>::default().encode_batch(message, usize::BITS as usize - 1);
+    }
+
+    #[test]
+    fn padded_encoding_matches_naive() {
+        for width in [1, 4, 16, 64] {
+            for rate in [0, 1, 2, 3] {
+                let mut mat = matrix(4, width, 13);
+                mat.values.resize(mat.values.len() << rate, F::ZERO);
+                let expected = NaiveAdditiveNtt::default().ntt_batch(mat.clone());
+                assert_eq!(
+                    AdditiveRsEncoder::<F>::default().encode_batch_padded(mat, rate),
+                    expected
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic = "padding exceeds matrix height"]
+    fn padded_encoding_rejects_excessive_padding() {
+        let _ = AdditiveRsEncoder::<F>::default().encode_batch_padded(matrix(2, 4, 0), 3);
+    }
+
+    #[test]
+    #[should_panic]
+    fn padded_encoding_rejects_non_power_of_two_height() {
+        let mat = RowMajorMatrix::new(vec![F::ZERO; 12], 4);
+        let _ = AdditiveRsEncoder::<F>::default().encode_batch_padded(mat, 1);
     }
 
     proptest! {

--- a/binary-dft/src/encoder.rs
+++ b/binary-dft/src/encoder.rs
@@ -18,7 +18,7 @@ use crate::traits::AdditiveNtt;
 /// the evaluation of `f̂(Ŵ_0(x), …, Ŵ_{k−1}(x))` on `S_{k + log_inv_rate}`.
 ///
 /// The alphabet is `BinaryField128`, where [`PolyBasisNtt`] is the faster transform and falls
-/// back to [`LchNtt`](crate::LchNtt) on a target without a carryless multiply, so it is the default.
+/// back to the portable tower transform on a target without a carryless multiply, so it is the default.
 ///
 /// `F` is phantom: [`Encoder`] is only implemented below for `F = BinaryField128`, and stays
 /// that way as long as the alphabet is fixed (D9), so the parameter carries no other instance.

--- a/binary-dft/src/encoder.rs
+++ b/binary-dft/src/encoder.rs
@@ -7,10 +7,8 @@ use p3_commit::Encoder;
 use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
-use crate::domain::domain_point;
 use crate::poly::PolyBasisNtt;
 use crate::traits::AdditiveNtt;
 
@@ -37,14 +35,13 @@ impl<Ntt: AdditiveNtt<BinaryField128> + Sync> Encoder<BinaryField128>
 {
     fn encode_batch(
         &self,
-        message: RowMajorMatrix<BinaryField128>,
+        mut message: RowMajorMatrix<BinaryField128>,
         log_inv_rate: usize,
     ) -> RowMajorMatrix<BinaryField128> {
         if log_inv_rate == 0 {
             return self.ntt.ntt_batch(message);
         }
 
-        let width = message.width();
         let len = message.values.len();
         let padded_len = u32::try_from(log_inv_rate)
             .ok()
@@ -54,30 +51,9 @@ impl<Ntt: AdditiveNtt<BinaryField128> + Sync> Encoder<BinaryField128>
             // what actually proves no bits were lost.
             .filter(|&padded| padded >> log_inv_rate == len)
             .expect("codeword length overflows usize");
-        let log_message_height = log2_strict_usize(message.height());
-
-        // Zero-padding to `S_{k+r}` and transforming the whole codeword leaves the appended
-        // `hi` coefficient half zero at every stage `j >= k`, so those butterflies only ever
-        // replicate `lo` — yet the carryless multiply against that zero still runs, `r` stages
-        // deep. The equivalent computation is `2^r` independent height-`2^k` transforms of the
-        // unpadded message, one per coset `c` of `S_k` in `S_{k+r}`, evaluated at
-        // `domain_point(c << k)`: every codeword row decomposes as `c*2^k + m` with
-        // `domain_point(c*2^k + m) = domain_point(c << k) + domain_point(m)`, and the padding
-        // rows never enter the computation at all. Each coset is independent, so they run in
-        // parallel; `shifted_ntt_batch` takes its message by value, so each needs its own copy.
-        let mut values = BinaryField128::zero_vec(padded_len);
-        values
-            .par_chunks_mut(len)
-            .enumerate()
-            .for_each(|(c, chunk)| {
-                let shift = domain_point::<BinaryField128>(c << log_message_height);
-                let coset = self
-                    .ntt
-                    .shifted_ntt_batch(RowMajorMatrix::new(message.values.clone(), width), shift);
-                chunk.copy_from_slice(&coset.values);
-            });
-
-        RowMajorMatrix::new(values, width)
+        let _ = log2_strict_usize(message.height());
+        message.values.resize(padded_len, BinaryField128::ZERO);
+        self.ntt.ntt_batch_padded(message, log_inv_rate)
     }
 }
 

--- a/binary-dft/src/lib.rs
+++ b/binary-dft/src/lib.rs
@@ -8,6 +8,7 @@ mod encoder;
 mod lch;
 mod naive;
 mod poly;
+mod tower;
 mod traits;
 
 pub use domain::*;

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -105,18 +105,98 @@ fn stage(values: &mut [u128], half: usize, j: usize, twiddles: &Twiddles, invers
         });
 }
 
+// A conservative tile budget; the row count scales with the element size and matrix width.
+const TILE_BYTES: usize = 32 * 1024;
+
+/// A tile stays on one worker across its adjacent stages.
+fn local_stage(
+    values: &mut [u128],
+    half: usize,
+    j: usize,
+    twiddles: &Twiddles,
+    inverse: bool,
+    first: usize,
+) {
+    let mut t = twiddles.at(j, first);
+    for (index, block) in values.chunks_mut(half << 1).enumerate() {
+        let (lo, hi) = block.split_at_mut(half);
+        if t == 0 {
+            for (u, v) in lo.iter_mut().zip(hi) {
+                *v ^= *u;
+            }
+        } else if inverse {
+            for (u, v) in lo.iter_mut().zip(hi) {
+                *v ^= *u;
+                *u ^= poly_basis::mul(t, *v);
+            }
+        } else {
+            for (u, v) in lo.iter_mut().zip(hi) {
+                *u ^= poly_basis::mul(t, *v);
+                *v ^= *u;
+            }
+        }
+        t ^= twiddles.deltas[(first + index).trailing_ones() as usize];
+    }
+}
+
+/// Complete the stages confined to one cache-sized set of rows before leaving it.
+fn local_stages(
+    values: &mut [u128],
+    width: usize,
+    log_n: usize,
+    twiddles: &Twiddles,
+    inverse: bool,
+) -> usize {
+    let rows = (TILE_BYTES / core::mem::size_of::<u128>() / width).max(1);
+    let local = p3_util::log2_floor_usize(rows).min(log_n);
+    let tile_len = (1 << local) * width;
+    values
+        .par_chunks_mut(tile_len)
+        .enumerate()
+        .for_each(|(tile, values)| {
+            for k in 0..local {
+                let j = if inverse { k } else { local - 1 - k };
+                local_stage(
+                    values,
+                    (1 << j) * width,
+                    j,
+                    twiddles,
+                    inverse,
+                    tile << (local - j - 1),
+                );
+            }
+        });
+    local
+}
+
 /// Forward transform of polynomial-basis values in an existing allocation.
 fn forward(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField128) {
     let twiddles = Twiddles::new(log_n, shift);
-    for j in (0..log_n).rev() {
+    if core::mem::size_of_val(values) <= TILE_BYTES {
+        for j in (0..log_n).rev() {
+            stage(values, (1 << j) * width, j, &twiddles, false);
+        }
+        return;
+    }
+    let rows = (TILE_BYTES / core::mem::size_of::<u128>() / width).max(1);
+    let local = p3_util::log2_floor_usize(rows).min(log_n);
+    for j in (local..log_n).rev() {
         stage(values, (1 << j) * width, j, &twiddles, false);
     }
+    local_stages(values, width, log_n, &twiddles, false);
 }
 
 /// Inverse transform with the data kept in the polynomial basis.
 fn inverse(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField128) {
     let twiddles = Twiddles::new(log_n, shift);
-    for j in 0..log_n {
+    if core::mem::size_of_val(values) <= TILE_BYTES {
+        for j in 0..log_n {
+            stage(values, (1 << j) * width, j, &twiddles, true);
+        }
+        return;
+    }
+    let local = local_stages(values, width, log_n, &twiddles, true);
+    for j in local..log_n {
         stage(values, (1 << j) * width, j, &twiddles, true);
     }
 }
@@ -361,6 +441,21 @@ mod tests {
                     t ^= twiddles.deltas[block.trailing_ones() as usize];
                 }
             }
+        }
+    }
+
+    #[test]
+    fn transforms_cross_cache_boundaries_in_natural_order() {
+        for width in [1, 3, 16, 64] {
+            let mat = matrix(12, width, 29);
+            let shift = BinaryField128::from_repr((1 << 127) | 7919);
+            let expected = crate::LchNtt::default().shifted_ntt_batch(mat.clone(), shift);
+            let actual = PolyBasisNtt::default().shifted_ntt_batch(mat.clone(), shift);
+            assert_eq!(actual, expected);
+            assert_eq!(
+                PolyBasisNtt::default().shifted_intt_batch(actual, shift),
+                mat
+            );
         }
     }
 

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -9,7 +9,7 @@ use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
-use crate::domain::{domain_point, domain_point_steps, subspace_polynomial};
+use crate::domain::domain_point;
 use crate::lch::{BUTTERFLY_GRAIN, LchNtt};
 use crate::traits::AdditiveNtt;
 
@@ -29,118 +29,95 @@ pub struct PolyBasisNtt {
     tower: LchNtt<BinaryField128>,
 }
 
-/// The twiddle of block `blk` of stage `j`, in the polynomial basis.
-#[inline]
-fn twiddle(base: BinaryField128, blk: usize) -> u128 {
-    poly_basis::from_tower(base + domain_point::<BinaryField128>(blk << 1))
+/// Stage shifts and the XOR increments between consecutive block twiddles.
+struct Twiddles {
+    basis: [u128; usize::BITS as usize],
+    deltas: [u128; usize::BITS as usize],
+    shifts: [u128; usize::BITS as usize],
 }
 
-/// [`domain_point_steps`] carried into the polynomial basis.
-///
-/// The change of basis is additive, so an increment converted here applies to a twiddle
-/// already in this basis by `XOR`.
-fn twiddle_steps(count: usize) -> Vec<u128> {
-    domain_point_steps::<BinaryField128>(count)
-        .into_iter()
-        .map(poly_basis::from_tower)
-        .collect()
+impl Twiddles {
+    fn new(log_n: usize, shift: BinaryField128) -> Self {
+        let mut result = Self {
+            basis: [0; usize::BITS as usize],
+            deltas: [0; usize::BITS as usize],
+            shifts: [0; usize::BITS as usize],
+        };
+        let mut delta = 0;
+        let mut base = poly_basis::from_tower(shift);
+        for j in 0..log_n {
+            result.basis[j] = poly_basis::from_tower(BinaryField128::cantor_basis(j + 1));
+            delta ^= result.basis[j];
+            result.deltas[j] = delta;
+            result.shifts[j] = base;
+            base = poly_basis::square(base) ^ base;
+        }
+        result
+    }
+
+    const fn at(&self, stage: usize, mut block: usize) -> u128 {
+        let mut t = self.shifts[stage];
+        while block != 0 {
+            t ^= self.basis[block.trailing_zeros() as usize];
+            block &= block - 1;
+        }
+        t
+    }
+}
+
+/// A stage uses bounded chunks, each starting from its own independently indexed twiddle.
+fn stage(values: &mut [u128], half: usize, j: usize, twiddles: &Twiddles, inverse: bool) {
+    let blocks_per_chunk = (BUTTERFLY_GRAIN / (half << 1)).max(1);
+    values
+        .par_chunks_mut((half << 1) * blocks_per_chunk)
+        .enumerate()
+        .for_each(|(chunk_index, chunk)| {
+            let first = chunk_index * blocks_per_chunk;
+            let mut t = twiddles.at(j, first);
+            for (index, block) in chunk.chunks_mut(half << 1).enumerate() {
+                let (lo, hi) = block.split_at_mut(half);
+                let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
+                    if t == 0 {
+                        for (u, v) in lo.iter_mut().zip(hi) {
+                            *v ^= *u;
+                        }
+                    } else if inverse {
+                        for (u, v) in lo.iter_mut().zip(hi) {
+                            *v ^= *u;
+                            *u ^= poly_basis::mul(t, *v);
+                        }
+                    } else {
+                        for (u, v) in lo.iter_mut().zip(hi) {
+                            *u ^= poly_basis::mul(t, *v);
+                            *v ^= *u;
+                        }
+                    }
+                };
+                if half <= BUTTERFLY_GRAIN {
+                    butterfly(lo, hi);
+                } else {
+                    lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                        .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                        .for_each(|(lo, hi)| butterfly(lo, hi));
+                }
+                t ^= twiddles.deltas[(first + index).trailing_ones() as usize];
+            }
+        });
 }
 
 /// Forward transform of polynomial-basis values in an existing allocation.
-///
-/// An increment depends only on a block index's trailing-zero count, never on the stage, so one
-/// table serves every stage and each stage uses the prefix it reaches. A height of one runs no
-/// stage and needs no table.
 fn forward(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField128) {
-    let steps = twiddle_steps(log_n.saturating_sub(1));
+    let twiddles = Twiddles::new(log_n, shift);
     for j in (0..log_n).rev() {
-        let half = (1 << j) * width;
-        let base = subspace_polynomial::<BinaryField128>(j, shift);
-        let per_task = (BUTTERFLY_GRAIN / half).max(1);
-        values
-            .par_chunks_mut(per_task * (half << 1))
-            .enumerate()
-            .for_each(|(task, group)| {
-                let first = task * per_task;
-                let mut t = twiddle(base, first);
-                // Invariant: blocks are visited in ascending index order.
-                // Carrying the twiddle from one block to the next relies on it.
-                for (i, block) in group.chunks_mut(half << 1).enumerate() {
-                    if i != 0 {
-                        t ^= steps[(first + i).trailing_zeros() as usize];
-                    }
-                    let zero = t == 0;
-                    let (lo, hi) = block.split_at_mut(half);
-                    let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                        if zero {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v ^= *u;
-                            }
-                        } else {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *u ^= poly_basis::mul(t, *v);
-                                *v ^= *u;
-                            }
-                        }
-                    };
-                    if half <= BUTTERFLY_GRAIN {
-                        butterfly(lo, hi);
-                    } else {
-                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                            .for_each(|(lo, hi)| butterfly(lo, hi));
-                    }
-                }
-            });
+        stage(values, (1 << j) * width, j, &twiddles, false);
     }
 }
 
 /// Inverse transform with the data kept in the polynomial basis.
-///
-/// An increment depends only on a block index's trailing-zero count, never on the stage, so one
-/// table serves every stage and each stage uses the prefix it reaches. A height of one runs no
-/// stage and needs no table.
 fn inverse(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField128) {
-    let steps = twiddle_steps(log_n.saturating_sub(1));
+    let twiddles = Twiddles::new(log_n, shift);
     for j in 0..log_n {
-        let half = (1 << j) * width;
-        let base = subspace_polynomial::<BinaryField128>(j, shift);
-        let per_task = (BUTTERFLY_GRAIN / half).max(1);
-        values
-            .par_chunks_mut(per_task * (half << 1))
-            .enumerate()
-            .for_each(|(task, group)| {
-                let first = task * per_task;
-                let mut t = twiddle(base, first);
-                // Invariant: blocks are visited in ascending index order.
-                // Carrying the twiddle from one block to the next relies on it.
-                for (i, block) in group.chunks_mut(half << 1).enumerate() {
-                    if i != 0 {
-                        t ^= steps[(first + i).trailing_zeros() as usize];
-                    }
-                    let zero = t == 0;
-                    let (lo, hi) = block.split_at_mut(half);
-                    let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                        if zero {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v ^= *u;
-                            }
-                        } else {
-                            for (u, v) in lo.iter_mut().zip(hi) {
-                                *v ^= *u;
-                                *u ^= poly_basis::mul(t, *v);
-                            }
-                        }
-                    };
-                    if half <= BUTTERFLY_GRAIN {
-                        butterfly(lo, hi);
-                    } else {
-                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                            .for_each(|(lo, hi)| butterfly(lo, hi));
-                    }
-                }
-            });
+        stage(values, (1 << j) * width, j, &twiddles, true);
     }
 }
 
@@ -256,7 +233,12 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .enumerate()
             .for_each(|(c, chunk)| {
                 chunk.copy_from_slice(&coeffs);
-                forward(chunk, width, log_n, shift + domain_point::<BinaryField128>((c + 1) << log_n));
+                forward(
+                    chunk,
+                    width,
+                    log_n,
+                    shift + domain_point::<BinaryField128>((c + 1) << log_n),
+                );
                 for v in chunk {
                     *v = poly_basis::to_tower(*v).to_repr();
                 }
@@ -357,6 +339,29 @@ mod tests {
     #[should_panic = "extended codeword length overflows usize"]
     fn lde_rejects_length_overflow() {
         let _ = PolyBasisNtt::default().lde_batch(matrix(1, 1, 0), usize::BITS as usize - 1);
+    }
+
+    #[test]
+    fn incremental_twiddles_match_independent_domain_points() {
+        use p3_binary_field::poly_basis;
+
+        use crate::domain::{domain_point, subspace_polynomial};
+        let shift = BinaryField128::from_repr((1 << 127) | 123);
+        let twiddles = super::Twiddles::new(usize::BITS as usize - 1, shift);
+        for stage in [0, 1, 7, 15, 31]
+            .into_iter()
+            .filter(|&stage| stage < usize::BITS as usize - 1)
+        {
+            for start in [0, 1, 63, 127, (1usize << (usize::BITS - 3)) - 3] {
+                let mut t = twiddles.at(stage, start);
+                for block in start..start + 9 {
+                    let expected = subspace_polynomial(stage, shift)
+                        + domain_point::<BinaryField128>(block << 1);
+                    assert_eq!(t, poly_basis::from_tower(expected));
+                    t ^= twiddles.deltas[block.trailing_ones() as usize];
+                }
+            }
+        }
     }
 
     proptest! {

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -77,20 +77,10 @@ fn stage(values: &mut [u128], half: usize, j: usize, twiddles: &Twiddles, invers
             for (index, block) in chunk.chunks_mut(half << 1).enumerate() {
                 let (lo, hi) = block.split_at_mut(half);
                 let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                    if t == 0 {
-                        for (u, v) in lo.iter_mut().zip(hi) {
-                            *v ^= *u;
-                        }
-                    } else if inverse {
-                        for (u, v) in lo.iter_mut().zip(hi) {
-                            *v ^= *u;
-                            *u ^= poly_basis::mul(t, *v);
-                        }
+                    if inverse {
+                        poly_basis::butterfly_inverse(lo, hi, t);
                     } else {
-                        for (u, v) in lo.iter_mut().zip(hi) {
-                            *u ^= poly_basis::mul(t, *v);
-                            *v ^= *u;
-                        }
+                        poly_basis::butterfly_forward(lo, hi, t);
                     }
                 };
                 if half <= BUTTERFLY_GRAIN {
@@ -120,20 +110,10 @@ fn local_stage(
     let mut t = twiddles.at(j, first);
     for (index, block) in values.chunks_mut(half << 1).enumerate() {
         let (lo, hi) = block.split_at_mut(half);
-        if t == 0 {
-            for (u, v) in lo.iter_mut().zip(hi) {
-                *v ^= *u;
-            }
-        } else if inverse {
-            for (u, v) in lo.iter_mut().zip(hi) {
-                *v ^= *u;
-                *u ^= poly_basis::mul(t, *v);
-            }
+        if inverse {
+            poly_basis::butterfly_inverse(lo, hi, t);
         } else {
-            for (u, v) in lo.iter_mut().zip(hi) {
-                *u ^= poly_basis::mul(t, *v);
-                *v ^= *u;
-            }
+            poly_basis::butterfly_forward(lo, hi, t);
         }
         t ^= twiddles.deltas[(first + index).trailing_ones() as usize];
     }

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -66,8 +66,51 @@ impl Twiddles {
     }
 }
 
+/// Schedule enough butterfly-sized work per worker to amortize parallel dispatch.
+// The serial dependency exposes a `const` thread-count query, while the parallel
+// implementation cannot; keep this shared scheduler callable in both configurations.
+#[allow(clippy::missing_const_for_fn)]
+fn use_parallel(elements: usize) -> bool {
+    let threads = p3_maybe_rayon::prelude::current_num_threads();
+    threads > 1 && elements >= 2 * BUTTERFLY_GRAIN * threads
+}
+
+fn for_chunks(
+    values: &mut [u128],
+    chunk_len: usize,
+    stages: usize,
+    operation: impl Fn((usize, &mut [u128])) + Send + Sync,
+) {
+    if values.len() > chunk_len && use_parallel(values.len().saturating_mul(stages.max(1))) {
+        values
+            .par_chunks_mut(chunk_len)
+            .enumerate()
+            .for_each(operation);
+    } else {
+        values.chunks_mut(chunk_len).enumerate().for_each(operation);
+    }
+}
+
+fn convert(values: &mut [u128], conversion: impl Fn(u128) -> u128 + Send + Sync) {
+    // Basis conversion does several dependent lookups per element, more work than
+    // a butterfly, so it amortizes dispatch at a smaller byte volume.
+    if use_parallel(values.len().saturating_mul(4)) {
+        values
+            .par_iter_mut()
+            .for_each(|value| *value = conversion(*value));
+    } else {
+        values
+            .iter_mut()
+            .for_each(|value| *value = conversion(*value));
+    }
+}
+
 /// A stage uses bounded chunks, each starting from its own independently indexed twiddle.
 fn stage(values: &mut [u128], half: usize, j: usize, twiddles: &Twiddles, inverse: bool) {
+    if !use_parallel(values.len()) {
+        local_stage(values, half, j, twiddles, inverse, 0);
+        return;
+    }
     let blocks_per_chunk = (BUTTERFLY_GRAIN / (half << 1)).max(1);
     values
         .par_chunks_mut((half << 1) * blocks_per_chunk)
@@ -131,22 +174,19 @@ fn local_stages(
     let rows = (TILE_BYTES / core::mem::size_of::<u128>() / width).max(1);
     let local = p3_util::log2_floor_usize(rows).min(log_n);
     let tile_len = (1 << local) * width;
-    values
-        .par_chunks_mut(tile_len)
-        .enumerate()
-        .for_each(|(tile, values)| {
-            for k in 0..local {
-                let j = if inverse { k } else { local - 1 - k };
-                local_stage(
-                    values,
-                    (1 << j) * width,
-                    j,
-                    twiddles,
-                    inverse,
-                    tile << (local - j - 1),
-                );
-            }
-        });
+    for_chunks(values, tile_len, local, |(tile, values)| {
+        for k in 0..local {
+            let j = if inverse { k } else { local - 1 - k };
+            local_stage(
+                values,
+                (1 << j) * width,
+                j,
+                twiddles,
+                inverse,
+                tile << (local - j - 1),
+            );
+        }
+    });
     local
 }
 
@@ -201,15 +241,13 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .into_iter()
             .map(BinaryField128::to_repr)
             .collect();
-        values
-            .par_iter_mut()
-            .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
+        convert(&mut values, |v| {
+            poly_basis::from_tower(BinaryField128::from_repr(v))
+        });
 
         forward(&mut values, width, log_n, shift);
 
-        values
-            .par_iter_mut()
-            .for_each(|v| *v = poly_basis::to_tower(*v).to_repr());
+        convert(&mut values, |v| poly_basis::to_tower(v).to_repr());
         mat.values = values.into_iter().map(BinaryField128::from_repr).collect();
         mat
     }
@@ -232,24 +270,30 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .map(BinaryField128::to_repr)
             .collect();
         let (message, tail) = values.split_at_mut(len);
-        message.par_iter_mut().for_each(|v| {
-            *v = poly_basis::from_tower(BinaryField128::from_repr(*v));
+        convert(message, |v| {
+            poly_basis::from_tower(BinaryField128::from_repr(v))
         });
-        // Keep the coefficient prefix immutable until every other coset has copied it.
-        // Each worker transforms its final destination, without a temporary coset matrix.
-        tail.par_chunks_mut(len).enumerate().for_each(|(c, chunk)| {
-            chunk.copy_from_slice(message);
-            forward(
-                chunk,
-                width,
-                log_message,
-                domain_point((c + 1) << log_message),
-            );
-        });
-        forward(message, width, log_message, BinaryField128::ZERO);
-        values
-            .par_iter_mut()
-            .for_each(|v| *v = poly_basis::to_tower(*v).to_repr());
+        if len >= 2 * BUTTERFLY_GRAIN * p3_maybe_rayon::prelude::current_num_threads() {
+            // Keep large coefficient copies next to evaluation so the copied data
+            // is still hot, including when only one worker is available.
+            for_chunks(tail, len, log_message, |(c, chunk)| {
+                chunk.copy_from_slice(message);
+                forward(
+                    chunk,
+                    width,
+                    log_message,
+                    domain_point((c + 1) << log_message),
+                );
+            });
+            forward(message, width, log_message, BinaryField128::ZERO);
+        } else {
+            // Small cosets can run together after all coefficient copies are made.
+            for_chunks(tail, len, 1, |(_, chunk)| chunk.copy_from_slice(message));
+            for_chunks(&mut values, len, log_message, |(c, chunk)| {
+                forward(chunk, width, log_message, domain_point(c << log_message));
+            });
+        }
+        convert(&mut values, |v| poly_basis::to_tower(v).to_repr());
         mat.values = values.into_iter().map(BinaryField128::from_repr).collect();
         mat
     }
@@ -282,28 +326,25 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .collect();
         let mut values = alloc::vec![0u128; padded_len];
         values[..len].copy_from_slice(&coeffs);
-        coeffs
-            .par_iter_mut()
-            .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
+        convert(&mut coeffs, |v| {
+            poly_basis::from_tower(BinaryField128::from_repr(v))
+        });
         inverse(&mut coeffs, width, log_n, shift);
 
         // The input evaluations already are the first coset. Only new cosets need
         // evaluation and conversion back from the polynomial basis.
-        values[len..]
-            .par_chunks_mut(len)
-            .enumerate()
-            .for_each(|(c, chunk)| {
-                chunk.copy_from_slice(&coeffs);
-                forward(
-                    chunk,
-                    width,
-                    log_n,
-                    shift + domain_point::<BinaryField128>((c + 1) << log_n),
-                );
-                for v in chunk {
-                    *v = poly_basis::to_tower(*v).to_repr();
-                }
-            });
+        for_chunks(&mut values[len..], len, log_n, |(c, chunk)| {
+            chunk.copy_from_slice(&coeffs);
+            forward(
+                chunk,
+                width,
+                log_n,
+                shift + domain_point::<BinaryField128>((c + 1) << log_n),
+            );
+            for v in chunk {
+                *v = poly_basis::to_tower(*v).to_repr();
+            }
+        });
         mat.values = values.into_iter().map(BinaryField128::from_repr).collect();
         mat
     }
@@ -324,15 +365,13 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .into_iter()
             .map(BinaryField128::to_repr)
             .collect();
-        values
-            .par_iter_mut()
-            .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
+        convert(&mut values, |v| {
+            poly_basis::from_tower(BinaryField128::from_repr(v))
+        });
 
         inverse(&mut values, width, log_n, shift);
 
-        values
-            .par_iter_mut()
-            .for_each(|v| *v = poly_basis::to_tower(*v).to_repr());
+        convert(&mut values, |v| poly_basis::to_tower(v).to_repr());
         mat.values = values.into_iter().map(BinaryField128::from_repr).collect();
         mat
     }

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -10,10 +10,10 @@ use p3_maybe_rayon::prelude::*;
 use p3_util::log2_strict_usize;
 
 use crate::domain::domain_point;
-use crate::lch::{BUTTERFLY_GRAIN, LchNtt};
+use crate::lch::BUTTERFLY_GRAIN;
 use crate::traits::AdditiveNtt;
 
-/// [`LchNtt`] over `BinaryField128`, with the data held in the polynomial basis throughout.
+/// [`LchNtt`](crate::LchNtt) over `BinaryField128`, with the data held in the polynomial basis throughout.
 ///
 /// A tower-basis product converts both operands into the polynomial basis and the result back,
 /// sixteen dependent table lookups apiece, which is most of what a butterfly costs. Converting
@@ -23,10 +23,11 @@ use crate::traits::AdditiveNtt;
 ///
 /// Without a carryless-multiply instruction that product is a bit-serial loop and slower than
 /// the tower arithmetic it replaces, so on such a target the transform runs in the tower basis
-/// instead. The choice is a constant and only one arm survives compilation.
+/// instead, using typed subfield multiplication when the twiddle permits it.
+/// The choice is a constant and only one arm survives compilation.
 #[derive(Clone, Debug, Default)]
 pub struct PolyBasisNtt {
-    tower: LchNtt<BinaryField128>,
+    tower: crate::tower::TowerNtt,
 }
 
 /// Stage shifts and the XOR increments between consecutive block twiddles.

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -95,6 +95,55 @@ fn forward(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField12
     }
 }
 
+/// Inverse transform with the data kept in the polynomial basis.
+///
+/// An increment depends only on a block index's trailing-zero count, never on the stage, so one
+/// table serves every stage and each stage uses the prefix it reaches. A height of one runs no
+/// stage and needs no table.
+fn inverse(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField128) {
+    let steps = twiddle_steps(log_n.saturating_sub(1));
+    for j in 0..log_n {
+        let half = (1 << j) * width;
+        let base = subspace_polynomial::<BinaryField128>(j, shift);
+        let per_task = (BUTTERFLY_GRAIN / half).max(1);
+        values
+            .par_chunks_mut(per_task * (half << 1))
+            .enumerate()
+            .for_each(|(task, group)| {
+                let first = task * per_task;
+                let mut t = twiddle(base, first);
+                // Invariant: blocks are visited in ascending index order.
+                // Carrying the twiddle from one block to the next relies on it.
+                for (i, block) in group.chunks_mut(half << 1).enumerate() {
+                    if i != 0 {
+                        t ^= steps[(first + i).trailing_zeros() as usize];
+                    }
+                    let zero = t == 0;
+                    let (lo, hi) = block.split_at_mut(half);
+                    let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
+                        if zero {
+                            for (u, v) in lo.iter_mut().zip(hi) {
+                                *v ^= *u;
+                            }
+                        } else {
+                            for (u, v) in lo.iter_mut().zip(hi) {
+                                *v ^= *u;
+                                *u ^= poly_basis::mul(t, *v);
+                            }
+                        }
+                    };
+                    if half <= BUTTERFLY_GRAIN {
+                        butterfly(lo, hi);
+                    } else {
+                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                            .for_each(|(lo, hi)| butterfly(lo, hi));
+                    }
+                }
+            });
+    }
+}
+
 impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
     fn shifted_ntt_batch(
         &self,
@@ -167,6 +216,55 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
         mat
     }
 
+    fn shifted_lde_batch(
+        &self,
+        mut mat: RowMajorMatrix<BinaryField128>,
+        added_bits: usize,
+        shift: BinaryField128,
+    ) -> RowMajorMatrix<BinaryField128> {
+        if !poly_basis::HAS_HARDWARE_CLMUL {
+            return self.tower.shifted_lde_batch(mat, added_bits, shift);
+        }
+        let log_n = log2_strict_usize(mat.height());
+        if added_bits == 0 {
+            return mat;
+        }
+        let width = mat.width;
+        let len = mat.values.len();
+        let padded_len = u32::try_from(added_bits)
+            .ok()
+            .and_then(|bits| len.checked_shl(bits))
+            .filter(|&padded| padded >> added_bits == len)
+            .expect("extended codeword length overflows usize");
+        // Preserve the evaluation prefix in its final allocation, then reuse the
+        // original allocation for coefficients instead of cloning it before a resize.
+        let mut coeffs: Vec<u128> = core::mem::take(&mut mat.values)
+            .into_iter()
+            .map(BinaryField128::to_repr)
+            .collect();
+        let mut values = alloc::vec![0u128; padded_len];
+        values[..len].copy_from_slice(&coeffs);
+        coeffs
+            .par_iter_mut()
+            .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
+        inverse(&mut coeffs, width, log_n, shift);
+
+        // The input evaluations already are the first coset. Only new cosets need
+        // evaluation and conversion back from the polynomial basis.
+        values[len..]
+            .par_chunks_mut(len)
+            .enumerate()
+            .for_each(|(c, chunk)| {
+                chunk.copy_from_slice(&coeffs);
+                forward(chunk, width, log_n, shift + domain_point::<BinaryField128>((c + 1) << log_n));
+                for v in chunk {
+                    *v = poly_basis::to_tower(*v).to_repr();
+                }
+            });
+        mat.values = values.into_iter().map(BinaryField128::from_repr).collect();
+        mat
+    }
+
     fn shifted_intt_batch(
         &self,
         mut mat: RowMajorMatrix<BinaryField128>,
@@ -187,50 +285,7 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .par_iter_mut()
             .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
 
-        // An increment depends only on a block index's trailing-zero count, never on the stage,
-        // so one table serves every stage and each stage uses the prefix it reaches.
-        // A height of one runs no stage and needs no table.
-        let steps = twiddle_steps(log_n.saturating_sub(1));
-        for j in 0..log_n {
-            let half = (1 << j) * width;
-            let base = subspace_polynomial::<BinaryField128>(j, shift);
-            let per_task = (BUTTERFLY_GRAIN / half).max(1);
-            values
-                .par_chunks_mut(per_task * (half << 1))
-                .enumerate()
-                .for_each(|(task, group)| {
-                    let first = task * per_task;
-                    let mut t = twiddle(base, first);
-                    // Invariant: blocks are visited in ascending index order.
-                    // Carrying the twiddle from one block to the next relies on it.
-                    for (i, block) in group.chunks_mut(half << 1).enumerate() {
-                        if i != 0 {
-                            t ^= steps[(first + i).trailing_zeros() as usize];
-                        }
-                        let zero = t == 0;
-                        let (lo, hi) = block.split_at_mut(half);
-                        let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                            if zero {
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    *v ^= *u;
-                                }
-                            } else {
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    *v ^= *u;
-                                    *u ^= poly_basis::mul(t, *v);
-                                }
-                            }
-                        };
-                        if half <= BUTTERFLY_GRAIN {
-                            butterfly(lo, hi);
-                        } else {
-                            lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                                .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                                .for_each(|(lo, hi)| butterfly(lo, hi));
-                        }
-                    }
-                });
-        }
+        inverse(&mut values, width, log_n, shift);
 
         values
             .par_iter_mut()
@@ -281,6 +336,27 @@ mod tests {
                 );
             }
         }
+    }
+
+    #[test]
+    fn shifted_lde_matches_naive_at_wide_widths() {
+        for width in [1, 4, 16, 64] {
+            for added in [0, 1, 2, 3] {
+                let mat = matrix(4, width, 17);
+                let shift = BinaryField128::from_repr(1 << 127);
+                let expected =
+                    NaiveAdditiveNtt::default().shifted_lde_batch(mat.clone(), added, shift);
+                let actual = PolyBasisNtt::default().shifted_lde_batch(mat.clone(), added, shift);
+                assert_eq!(actual, expected);
+                assert_eq!(&actual.values[..mat.values.len()], &mat.values);
+            }
+        }
+    }
+
+    #[test]
+    #[should_panic = "extended codeword length overflows usize"]
+    fn lde_rejects_length_overflow() {
+        let _ = PolyBasisNtt::default().lde_batch(matrix(1, 1, 0), usize::BITS as usize - 1);
     }
 
     proptest! {

--- a/binary-dft/src/poly.rs
+++ b/binary-dft/src/poly.rs
@@ -3,6 +3,7 @@
 use alloc::vec::Vec;
 
 use p3_binary_field::{BinaryField128, TowerLevel, poly_basis};
+use p3_field::PrimeCharacteristicRing;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_maybe_rayon::prelude::*;
@@ -45,6 +46,55 @@ fn twiddle_steps(count: usize) -> Vec<u128> {
         .collect()
 }
 
+/// Forward transform of polynomial-basis values in an existing allocation.
+///
+/// An increment depends only on a block index's trailing-zero count, never on the stage, so one
+/// table serves every stage and each stage uses the prefix it reaches. A height of one runs no
+/// stage and needs no table.
+fn forward(values: &mut [u128], width: usize, log_n: usize, shift: BinaryField128) {
+    let steps = twiddle_steps(log_n.saturating_sub(1));
+    for j in (0..log_n).rev() {
+        let half = (1 << j) * width;
+        let base = subspace_polynomial::<BinaryField128>(j, shift);
+        let per_task = (BUTTERFLY_GRAIN / half).max(1);
+        values
+            .par_chunks_mut(per_task * (half << 1))
+            .enumerate()
+            .for_each(|(task, group)| {
+                let first = task * per_task;
+                let mut t = twiddle(base, first);
+                // Invariant: blocks are visited in ascending index order.
+                // Carrying the twiddle from one block to the next relies on it.
+                for (i, block) in group.chunks_mut(half << 1).enumerate() {
+                    if i != 0 {
+                        t ^= steps[(first + i).trailing_zeros() as usize];
+                    }
+                    let zero = t == 0;
+                    let (lo, hi) = block.split_at_mut(half);
+                    let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
+                        if zero {
+                            for (u, v) in lo.iter_mut().zip(hi) {
+                                *v ^= *u;
+                            }
+                        } else {
+                            for (u, v) in lo.iter_mut().zip(hi) {
+                                *u ^= poly_basis::mul(t, *v);
+                                *v ^= *u;
+                            }
+                        }
+                    };
+                    if half <= BUTTERFLY_GRAIN {
+                        butterfly(lo, hi);
+                    } else {
+                        lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                            .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                            .for_each(|(lo, hi)| butterfly(lo, hi));
+                    }
+                }
+            });
+    }
+}
+
 impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
     fn shifted_ntt_batch(
         &self,
@@ -68,51 +118,48 @@ impl AdditiveNtt<BinaryField128> for PolyBasisNtt {
             .par_iter_mut()
             .for_each(|v| *v = poly_basis::from_tower(BinaryField128::from_repr(*v)));
 
-        // An increment depends only on a block index's trailing-zero count, never on the stage,
-        // so one table serves every stage and each stage uses the prefix it reaches.
-        // A height of one runs no stage and needs no table.
-        let steps = twiddle_steps(log_n.saturating_sub(1));
-        for j in (0..log_n).rev() {
-            let half = (1 << j) * width;
-            let base = subspace_polynomial::<BinaryField128>(j, shift);
-            let per_task = (BUTTERFLY_GRAIN / half).max(1);
-            values
-                .par_chunks_mut(per_task * (half << 1))
-                .enumerate()
-                .for_each(|(task, group)| {
-                    let first = task * per_task;
-                    let mut t = twiddle(base, first);
-                    // Invariant: blocks are visited in ascending index order.
-                    // Carrying the twiddle from one block to the next relies on it.
-                    for (i, block) in group.chunks_mut(half << 1).enumerate() {
-                        if i != 0 {
-                            t ^= steps[(first + i).trailing_zeros() as usize];
-                        }
-                        let zero = t == 0;
-                        let (lo, hi) = block.split_at_mut(half);
-                        let butterfly = |lo: &mut [u128], hi: &mut [u128]| {
-                            if zero {
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    *v ^= *u;
-                                }
-                            } else {
-                                for (u, v) in lo.iter_mut().zip(hi) {
-                                    *u ^= poly_basis::mul(t, *v);
-                                    *v ^= *u;
-                                }
-                            }
-                        };
-                        if half <= BUTTERFLY_GRAIN {
-                            butterfly(lo, hi);
-                        } else {
-                            lo.par_chunks_mut(BUTTERFLY_GRAIN)
-                                .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
-                                .for_each(|(lo, hi)| butterfly(lo, hi));
-                        }
-                    }
-                });
-        }
+        forward(&mut values, width, log_n, shift);
 
+        values
+            .par_iter_mut()
+            .for_each(|v| *v = poly_basis::to_tower(*v).to_repr());
+        mat.values = values.into_iter().map(BinaryField128::from_repr).collect();
+        mat
+    }
+
+    fn ntt_batch_padded(
+        &self,
+        mut mat: RowMajorMatrix<BinaryField128>,
+        log_inv_rate: usize,
+    ) -> RowMajorMatrix<BinaryField128> {
+        let log_n = log2_strict_usize(mat.height());
+        assert!(log_inv_rate <= log_n, "padding exceeds matrix height");
+        if log_inv_rate == 0 || !poly_basis::HAS_HARDWARE_CLMUL {
+            return self.ntt_batch(mat);
+        }
+        let width = mat.width;
+        let log_message = log_n - log_inv_rate;
+        let len = mat.values.len() >> log_inv_rate;
+        let mut values: Vec<u128> = core::mem::take(&mut mat.values)
+            .into_iter()
+            .map(BinaryField128::to_repr)
+            .collect();
+        let (message, tail) = values.split_at_mut(len);
+        message.par_iter_mut().for_each(|v| {
+            *v = poly_basis::from_tower(BinaryField128::from_repr(*v));
+        });
+        // Keep the coefficient prefix immutable until every other coset has copied it.
+        // Each worker transforms its final destination, without a temporary coset matrix.
+        tail.par_chunks_mut(len).enumerate().for_each(|(c, chunk)| {
+            chunk.copy_from_slice(message);
+            forward(
+                chunk,
+                width,
+                log_message,
+                domain_point((c + 1) << log_message),
+            );
+        });
+        forward(message, width, log_message, BinaryField128::ZERO);
         values
             .par_iter_mut()
             .for_each(|v| *v = poly_basis::to_tower(*v).to_repr());
@@ -217,6 +264,23 @@ mod tests {
                 .collect(),
             width,
         )
+    }
+
+    #[test]
+    fn padded_transform_matches_naive_at_wide_widths() {
+        use p3_field::PrimeCharacteristicRing;
+        for width in [1, 4, 16, 64] {
+            for added in [0, 1, 2, 3] {
+                let mut mat = matrix(4, width, 13);
+                mat.values
+                    .resize(mat.values.len() << added, BinaryField128::ZERO);
+                let expected = NaiveAdditiveNtt::default().ntt_batch(mat.clone());
+                assert_eq!(
+                    PolyBasisNtt::default().ntt_batch_padded(mat, added),
+                    expected
+                );
+            }
+        }
     }
 
     proptest! {

--- a/binary-dft/src/tower.rs
+++ b/binary-dft/src/tower.rs
@@ -1,0 +1,147 @@
+//! The portable `BinaryField128` transform with typed subfield twiddles.
+
+use core::ops::Mul;
+
+use p3_binary_field::{
+    BinaryField8, BinaryField16, BinaryField32, BinaryField64, BinaryField128, TowerLevel,
+};
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_maybe_rayon::prelude::*;
+use p3_util::log2_strict_usize;
+
+use crate::domain::{domain_point, subspace_polynomial};
+use crate::lch::BUTTERFLY_GRAIN;
+
+/// The specialized portable implementation also supplies the trait's generic LDE path.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct TowerNtt;
+
+impl crate::AdditiveNtt<BinaryField128> for TowerNtt {
+    fn shifted_ntt_batch(
+        &self,
+        mut mat: RowMajorMatrix<BinaryField128>,
+        shift: BinaryField128,
+    ) -> RowMajorMatrix<BinaryField128> {
+        transform(&mut mat, shift, false);
+        mat
+    }
+
+    fn shifted_intt_batch(
+        &self,
+        mut mat: RowMajorMatrix<BinaryField128>,
+        shift: BinaryField128,
+    ) -> RowMajorMatrix<BinaryField128> {
+        transform(&mut mat, shift, true);
+        mat
+    }
+}
+
+fn butterfly<T: Copy>(lo: &mut [BinaryField128], hi: &mut [BinaryField128], t: T, inverse: bool)
+where
+    BinaryField128: Mul<T, Output = BinaryField128>,
+{
+    if inverse {
+        for (u, v) in lo.iter_mut().zip(hi) {
+            *v += *u;
+            *u += *v * t;
+        }
+    } else {
+        for (u, v) in lo.iter_mut().zip(hi) {
+            *u += *v * t;
+            *v += *u;
+        }
+    }
+}
+
+pub(crate) fn transform(
+    mat: &mut RowMajorMatrix<BinaryField128>,
+    shift: BinaryField128,
+    inverse: bool,
+) {
+    let log_n = log2_strict_usize(mat.height());
+    for k in 0..log_n {
+        let j = if inverse { k } else { log_n - 1 - k };
+        let half = (1 << j) * mat.width;
+        let base = subspace_polynomial(j, shift);
+        mat.values
+            .par_chunks_mut(half << 1)
+            .enumerate()
+            .for_each(|(block, values)| {
+                let t = base + domain_point::<BinaryField128>(block << 1);
+                let bits = t.to_repr();
+                let apply = |(lo, hi): (&mut [BinaryField128], &mut [BinaryField128])| {
+                    // A shifted twiddle is not necessarily in the domain's small subfield.
+                    // Check its actual coordinates before constructing a typed coefficient.
+                    if bits == 0 {
+                        for (u, v) in lo.iter().zip(hi) {
+                            *v += *u;
+                        }
+                    } else if bits <= u8::MAX as u128 {
+                        butterfly(lo, hi, BinaryField8::from_repr(bits as u8), inverse);
+                    } else if bits <= u16::MAX as u128 {
+                        butterfly(lo, hi, BinaryField16::from_repr(bits as u16), inverse);
+                    } else if bits <= u32::MAX as u128 {
+                        butterfly(lo, hi, BinaryField32::from_repr(bits as u32), inverse);
+                    } else if bits <= u64::MAX as u128 {
+                        butterfly(lo, hi, BinaryField64::from_repr(bits as u64), inverse);
+                    } else {
+                        butterfly(lo, hi, t, inverse);
+                    }
+                };
+                let (lo, hi) = values.split_at_mut(half);
+                if half <= BUTTERFLY_GRAIN {
+                    apply((lo, hi));
+                } else {
+                    lo.par_chunks_mut(BUTTERFLY_GRAIN)
+                        .zip(hi.par_chunks_mut(BUTTERFLY_GRAIN))
+                        .for_each(apply);
+                }
+            });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_binary_field::{BinaryField128, TowerLevel};
+    use p3_field::PrimeCharacteristicRing;
+    use p3_matrix::dense::RowMajorMatrix;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use crate::{AdditiveNtt, LchNtt, NaiveAdditiveNtt};
+
+    #[test]
+    fn mixed_twiddles_preserve_full_and_shifted_transforms() {
+        let mut rng = SmallRng::seed_from_u64(41);
+        for width in [1, 4, 16, 64] {
+            for shift in [
+                BinaryField128::ZERO,
+                BinaryField128::cantor_basis(15),
+                BinaryField128::from_repr(1 << 127),
+            ] {
+                let mat = RowMajorMatrix::<BinaryField128>::rand(&mut rng, 16, width);
+                let expected = NaiveAdditiveNtt::default().shifted_ntt_batch(mat.clone(), shift);
+                let mut actual = mat.clone();
+                super::transform(&mut actual, shift, false);
+                assert_eq!(actual, expected);
+                super::transform(&mut actual, shift, true);
+                assert_eq!(actual, mat);
+            }
+        }
+    }
+
+    #[test]
+    fn mixed_twiddles_agree_with_generic_tower_at_larger_sizes() {
+        let mut rng = SmallRng::seed_from_u64(43);
+        for shift in [BinaryField128::ZERO, BinaryField128::from_repr(1 << 127)] {
+            let mat = RowMajorMatrix::<BinaryField128>::rand(&mut rng, 1024, 16);
+            let expected = LchNtt::default().shifted_ntt_batch(mat.clone(), shift);
+            let mut actual = mat.clone();
+            super::transform(&mut actual, shift, false);
+            assert_eq!(actual, expected);
+            super::transform(&mut actual, shift, true);
+            assert_eq!(actual, mat);
+        }
+    }
+}

--- a/binary-dft/src/traits.rs
+++ b/binary-dft/src/traits.rs
@@ -1,6 +1,7 @@
 //! The additive NTT interface shared by the reference and fast transforms.
 
 use p3_binary_field::TowerLevel;
+use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 
 /// An additive NTT: evaluation of the novel polynomial basis on an `F_2`-linear subspace.
@@ -58,6 +59,11 @@ pub trait AdditiveNtt<F: TowerLevel> {
         added_bits: usize,
         shift: F,
     ) -> RowMajorMatrix<F> {
+        let log_n = p3_util::log2_strict_usize(mat.height());
+        assert!(log_n <= 1 << F::LOG_BITS, "domain exceeds field dimension");
+        if added_bits == 0 {
+            return mat;
+        }
         let coeffs = self.shifted_intt_batch(mat, shift);
         let width = coeffs.width;
         let len = coeffs.values.len();
@@ -75,5 +81,39 @@ pub trait AdditiveNtt<F: TowerLevel> {
         let mut values = F::zero_vec(padded_len);
         values[..len].copy_from_slice(&coeffs.values);
         self.shifted_ntt_batch(RowMajorMatrix::new(values, width), shift)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_binary_field::BinaryField8;
+    use p3_field::PrimeCharacteristicRing;
+    use p3_matrix::dense::RowMajorMatrix;
+
+    use super::AdditiveNtt;
+    use crate::LchNtt;
+
+    #[test]
+    fn identity_lde_preserves_input_allocation() {
+        let mat = RowMajorMatrix::new(vec![BinaryField8::ONE; 32], 4);
+        let ptr = mat.values.as_ptr();
+        let result = LchNtt::default().lde_batch(mat, 0);
+        assert_eq!(result.values.as_ptr(), ptr);
+        assert_eq!(result.values, vec![BinaryField8::ONE; 32]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn identity_lde_rejects_invalid_height() {
+        let _ = LchNtt::default().lde_batch(RowMajorMatrix::new(vec![BinaryField8::ONE; 3], 1), 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn identity_lde_rejects_domain_above_field_dimension() {
+        let _ =
+            LchNtt::default().lde_batch(RowMajorMatrix::new(vec![BinaryField8::ONE; 512], 1), 0);
     }
 }

--- a/binary-dft/src/traits.rs
+++ b/binary-dft/src/traits.rs
@@ -35,6 +35,20 @@ pub trait AdditiveNtt<F: TowerLevel> {
         self.shifted_ntt_batch(mat, F::ZERO)
     }
 
+    /// Transforms a matrix whose coefficient prefix has been padded with zero rows.
+    ///
+    /// The caller supplies `2^log_inv_rate` times the original height and must leave
+    /// every entry after that original prefix zero. Implementations may ignore that tail.
+    /// The default evaluates the full matrix; optimized implementations can skip zero work.
+    ///
+    /// # Panics
+    /// Panics for an invalid transform height or if the padding exceeds that height.
+    fn ntt_batch_padded(&self, mat: RowMajorMatrix<F>, log_inv_rate: usize) -> RowMajorMatrix<F> {
+        let log_n = p3_util::log2_strict_usize(mat.height());
+        assert!(log_inv_rate <= log_n, "padding exceeds matrix height");
+        self.ntt_batch(mat)
+    }
+
     /// Inverse of [`ntt_batch`](Self::ntt_batch).
     fn intt_batch(&self, mat: RowMajorMatrix<F>) -> RowMajorMatrix<F> {
         self.shifted_intt_batch(mat, F::ZERO)

--- a/binary-dft/tests/commit.rs
+++ b/binary-dft/tests/commit.rs
@@ -102,3 +102,38 @@ fn prefix_prover_commits_over_a_binary_field() {
 
     assert_eq!(root_fast, root_ref);
 }
+
+/// The padded production path preserves both layouts and their independently encoded roots.
+#[test]
+fn polynomial_commit_matches_naive_for_both_orders() {
+    use p3_matrix::dense::RowMajorMatrix;
+
+    let mut rng = SmallRng::seed_from_u64(19);
+    let values: Vec<F> = (0..1 << 8).map(|_| rng.random()).collect();
+    let mmcs = mmcs();
+    for folding in [0, 2, 4, 6] {
+        for rate in [1, 2, 3] {
+            for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
+                let message = match order {
+                    VariableOrder::Prefix => {
+                        RowMajorMatrixView::new(&values, 1 << (8 - folding)).transpose()
+                    }
+                    VariableOrder::Suffix => RowMajorMatrix::new(values.clone(), 1 << folding),
+                };
+                let expected = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default()
+                    .encode_batch(message, rate);
+                let (expected_root, _) = mmcs.commit_matrix(expected);
+                let (root, _) = commit_base(
+                    order,
+                    &AdditiveRsEncoder::<F>::default(),
+                    &mmcs,
+                    &mut challenger(),
+                    &Poly::new(values.clone()),
+                    folding,
+                    rate,
+                );
+                assert_eq!(root, expected_root);
+            }
+        }
+    }
+}

--- a/commit/src/encoder.rs
+++ b/commit/src/encoder.rs
@@ -25,6 +25,25 @@ pub trait Encoder<F: Field> {
     /// Panics if the height of `message` is not a power of two, or if the codeword height
     /// `2^(k + log_inv_rate)` overflows `usize`.
     fn encode_batch(&self, message: RowMajorMatrix<F>, log_inv_rate: usize) -> RowMajorMatrix<F>;
+
+    /// Encodes a coefficient matrix already padded to its final height.
+    ///
+    /// The original message occupies the first `height / 2^log_inv_rate` rows; the
+    /// caller must set the remaining entries to zero. Implementations may ignore
+    /// that tail and use the rate to avoid work on zero coefficients.
+    /// The default preserves the ordinary transform of the full padded matrix.
+    ///
+    /// # Panics
+    /// Panics if the height is not a power of two or the padding exceeds its height.
+    fn encode_batch_padded(
+        &self,
+        message: RowMajorMatrix<F>,
+        log_inv_rate: usize,
+    ) -> RowMajorMatrix<F> {
+        let log_height = p3_util::log2_strict_usize(message.height());
+        assert!(log_inv_rate <= log_height, "padding exceeds matrix height");
+        self.encode_batch(message, 0)
+    }
 }
 
 /// Reed-Solomon over the two-adic subgroup of order `2^(k + log_inv_rate)`: each column of
@@ -78,8 +97,9 @@ mod tests {
         padded
             .values
             .resize(message.values.len() * 4, BabyBear::ZERO);
-        let expected = dft.dft_batch(padded).to_row_major_matrix();
+        let expected = dft.dft_batch(padded.clone()).to_row_major_matrix();
 
+        assert_eq!(dft.encode_batch_padded(padded, 2), expected);
         assert_eq!(dft.encode_batch(message, 2), expected);
     }
 

--- a/sumcheck/src/commit.rs
+++ b/sumcheck/src/commit.rs
@@ -18,11 +18,9 @@ use crate::strategy::VariableOrder;
 ///
 /// Prefix order transposes the local folding block so the first folded
 /// variables become columns. Suffix order keeps the folding block as the row
-/// width. The message is built directly at codeword height, with the tail
-/// left at `F::ZERO`, and passed to `encoder` at `log_inv_rate = 0`: an
-/// already-padded message at rate zero is the same computation as padding an
-/// unexpanded one at the real rate, so this is exactly what the encoder would
-/// have built internally, without the extra allocation and copy.
+/// width. The message is built directly at codeword height, with a zero tail.
+/// Passing the original rate through [`Encoder::encode_batch_padded`] lets the
+/// encoder skip zero-coefficient work while preserving this fused allocation.
 pub fn commit_base<F, E, MT, Challenger>(
     order: VariableOrder,
     encoder: &E,
@@ -58,7 +56,7 @@ where
     let message = RowMajorMatrix::new(values, width);
 
     let encoded = info_span!("encode", height = codeword_height, width)
-        .in_scope(|| encoder.encode_batch(message, 0));
+        .in_scope(|| encoder.encode_batch_padded(message, starting_log_inv_rate));
 
     let (root, prover_data) = info_span!("commit_matrix").in_scope(|| mmcs.commit_matrix(encoded));
     challenger.observe(root.clone());


### PR DESCRIPTION
## Summary
Stacked on #2042 (binary-field) — this PR's diff is the 10 binary-dft-specific commits on top of it; it will shrink to just those once #2042 merges.

- Generate the polynomial-basis twiddle schedule incrementally (`Twiddles`) instead of rebuilding each stage's twiddles from scratch
- Keep adjacent small stages resident in cache-sized tiles rather than round-tripping through memory per stage
- Consume fused constant-twiddle field kernels and specialize portable twiddle products by subfield
- Return identity low-degree extensions directly, encode cosets in the destination allocation, and extend only new polynomial-basis cosets, avoiding redundant copies
- Size parallel work to actual conversion/butterfly cost instead of a fixed threshold

## Test plan
- [x] `cargo test -p p3-binary-dft` — all passing (42 unit + 2 integration)
- [x] `cargo clippy -p p3-binary-dft --all-targets -- -D warnings` — clean
- [x] `cargo check --workspace --all-targets` — clean
- [x] Benchmarked against `main` (`cargo bench -p p3-binary-dft`): `ntt/128/hybrid` (the `PolyBasisNtt` path these commits target) measures -3.7% to -6.2% consistently across all four domain sizes tested