### PR TITLE
fix(circle): account for transition selectors in quotient sizing

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -171,6 +171,10 @@ pub trait BaseAir<F>: Sync {
     /// Normally the prover runs a full symbolic evaluation to compute this.
     /// Overriding this method lets both the prover and verifier skip that
     /// pass when only the degree (not the full constraint list) is needed.
+    /// Domains with a full trace-space transition selector, such as Circle,
+    /// still infer the domain-specific degree and take the maximum of it and
+    /// this hint. The cached degree multiple used by this hint treats transition
+    /// selectors as degree zero and cannot bound their repeated products there.
     ///
     /// The value must be an upper bound on the degree multiple of every
     /// constraint (base and extension). It does not need to be tight, but

--- a/air/src/symbolic/expression.rs
+++ b/air/src/symbolic/expression.rs
@@ -49,6 +49,13 @@ impl<F: Field> SymLeaf for BaseLeaf<F> {
         }
     }
 
+    fn degree_multiple_with_transition(&self, transition_degree: usize) -> usize {
+        match self {
+            Self::IsTransition => transition_degree,
+            _ => self.degree_multiple(),
+        }
+    }
+
     fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
         match self {
             Self::Variable(v) => v.poly_degree(trace_len, periodic_periods),
@@ -351,6 +358,17 @@ mod tests {
 
         // The period-2 column has degree `N - N/2 = N/2`; each squaring doubles it.
         assert_eq!(expr.poly_degree(N, &[2]), (N / 2) << DEPTH);
+        assert_eq!(expr.degree_multiple_with_transition(1), 1 << DEPTH);
+    }
+
+    #[test]
+    fn degree_multiple_counts_every_transition_factor() {
+        let transition = SymbolicExpression::<BabyBear>::Leaf(BaseLeaf::IsTransition);
+        let main =
+            SymbolicExpression::from(SymbolicVariable::new(BaseEntry::Main { offset: 0 }, 0));
+        let expr = transition.clone().cube() * (main.cube() - transition);
+        assert_eq!(expr.degree_multiple_with_transition(0), 3);
+        assert_eq!(expr.degree_multiple_with_transition(1), 6);
     }
 
     #[test]

--- a/air/src/symbolic/expression_ext.rs
+++ b/air/src/symbolic/expression_ext.rs
@@ -48,6 +48,13 @@ impl<F: Field, EF: ExtensionField<F>> SymLeaf for ExtLeaf<F, EF> {
         }
     }
 
+    fn degree_multiple_with_transition(&self, transition_degree: usize) -> usize {
+        match self {
+            Self::Base(e) => e.degree_multiple_with_transition(transition_degree),
+            _ => self.degree_multiple(),
+        }
+    }
+
     fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
         match self {
             Self::Base(e) => e.poly_degree(trace_len, periodic_periods),

--- a/air/src/symbolic/mod.rs
+++ b/air/src/symbolic/mod.rs
@@ -35,6 +35,11 @@ pub trait SymLeaf: Clone + core::fmt::Debug {
     /// Returns the degree multiple of this leaf.
     fn degree_multiple(&self) -> usize;
 
+    /// Degree multiple with a domain-specific weight for the transition selector.
+    fn degree_multiple_with_transition(&self, _transition_degree: usize) -> usize {
+        self.degree_multiple()
+    }
+
     /// Returns the exact polynomial degree of this leaf over a trace of length
     /// `trace_len`, given the period of each periodic column.
     fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize;
@@ -108,6 +113,19 @@ impl<A: SymLeaf> SymbolicExpr<A> {
         }
     }
 
+    /// Degree multiple counting each transition-selector factor with the given weight.
+    ///
+    /// Weight zero uses the cached two-adic degree. Weight one also counts Circle
+    /// transition selectors as full trace-space polynomials. Periodic columns
+    /// retain their full degree multiple: Circle's doubling map does not give
+    /// them the reduced degree of a two-adic periodic polynomial.
+    pub fn degree_multiple_with_transition(&self, transition_degree: usize) -> usize {
+        if transition_degree == 0 {
+            return self.degree_multiple();
+        }
+        self.degree_with(&|leaf| leaf.degree_multiple_with_transition(transition_degree))
+    }
+
     /// Returns the exact polynomial degree of this expression over a trace of
     /// length `trace_len`, given the period of each periodic column (indexed by
     /// periodic column index).
@@ -116,47 +134,50 @@ impl<A: SymLeaf> SymbolicExpr<A> {
     /// polynomial it is and accounts for the reduced degree of periodic columns,
     /// unlike the trace-size-independent [`Self::degree_multiple`].
     pub fn poly_degree(&self, trace_len: usize, periodic_periods: &[usize]) -> usize {
+        self.degree_with(&|leaf| leaf.poly_degree(trace_len, periodic_periods))
+    }
+
+    fn degree_with(&self, leaf_degree: &impl Fn(&A) -> usize) -> usize {
         // The expression is a DAG: arithmetic nodes share `Arc` children, so a naive
         // recursion would revisit shared subtrees exponentially. Memoize on node
         // identity to keep this linear in the number of distinct nodes.
         let mut cache: BTreeMap<*const Self, usize> = BTreeMap::new();
-        self.poly_degree_memo(trace_len, periodic_periods, &mut cache)
+        self.degree_memo(leaf_degree, &mut cache)
     }
 
-    fn poly_degree_memo(
+    fn degree_memo(
         &self,
-        trace_len: usize,
-        periodic_periods: &[usize],
+        leaf_degree: &impl Fn(&A) -> usize,
         cache: &mut BTreeMap<*const Self, usize>,
     ) -> usize {
         match self {
-            Self::Leaf(a) => a.poly_degree(trace_len, periodic_periods),
-            Self::Add { x, y, .. } | Self::Sub { x, y, .. } => {
-                Self::child_poly_degree(x, trace_len, periodic_periods, cache).max(
-                    Self::child_poly_degree(y, trace_len, periodic_periods, cache),
-                )
-            }
-            Self::Neg { x, .. } => Self::child_poly_degree(x, trace_len, periodic_periods, cache),
+            Self::Leaf(a) => leaf_degree(a),
+            Self::Add { x, y, .. } | Self::Sub { x, y, .. } => Self::child_degree(
+                x,
+                leaf_degree,
+                cache,
+            )
+            .max(Self::child_degree(y, leaf_degree, cache)),
+            Self::Neg { x, .. } => Self::child_degree(x, leaf_degree, cache),
             Self::Mul { x, y, .. } => {
-                Self::child_poly_degree(x, trace_len, periodic_periods, cache)
-                    + Self::child_poly_degree(y, trace_len, periodic_periods, cache)
+                Self::child_degree(x, leaf_degree, cache)
+                    + Self::child_degree(y, leaf_degree, cache)
             }
         }
     }
 
     /// Degree of an `Arc`-shared child, looked up by pointer identity so each
     /// distinct node is evaluated at most once.
-    fn child_poly_degree(
+    fn child_degree(
         node: &Arc<Self>,
-        trace_len: usize,
-        periodic_periods: &[usize],
+        leaf_degree: &impl Fn(&A) -> usize,
         cache: &mut BTreeMap<*const Self, usize>,
     ) -> usize {
         let key = Arc::as_ptr(node);
         if let Some(&degree) = cache.get(&key) {
             return degree;
         }
-        let degree = node.poly_degree_memo(trace_len, periodic_periods, cache);
+        let degree = node.degree_memo(leaf_degree, cache);
         cache.insert(key, degree);
         degree
     }

--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 
 use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
-use p3_commit::Pcs;
+use p3_commit::{Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace};
 use p3_lookup::{InteractionSymbolicBuilder, LogUpGadget, Lookups};
 use p3_matrix::Matrix;
@@ -21,7 +21,7 @@ use p3_util::log2_strict_usize;
 
 use crate::config::{Challenge, Commitment, Domain, StarkGenericConfig as SGC};
 use crate::prover::StarkInstance;
-use crate::symbolic::get_log_num_quotient_chunks;
+use crate::symbolic::get_log_num_quotient_chunks_for_domain;
 
 /// Per-instance metadata for a preprocessed trace that lives inside a
 /// global preprocessed commitment.
@@ -321,14 +321,15 @@ where
                 // Base trace length `N` (before any ZK extension), matching what the
                 // prover and verifier feed the degree model for this instance.
                 let trace_len = 1usize << (ext_db - is_zk);
+                let domain = pcs.natural_domain_for_degree(trace_len);
                 let unpacked = Lookups::<Val<SC>>::from_air::<SC::Challenge, A>(air);
 
                 // `log_chunks` fixes the quotient bucket: n_chunks = 2^log_chunks.
                 let log_chunks =
-                    get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                    get_log_num_quotient_chunks_for_domain::<_, SC::Challenge, A, _>(
                         air,
                         AirLayout::from_air(air),
-                        trace_len,
+                        domain,
                         &unpacked,
                         is_zk,
                         &lookup_gadget,
@@ -340,16 +341,21 @@ where
                 //  => d <= 2^log_chunks + 1 - is_zk
                 let free_budget = (1usize << log_chunks) + 1 - is_zk;
                 let budget = free_budget.max(override_budget);
-                let packed = unpacked.pack_same_bus(&lookup_gadget, budget);
+                let packed = unpacked.pack_same_bus_with_degree(budget, |lookup| {
+                    lookup_gadget.constraint_degree_with_transition(
+                        lookup,
+                        domain.transition_degree_multiple(),
+                    )
+                });
 
                 if override_budget <= free_budget {
                     // No deliberate override: the fold must not have moved the quotient bucket,
                     // exactly as before.
                     debug_assert_eq!(
-                        get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                        get_log_num_quotient_chunks_for_domain::<_, SC::Challenge, A, _>(
                             air,
                             AirLayout::from_air(air),
-                            trace_len,
+                            domain,
                             &packed,
                             is_zk,
                             &lookup_gadget,
@@ -365,10 +371,10 @@ where
                     // `StarkSecurityParams::new` states as a buildability condition; without
                     // this check nothing else on the prove or verify path detects a violation.
                     let packed_log_chunks =
-                        get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                        get_log_num_quotient_chunks_for_domain::<_, SC::Challenge, A, _>(
                             air,
                             AirLayout::from_air(air),
-                            trace_len,
+                            domain,
                             &packed,
                             is_zk,
                             &lookup_gadget,

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -30,7 +30,7 @@ use crate::common::ProverData;
 use crate::config::{Challenge, Domain, StarkGenericConfig as SGC, Val};
 use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof, OpenedValuesWithLookups};
 use crate::symbolic::{
-    get_constraint_layout, get_log_num_quotient_chunks, get_symbolic_constraints,
+    get_constraint_layout, get_log_num_quotient_chunks_for_domain, get_symbolic_constraints,
 };
 use crate::transcript::BatchTranscript;
 
@@ -191,10 +191,10 @@ where
             // Infer the log of the quotient polynomial degree from symbolic analysis.
             let lq_chunks =
                 info_span!("infer log of constraint degree", air_idx = i).in_scope(|| {
-                    get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                    get_log_num_quotient_chunks_for_domain::<_, SC::Challenge, A, _>(
                         air,
                         layout,
-                        degrees[i],
+                        pcs.natural_domain_for_degree(degrees[i]),
                         all_lookups[i],
                         config.is_zk(),
                         &lookup_gadget,

--- a/batch-stark/src/symbolic.rs
+++ b/batch-stark/src/symbolic.rs
@@ -5,6 +5,7 @@ use p3_air::symbolic::{
     AirLayout, ConstraintLayout, SymbolicExpression, SymbolicExpressionExt,
     constraint_degree_from_poly_degree,
 };
+use p3_commit::PolynomialSpace;
 use p3_field::{Algebra, ExtensionField, Field};
 use p3_lookup::{InteractionSymbolicBuilder, Lookup, LookupProtocol};
 use p3_util::log2_ceil_usize;
@@ -50,6 +51,54 @@ where
     builder.constraint_layout()
 }
 
+/// Quotient sizing using the domain's transition-selector degree.
+///
+/// Circle needs a full symbolic bound, including periodic columns and every
+/// transition-selector factor. A domain-independent hint alone cannot supply it.
+pub fn get_log_num_quotient_chunks_for_domain<F, EF, A, LG>(
+    air: &A,
+    layout: AirLayout,
+    domain: impl PolynomialSpace<Val = F>,
+    contexts: &[Lookup<F>],
+    is_zk: usize,
+    lookup_gadget: &LG,
+) -> usize
+where
+    F: Field,
+    EF: ExtensionField<F>,
+    A: Air<InteractionSymbolicBuilder<F, EF>>,
+    SymbolicExpressionExt<F, EF>: Algebra<EF>,
+    LG: LookupProtocol,
+{
+    let transition_degree = domain.transition_degree_multiple();
+    if transition_degree == 0 {
+        return get_log_num_quotient_chunks(
+            air,
+            layout,
+            domain.size(),
+            contexts,
+            is_zk,
+            lookup_gadget,
+        );
+    }
+    assert!(is_zk <= 1, "is_zk must be either 0 or 1");
+
+    let (base, extension) = get_symbolic_constraints(air, layout, contexts, lookup_gadget);
+    let degree = base
+        .iter()
+        .map(|c| c.degree_multiple_with_transition(transition_degree))
+        .chain(
+            extension
+                .iter()
+                .map(|c| c.degree_multiple_with_transition(transition_degree)),
+        )
+        .max()
+        .unwrap_or(0)
+        .max(air.max_constraint_degree().unwrap_or(0));
+    log2_ceil_usize((degree + is_zk).max(2) - 1)
+}
+
+/// Two-adic quotient sizing; use [`get_log_num_quotient_chunks_for_domain`] for other domains.
 pub fn get_log_num_quotient_chunks<F, EF, A, LG>(
     air: &A,
     layout: AirLayout,

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -25,7 +25,7 @@ use crate::common::CommonData;
 use crate::config::{Challenge, Commitment, Domain, PcsError, StarkGenericConfig as SGC, Val};
 use crate::error::BatchVerificationError;
 use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof};
-use crate::symbolic::get_log_num_quotient_chunks;
+use crate::symbolic::get_log_num_quotient_chunks_for_domain;
 use crate::transcript::BatchTranscript;
 
 /// What [`commitments_with_opening_points`] builds: the PCS opening argument itself — one
@@ -428,10 +428,10 @@ where
         };
         let log_num_chunks =
             info_span!("infer log of constraint degree", air_idx = i).in_scope(|| {
-                get_log_num_quotient_chunks::<Val<SC>, SC::Challenge, A, LogUpGadget>(
+                get_log_num_quotient_chunks_for_domain::<_, SC::Challenge, A, _>(
                     air,
                     layout,
-                    1usize << base_db,
+                    pcs.natural_domain_for_degree(1usize << base_db),
                     &all_lookups[i],
                     config.is_zk(),
                     &lookup_gadget,

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -1682,6 +1682,158 @@ fn test_circle_stark_batch() -> Result<(), impl Debug> {
         .map_err(|e| format!("Verification failed: {:?}", e))
 }
 
+#[derive(Clone)]
+struct NonlinearTransitionAir {
+    degree_hint: Option<usize>,
+}
+
+impl<F> BaseAir<F> for NonlinearTransitionAir {
+    fn width(&self) -> usize {
+        1
+    }
+
+    fn max_constraint_degree(&self) -> Option<usize> {
+        self.degree_hint
+    }
+}
+
+impl<AB: AirBuilder> Air<AB> for NonlinearTransitionAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice()[0];
+        let next = main.next_slice()[0];
+        builder.when_first_row().assert_eq(local, AB::Expr::TWO);
+        builder
+            .when_transition()
+            .assert_eq(next, local.into().cube() + AB::Expr::ONE);
+    }
+}
+
+fn check_circle_nonlinear_transition(with_hint: bool) {
+    let config = make_circle_config();
+    let airs = [
+        NonlinearTransitionAir {
+            degree_hint: with_hint.then_some(3),
+        },
+        NonlinearTransitionAir {
+            degree_hint: with_hint.then_some(3),
+        },
+    ];
+    let traces = [16, 32].map(|height| {
+        let mut value = CircleVal::TWO;
+        RowMajorMatrix::new_col(
+            (0..height)
+                .map(|_| {
+                    let current = value;
+                    value = value.cube() + CircleVal::ONE;
+                    current
+                })
+                .collect(),
+        )
+    });
+    let instances = airs
+        .iter()
+        .zip(&traces)
+        .map(|(air, trace)| StarkInstance {
+            air,
+            trace,
+            public_values: vec![],
+        })
+        .collect::<Vec<_>>();
+    let prover_data = ProverData::empty(airs.len());
+    let proof = prove_batch(&config, &instances, &prover_data);
+    assert!(
+        verify_batch(
+            &config,
+            &airs,
+            &proof,
+            &[vec![], vec![]],
+            &prover_data.common
+        )
+        .is_ok(),
+        "valid Circle transitions rejected (hint={with_hint})"
+    );
+}
+
+#[test]
+fn circle_nonlinear_transition_without_hint() {
+    check_circle_nonlinear_transition(false);
+}
+
+#[test]
+fn circle_nonlinear_transition_with_hint() {
+    check_circle_nonlinear_transition(true);
+}
+
+#[derive(Clone)]
+struct CircleTransitionLookupAir {
+    receive: bool,
+}
+
+impl<F> BaseAir<F> for CircleTransitionLookupAir {
+    fn width(&self) -> usize {
+        2
+    }
+
+    fn max_constraint_degree(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+impl<AB: PermutationAirBuilder + InteractionBuilder> Air<AB> for CircleTransitionLookupAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let transition = builder.is_transition();
+        for &value in main.current_slice() {
+            builder.push_interaction(
+                "transition-payload",
+                [transition.clone() * value],
+                if self.receive { 1 } else { -1 },
+            );
+        }
+    }
+}
+
+#[test]
+fn circle_lookup_packing_preserves_quotient_budget() {
+    let config = make_circle_config();
+    let airs = [
+        CircleTransitionLookupAir { receive: true },
+        CircleTransitionLookupAir { receive: false },
+    ];
+    let trace = RowMajorMatrix::new(
+        (0..16)
+            .flat_map(|i| [CircleVal::from_u32(i), CircleVal::from_u32(i * i + 1)])
+            .collect(),
+        2,
+    );
+    let instances = airs
+        .iter()
+        .map(|air| StarkInstance {
+            air,
+            trace: &trace,
+            public_values: vec![],
+        })
+        .collect::<Vec<_>>();
+    let prover_data = ProverData::from_instances(&config, &instances);
+    for lookups in &prover_data.common.lookups {
+        // Each transition * payload has degree 2. Two such tuples would pin
+        // at degree 5 and exceed the unpacked degree-3 quotient bucket.
+        assert_eq!(lookups.len(), 2);
+    }
+    let proof = prove_batch(&config, &instances, &prover_data);
+    assert!(
+        verify_batch(
+            &config,
+            &airs,
+            &proof,
+            &[vec![], vec![]],
+            &prover_data.common
+        )
+        .is_ok()
+    );
+}
+
 type CompatCase<Config, V> = (
     Config,
     Vec<DemoAirWithLookups>,

--- a/circle/src/domain.rs
+++ b/circle/src/domain.rs
@@ -149,6 +149,12 @@ impl<F: ComplexExtendable> PolynomialSpace for CircleDomain<F> {
         1 << self.log_n
     }
 
+    fn transition_degree_multiple(&self) -> usize {
+        // `1 - normalized_last_selector` lies in the same FFT space as a trace
+        // column; unlike the two-adic selector its degree grows with the trace.
+        1
+    }
+
     fn first_point(&self) -> Self::Val {
         self.shift.to_projective_line().unwrap()
     }

--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -58,6 +58,15 @@ pub trait PolynomialSpace: Copy {
     /// The number of elements of the space.
     fn size(&self) -> usize;
 
+    /// Degree multiple of the transition selector in units of a trace column.
+    ///
+    /// The default is for two-adic domains, whose linear selector has degree
+    /// independent of the trace length. Domains using a full trace-space
+    /// selector, such as Circle, return one instead.
+    fn transition_degree_multiple(&self) -> usize {
+        0
+    }
+
     /// The first point in the space.
     fn first_point(&self) -> Self::Val;
 

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -106,6 +106,56 @@ impl LogUpGadget {
         Self {}
     }
 
+    /// Degree of the fraction-pin constraint, using the domain's transition degree.
+    ///
+    /// For `U * f - V`, the bound is `max(1 + deg(U), deg(V))`.
+    /// Each denominator factor contributes its combined-element degree; each
+    /// numerator term contributes its multiplicity and all other factors.
+    pub fn constraint_degree_with_transition<F: Field>(
+        &self,
+        lookup: &Lookup<F>,
+        transition_degree: usize,
+    ) -> usize {
+        assert!(lookup.multiplicities.len() == lookup.elements.len());
+        let degree =
+            |expr: &SymbolicExpression<F>| expr.degree_multiple_with_transition(transition_degree);
+
+        // Exclusive columns multiplex branches instead of multiplying denominators:
+        // D = sum(flag * (alpha - combine)) + (1 - sum(flag)), N = sum(flag * mult).
+        if let Some(flags) = &lookup.flags {
+            let deg_denom = flags
+                .iter()
+                .zip_eq(&lookup.elements)
+                .map(|(flag, elems)| degree(flag) + elems.iter().map(&degree).max().unwrap_or(0))
+                .chain(flags.iter().map(&degree))
+                .max()
+                .unwrap_or(0);
+            let deg_num = flags
+                .iter()
+                .zip_eq(&lookup.multiplicities)
+                .map(|(flag, m)| degree(flag) + degree(m))
+                .max()
+                .unwrap_or(0);
+            return (1 + deg_denom).max(deg_num);
+        }
+
+        let mut degs = Vec::with_capacity(lookup.elements.len());
+        let mut deg_sum = 0;
+        for elems in &lookup.elements {
+            let deg = elems.iter().map(&degree).max().unwrap_or(0);
+            degs.push(deg);
+            deg_sum += deg;
+        }
+        let deg_num = lookup
+            .multiplicities
+            .iter()
+            .zip(degs)
+            .map(|(m, deg)| degree(m) + deg_sum - deg)
+            .max()
+            .unwrap_or(0);
+        (1 + deg_sum).max(deg_num)
+    }
+
     /// Computes the combined elements for each tuple using the challenge `beta`:
     /// `combined_elements[i] = ∑_j elements[i][j] * β^(k-1-j), for a tuple of width k`
     fn combine_elements<AB, E>(
@@ -443,64 +493,7 @@ impl LookupProtocol for LogUpGadget {
     ///
     /// The constraint degree is then: `max(1 + deg(U_c), deg(V_c))`
     fn constraint_degree<F: Field>(&self, lookup: &Lookup<F>) -> usize {
-        assert!(lookup.multiplicities.len() == lookup.elements.len());
-
-        // Exclusive column: the multiplex takes the per-branch maximum degree.
-        //
-        //   D = sum_k flag_k * (alpha - combine_k) + (1 - sum_k flag_k)
-        //   N = sum_k flag_k * mult_k
-        //
-        // The challenges are constant.
-        // So combine_k has the degree of its widest element.
-        // Each branch then adds its flag's degree on top.
-        if let Some(flags) = &lookup.flags {
-            let deg_denom = flags
-                .iter()
-                .zip_eq(&lookup.elements)
-                .map(|(flag, elems)| {
-                    let elem_deg = elems.iter().map(|e| e.degree_multiple()).max().unwrap_or(0);
-                    flag.degree_multiple() + elem_deg
-                })
-                // The fallback term (1 - sum flag) carries only the flag degree.
-                .chain(flags.iter().map(SymbolicExpression::degree_multiple))
-                .max()
-                .unwrap_or(0);
-
-            let deg_num = flags
-                .iter()
-                .zip_eq(&lookup.multiplicities)
-                .map(|(flag, m)| flag.degree_multiple() + m.degree_multiple())
-                .max()
-                .unwrap_or(0);
-
-            return (1 + deg_denom).max(deg_num);
-        }
-
-        let n = lookup.multiplicities.len();
-
-        // Compute degrees in a single pass.
-        let mut degs = Vec::with_capacity(n);
-        let mut deg_sum = 0;
-        for elems in &lookup.elements {
-            let deg = elems
-                .iter()
-                .map(|elt| elt.degree_multiple())
-                .max()
-                .unwrap_or(0);
-            degs.push(deg);
-            deg_sum += deg;
-        }
-
-        // Compute 1 + degree(denominator).
-        let deg_denom_constr = 1 + deg_sum;
-
-        // Compute degree(numerator).
-        let deg_num = (0..n)
-            .map(|i| lookup.multiplicities[i].degree_multiple() + deg_sum - degs[i])
-            .max()
-            .unwrap_or(0);
-
-        deg_denom_constr.max(deg_num)
+        self.constraint_degree_with_transition(lookup, 0)
     }
 
     #[instrument(name = "generate lookup permutation", skip_all, level = "debug")]

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -114,6 +114,24 @@ fn constraint_degree_matches_formula() {
 }
 
 #[test]
+fn constraint_degree_counts_transition_payloads_multiplicities_and_flags() {
+    let transition = SymbolicExpression::<F>::Leaf(BaseLeaf::IsTransition);
+    let mut lookup = Lookup {
+        kind: Kind::Local,
+        elements: vec![vec![transition.clone().square()]],
+        multiplicities: vec![transition.exp_u64(5)],
+        count_weight: 1,
+        column: 0,
+        flags: None,
+    };
+    assert_eq!(LogUpGadget.constraint_degree(&lookup), 1);
+    assert_eq!(LogUpGadget.constraint_degree_with_transition(&lookup, 1), 5);
+    lookup.flags = Some(vec![transition]);
+    assert_eq!(LogUpGadget.constraint_degree(&lookup), 1);
+    assert_eq!(LogUpGadget.constraint_degree_with_transition(&lookup, 1), 6);
+}
+
+#[test]
 fn compute_combined_sum_terms_matches_definition() {
     // Single tuple with one element.
     //

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -247,6 +247,19 @@ impl<F: Field> Lookups<F> {
     /// - `max_degree` — the largest degree that leaves the quotient cost unchanged.
     #[must_use]
     pub fn pack_same_bus<LG: LookupProtocol>(self, gadget: &LG, max_degree: usize) -> Self {
+        self.pack_same_bus_with_degree(max_degree, |lookup| gadget.constraint_degree(lookup))
+    }
+
+    /// Like [`Self::pack_same_bus`], with a domain-aware fraction-pin degree bound.
+    ///
+    /// `constraint_degree` must upper-bound the merged lookup's fraction-pin degree
+    /// in the same units as `max_degree`.
+    #[must_use]
+    pub fn pack_same_bus_with_degree(
+        self,
+        max_degree: usize,
+        constraint_degree: impl Fn(&Lookup<F>) -> usize,
+    ) -> Self {
         // Locals keep their leading columns, untouched.
         let mut packed: Vec<Lookup<F>> = Vec::with_capacity(self.0.len());
         // Globals bucket by bus name, in first-appearance order.
@@ -290,7 +303,7 @@ impl<F: Field> Lookups<F> {
                         cur.multiplicities
                             .extend(member.multiplicities.iter().cloned());
 
-                        if gadget.constraint_degree(&cur) <= max_degree {
+                        if constraint_degree(&cur) <= max_degree {
                             // Within budget: keep the merge.
                             // Each tuple holds its own per-row query bound, so the bounds add.
                             cur.count_weight = cur

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -18,7 +18,7 @@ use tracing::{debug_span, info_span, instrument};
 use crate::{
     Commitments, Domain, OpenedValues, PackedChallenge, PackedVal, PreprocessedProverData, Proof,
     ProverConstraintFolder, StarkGenericConfig, Val, get_constraint_layout,
-    get_log_num_quotient_chunks,
+    get_log_num_quotient_chunks_for_domain,
 };
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use crate::{VectorizedChallenge, VectorizedConstraintFolder, VectorizedVal};
@@ -156,7 +156,7 @@ where
     // Y_i's will be the `i`'th element of the next row and the Z_i's will be evaluations of
     // selector polynomials on the given row index.
     //
-    // When we convert to working with polynomials, the `X_i`'s and `Y_i`'s will be replaced by the
+    // For two-adic domains, the `X_i`'s and `Y_i`'s will be replaced by the
     // degree `N - 1` polynomials `T_i(x)` and `T_i(hx)` respectively. The selector polynomials are
     // a little more complicated, however.
     //
@@ -176,27 +176,29 @@ where
     //          C(x) = C(T_1(x), ..., T_w(x), T_1(hx), ... T_w(hx), S_1(x), S_2(x), S_3(x))
     // We get the constraint bound:
     //          deg(C(x)) <= deg(C) * (N - 1) + 1
-    // The `+1` is due to the `is_transition` selector which is not accounted for in `deg(C)`. Note
-    // that S_i^2 should never appear in a constraint as it should just be replaced by `S_i`.
+    // The `+1` assumes at most one `is_transition` factor per term. Circle instead
+    // counts each transition factor at full trace-space degree.
     //
     // For now in comments we assume that `deg(C) = 3` meaning `deg(C(x)) <= 3N - 2`
+
+    let pcs = config.pcs();
+    // Get the subgroup `H` of size `N`, or a standard-position twin coset for Circle.
+    let trace_domain = pcs.natural_domain_for_degree(degree);
 
     // From the degree of the constraint polynomial, compute the number
     // of quotient polynomials we will split Q(x) into. This is chosen to
     // always be a power of 2.
-    let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, degree, config.is_zk());
+    let log_num_quotient_chunks = get_log_num_quotient_chunks_for_domain::<Val<SC>, A>(
+        air,
+        layout,
+        trace_domain,
+        config.is_zk(),
+    );
 
     let num_quotient_chunks = 1 << (log_num_quotient_chunks + config.is_zk());
 
-    // Initialize the PCS and the Challenger.
-    let pcs = config.pcs();
+    // Initialize the Challenger.
     let mut challenger = config.initialise_challenger();
-
-    // Get the subgroup `H` of size `N`. We treat each column `T_i` of
-    // the trace as an evaluation vector of polynomials `T_i(x)` over `H`.
-    // (In the Circle STARK case `H` is instead a standard position twin coset of size `N`)
-    let trace_domain = pcs.natural_domain_for_degree(degree);
 
     // When ZK is enabled, we need to use an extended domain of size `2N` as we will
     // add random values to the trace.

--- a/uni-stark/src/symbolic.rs
+++ b/uni-stark/src/symbolic.rs
@@ -1,11 +1,58 @@
 //! STARK-specific quotient polynomial degree calculations.
 
 use p3_air::Air;
-use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_max_constraint_degree_extension};
+use p3_air::symbolic::{
+    AirLayout, SymbolicAirBuilder, get_all_symbolic_constraints,
+    get_max_constraint_degree_extension,
+};
+use p3_commit::PolynomialSpace;
 use p3_field::{ExtensionField, Field};
 use p3_util::log2_ceil_usize;
 use tracing::instrument;
 
+/// Size the quotient using the trace domain's transition-selector degree.
+///
+/// Two-adic domains retain the cached degree and hint fast paths. Circle uses
+/// full trace-space degrees for selectors and periodic columns. Its symbolic
+/// degree is checked even with a hint, since the hint does not encode how many
+/// transition factors occur in a constraint.
+pub fn get_log_num_quotient_chunks_for_domain<F, A>(
+    air: &A,
+    layout: AirLayout,
+    domain: impl PolynomialSpace<Val = F>,
+    is_zk: usize,
+) -> usize
+where
+    F: Field,
+    A: Air<SymbolicAirBuilder<F>>,
+{
+    let transition_degree = domain.transition_degree_multiple();
+    if transition_degree == 0 {
+        return get_log_num_quotient_chunks(air, layout, domain.size(), is_zk);
+    }
+
+    assert!(is_zk <= 1, "is_zk must be either 0 or 1");
+    let (base, extension) = get_all_symbolic_constraints::<F, F, A>(air, layout);
+    let degree = base
+        .iter()
+        .map(|c| c.degree_multiple_with_transition(transition_degree))
+        .chain(
+            extension
+                .iter()
+                .map(|c| c.degree_multiple_with_transition(transition_degree)),
+        )
+        .max()
+        .unwrap_or(0)
+        .max(air.max_constraint_degree().unwrap_or(0));
+
+    // Circle STARKs, section 5.3: an odd constraint degree d gives a quotient
+    // in the FFT subspace L^-_{(d-1)N}. For even d >= 4, rounding d-1 up to a
+    // power of two provides strict room; d <= 2 uses Circle's doubled disjoint
+    // domain. Thus the same chunk formula applies once d counts all selectors.
+    log2_ceil_usize((degree + is_zk).max(2) - 1)
+}
+
+/// Two-adic quotient sizing; use [`get_log_num_quotient_chunks_for_domain`] for other domains.
 #[instrument(skip_all, level = "debug")]
 pub fn get_log_num_quotient_chunks<F, A>(
     air: &A,
@@ -42,6 +89,7 @@ where
     get_log_quotient_degree_extension(air, layout, trace_len, is_zk)
 }
 
+/// Two-adic quotient sizing, including extension constraints.
 #[instrument(
     name = "infer log of base and extension constraint degree",
     skip_all,

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -16,7 +16,7 @@ use p3_util::{checked_log_size_sum, checked_pow2};
 use tracing::instrument;
 
 use crate::error::{InvalidProofShapeError, PeriodicColumnError, VerificationError};
-use crate::symbolic::get_log_num_quotient_chunks;
+use crate::symbolic::get_log_num_quotient_chunks_for_domain;
 use crate::{
     AirLayout, Domain, PcsError, PreprocessedVerifierKey, Proof, StarkGenericConfig, Val,
     VerifierConstraintFolder,
@@ -334,8 +334,12 @@ where
     // measures trace columns as degree-`(N - 1)` polynomials and accounts for ZK
     // separately via `is_zk`.
     let base_degree = 1usize << base_degree_bits;
-    let log_num_quotient_chunks =
-        get_log_num_quotient_chunks::<Val<SC>, A>(air, layout, base_degree, config.is_zk());
+    let log_num_quotient_chunks = get_log_num_quotient_chunks_for_domain::<Val<SC>, A>(
+        air,
+        layout,
+        pcs.natural_domain_for_degree(base_degree),
+        config.is_zk(),
+    );
     let (_, num_quotient_chunks) = checked_log_size_sum(log_num_quotient_chunks, config.is_zk())
         .ok_or_else(|| InvalidProofShapeError::QuotientDomainTooLarge {
             air: None,

--- a/uni-stark/tests/fib_air.rs
+++ b/uni-stark/tests/fib_air.rs
@@ -1,6 +1,7 @@
 use core::borrow::Borrow;
+use std::borrow::Cow;
 
-use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_air::{Air, AirBuilder, BaseAir, ExtensionBuilder, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
 use p3_circle::CirclePcs;
@@ -230,6 +231,152 @@ fn make_circle_config() -> CircleConfig {
     };
     let challenger = CircleChallenger::from_hasher(vec![], byte_hash);
     CircleConfig::new(pcs, challenger)
+}
+
+struct NonlinearTransitionAir {
+    degree: usize,
+    transition_power: usize,
+    degree_hint: Option<usize>,
+    extension_constraint: bool,
+}
+
+impl<F> BaseAir<F> for NonlinearTransitionAir {
+    fn width(&self) -> usize {
+        1
+    }
+
+    fn max_constraint_degree(&self) -> Option<usize> {
+        self.degree_hint
+    }
+}
+
+impl<AB: ExtensionBuilder> Air<AB> for NonlinearTransitionAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice()[0];
+        let next = main.next_slice()[0];
+        builder.when_first_row().assert_eq(local, AB::Expr::TWO);
+        let guard = builder
+            .is_transition()
+            .exp_u64(self.transition_power as u64);
+        let constraint = guard * (next - local.into().exp_u64(self.degree as u64) - AB::Expr::ONE);
+        if self.extension_constraint {
+            builder.assert_zero_ext(AB::ExprEF::from(constraint));
+        } else {
+            builder.assert_zero(constraint);
+        }
+    }
+}
+
+fn check_circle_nonlinear_transition(with_hint: bool, extension_constraint: bool) {
+    let config = make_circle_config();
+    // Both sides of power-of-two quotient buckets, plus repeated guards.
+    for (degree, transition_power) in [(2, 1), (3, 1), (4, 1), (5, 1), (8, 1), (9, 1), (3, 3)] {
+        let air = NonlinearTransitionAir {
+            degree,
+            transition_power,
+            degree_hint: with_hint.then_some(degree),
+            extension_constraint,
+        };
+        let mut value = CircleVal::TWO;
+        let trace = RowMajorMatrix::new_col(
+            (0..16)
+                .map(|_| {
+                    let current = value;
+                    value = value.exp_u64(degree as u64) + CircleVal::ONE;
+                    current
+                })
+                .collect(),
+        );
+        let mut proof = prove(&config, &air, trace, &[]);
+        assert_eq!(
+            proof.opened_values.quotient_chunks.len(),
+            (degree + transition_power - 1).next_power_of_two(),
+        );
+        assert!(
+            verify(&config, &air, &proof, &[]).is_ok(),
+            "valid degree-{degree} Circle transition rejected (hint={with_hint})"
+        );
+        proof.opened_values.trace_local[0] += CircleChallenge::ONE;
+        assert!(verify(&config, &air, &proof, &[]).is_err());
+    }
+}
+
+#[test]
+fn circle_nonlinear_transition_without_hint() {
+    check_circle_nonlinear_transition(false, false);
+}
+
+#[test]
+fn circle_nonlinear_transition_with_hint() {
+    check_circle_nonlinear_transition(true, false);
+}
+
+#[test]
+fn circle_nonlinear_transition_extension_constraints() {
+    check_circle_nonlinear_transition(false, true);
+    check_circle_nonlinear_transition(true, true);
+}
+
+struct CirclePeriodicProductAir {
+    column: Vec<CircleVal>,
+    degree: u64,
+}
+
+impl BaseAir<CircleVal> for CirclePeriodicProductAir {
+    fn width(&self) -> usize {
+        1
+    }
+
+    fn num_periodic_columns(&self) -> usize {
+        1
+    }
+
+    fn periodic_columns(&self) -> Cow<'_, [Vec<CircleVal>]> {
+        Cow::Borrowed(core::slice::from_ref(&self.column))
+    }
+}
+
+impl<AB: AirBuilder<F = CircleVal>> Air<AB> for CirclePeriodicProductAir {
+    fn eval(&self, builder: &mut AB) {
+        let periodic: AB::Expr = builder.periodic_values()[0].into();
+        let local = builder.main().current_slice()[0];
+        builder.assert_eq(local, periodic.exp_u64(self.degree));
+    }
+}
+
+#[test]
+fn circle_periodic_products_use_full_trace_degree() {
+    let config = make_circle_config();
+    for degree in [3, 5, 9] {
+        let air = CirclePeriodicProductAir {
+            column: vec![CircleVal::TWO, CircleVal::from_u32(3)],
+            degree,
+        };
+        let trace =
+            RowMajorMatrix::new_col((0..16).map(|i| air.column[i % 2].exp_u64(degree)).collect());
+        let proof = prove(&config, &air, trace, &[]);
+        assert_eq!(
+            proof.opened_values.quotient_chunks.len(),
+            (degree - 1) as usize
+        );
+        assert!(verify(&config, &air, &proof, &[]).is_ok());
+    }
+}
+
+#[test]
+#[cfg(not(debug_assertions))]
+fn circle_invalid_nonlinear_transition_is_rejected() {
+    let config = make_circle_config();
+    let air = NonlinearTransitionAir {
+        degree: 3,
+        transition_power: 3,
+        degree_hint: Some(3),
+        extension_constraint: false,
+    };
+    let trace = RowMajorMatrix::new_col(vec![CircleVal::TWO; 16]);
+    let proof = prove(&config, &air, trace, &[]);
+    assert!(verify(&config, &air, &proof, &[]).is_err());
 }
 
 fn circle_compat_case() -> (


### PR DESCRIPTION
## Summary

Circle's transition selector is a full trace-space polynomial, but the shared quotient-sizing model treats it as degree zero. This undersizes the quotient for valid nonlinear transitions and causes `OodEvaluationMismatch`.

- Add a domain-specific transition degree and use it consistently in uni-stark and batch-stark proving, verification, and lookup preparation.
- Count every transition-selector factor, retain full Circle periodic-column degrees, and include both base and extension constraints even when an AIR supplies a degree hint.
- Keep lookup packing within the corrected quotient budget, including selectors in payloads, multiplicities, and flags.
- Preserve the existing two-adic cached/hint fast paths and memoize symbolic DAG traversal.

closes #575 

## Validation

The original nonlinear-transition regressions failed before the fix in both uni-stark and batch-stark, with and without hints. Added coverage also checks quotient bucket boundaries, repeated guards, extension constraints, periodic products, lookup packing, tampered openings, and rejection of invalid traces in release mode. Existing Circle and two-adic compatibility fixtures still verify.

Fresh release/parallel tests passed for the six affected crates, excluding two pre-existing tests that expect debug-only assertions to panic:

```sh
cargo test --offline --release \
  -p p3-air -p p3-commit -p p3-circle -p p3-lookup \
  -p p3-uni-stark -p p3-batch-stark \
  --features parallel --no-fail-fast -- \
  --skip generate_permutation_exclusive_rejects_non_boolean_flag \
  --skip generate_permutation_exclusive_rejects_two_active_flags
```

Both excluded failures were reproduced on unmodified `c239716c`; their code is unchanged. Nightly formatting checks also pass.

## Performance

A local M31/Keccak release microbenchmark compared this fix with `c239716c` using a sufficient manual degree hint on the baseline. For 16,384-row degree-3 and degree-4 recurrences, proving remained about 183 ms with identical serialized proof sizes. Fixed-branch verification measured approximately 0.41-0.44 ms. Measurements used nine timed iterations after two warmups; this is a focused regression check, not a general throughput claim.
