### PR TITLE
feat(multi-stark): wire binary fields and PCS end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,20 @@ Hashes
 - [x] Monolith
 
 
+## Binary-field example
+
+The [binary AIR example](multi-stark/examples/prove_binary_field.rs) proves a nonlinear
+recurrence over `BinaryField128` using the multilinear STARK prover and `BinaryPcs`,
+with Keccak Merkle commitments and a binary challenger. It serializes the proof and
+verifies it with a fresh transcript:
+
+```bash
+cargo run --release -p p3-multi-stark --example prove_binary_field
+```
+
+This example is not zero knowledge. Characteristic-two LogUp lookups are unsupported
+and rejected; the example uses ordinary AIR constraints.
+
 ## Benchmarks
 
 Many variations are possible, with different fields, hashes, and so forth, which can be controlled through the command line.

--- a/binary-field/src/lib.rs
+++ b/binary-field/src/lib.rs
@@ -14,6 +14,7 @@ mod packed;
 pub mod poly_basis;
 mod tables;
 mod tower;
+mod transcript;
 
 pub use challenger::BinaryChallenger;
 pub use gf2::Gf2;

--- a/binary-field/src/transcript.rs
+++ b/binary-field/src/transcript.rs
@@ -1,0 +1,43 @@
+//! Canonical typed-transcript encoding for the 128-bit tower field.
+
+use alloc::vec::Vec;
+
+use p3_challenger::CanObserve;
+use p3_challenger::fs::{TranscriptError, TranscriptField, TypeTag};
+
+use crate::{BinaryField128, TowerLevel};
+
+impl TranscriptField for BinaryField128 {
+    fn algebra_tag(degree: usize) -> TypeTag {
+        TypeTag::BinaryTower { bits: 128, degree }
+    }
+
+    fn observe_seed<C: CanObserve<Self>>(challenger: &mut C, bytes: &[u8]) {
+        // Embed the length and chunks in the tower basis, not via `from_u128`,
+        // which embeds integers in GF(2) and would retain only their parity.
+        challenger.observe(Self::from_repr(bytes.len() as u128));
+        for chunk in bytes.chunks(16) {
+            let mut padded = [0; 16];
+            padded[..chunk.len()].copy_from_slice(chunk);
+            challenger.observe(Self::from_repr(u128::from_le_bytes(padded)));
+        }
+    }
+
+    fn wire_len() -> usize {
+        16
+    }
+
+    fn encode(value: &Self, out: &mut Vec<u8>) {
+        out.extend_from_slice(&value.to_repr().to_be_bytes());
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, TranscriptError> {
+        let prefix = bytes.get(..16).ok_or(TranscriptError::BadProofShape {
+            reason: "not enough bytes for a canonical binary field encoding",
+        })?;
+        // Every 128-bit representation is canonical in this field.
+        Ok(Self::from_repr(u128::from_be_bytes(
+            prefix.try_into().unwrap(),
+        )))
+    }
+}

--- a/binary-field/tests/transcript.rs
+++ b/binary-field/tests/transcript.rs
@@ -1,0 +1,113 @@
+use p3_binary_field::{BinaryChallenger, BinaryField128, TowerLevel};
+use p3_challenger::fs::{
+    Codec, DomainSeparator, FieldToFieldCodec, FieldUnit, Hierarchy, Interaction,
+    InteractionPattern, Kind, Length, ProverState, TypeTag, Unit, VerifierState,
+};
+use p3_challenger::{CanObserve, HashChallenger};
+use p3_keccak::Keccak256Hash;
+use proptest::prelude::*;
+
+type F = BinaryField128;
+type Ch = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
+type Cdc = FieldToFieldCodec<F>;
+
+#[derive(Default)]
+struct Recorder(Vec<F>);
+
+impl CanObserve<F> for Recorder {
+    fn observe(&mut self, value: F) {
+        self.0.push(value);
+    }
+}
+
+fn seed(bytes: &[u8]) -> Vec<F> {
+    let mut recorder = Recorder::default();
+    FieldUnit::<F>::observe_bytes(&mut recorder, bytes);
+    recorder.0
+}
+
+#[test]
+fn binary_seed_preserves_bytes_and_length_in_the_tower_basis() {
+    assert_ne!(seed(&[2]), seed(&[0]));
+    assert_ne!(seed(&[0xaa]), seed(&[0xaa, 0]));
+    assert_ne!(seed(&[]), seed(&[0]));
+    assert_eq!(seed(&[1, 2, 3]), [F::from_repr(3), F::from_repr(0x030201)]);
+}
+
+#[test]
+fn binary_wire_encoding_is_canonical_and_uses_every_bit() {
+    for raw in [0, 1, 2, 1 << 127, u128::MAX] {
+        let value = F::from_repr(raw);
+        let mut bytes = Vec::new();
+        <Cdc as Codec<Ch, F>>::encode(&value, &mut bytes);
+        assert_eq!(bytes, raw.to_be_bytes());
+        assert_eq!(<Cdc as Codec<Ch, F>>::decode(&bytes).unwrap(), value);
+        assert_eq!(bytes.len(), <Cdc as Codec<Ch, F>>::wire_len());
+    }
+    assert!(<Cdc as Codec<Ch, F>>::decode(&[0; 15]).is_err());
+}
+
+#[test]
+fn binary_type_tag_commits_to_the_coefficient_field() {
+    // Both carry 128 bits, but one is a native tower element and the other
+    // is decomposed into 128 GF(2) coefficients; they have different encodings.
+    let native =
+        Interaction::algebra::<F, F>(Hierarchy::Atomic, Kind::Message, "x", Length::Scalar);
+    assert_ne!(
+        native.type_tag(),
+        TypeTag::Algebra {
+            modulus: 2,
+            degree: 128
+        }
+    );
+    assert_eq!(
+        format!("{native:#}"),
+        "Atomic Message 1 x Scalar BinaryTower(128^1)"
+    );
+}
+
+#[test]
+fn binary_typed_wire_round_trip() {
+    let pattern = InteractionPattern::new(vec![
+        Interaction::algebra::<F, F>(Hierarchy::Atomic, Kind::Message, "x", Length::Scalar),
+        Interaction::algebra::<F, F>(Hierarchy::Atomic, Kind::Challenge, "r", Length::Scalar),
+    ])
+    .unwrap();
+    let ds = DomainSeparator::<FieldUnit<F>>::new(1, b"binary-test", pattern);
+    let fresh = || Ch::from_hasher(Vec::new(), Keccak256Hash);
+    let value = F::from_repr(1 << 127 | 2);
+    let mut prover = ProverState::new(fresh(), &ds);
+    prover.add_scalar::<F, Cdc>("x", &value);
+    let challenge = prover.challenge_scalar::<F, Cdc>("r").into_inner();
+    let wire = prover.finalize();
+    assert_eq!(wire, value.to_repr().to_be_bytes());
+    let mut verifier = VerifierState::new(fresh(), &ds, &wire);
+    assert_eq!(
+        verifier.next_scalar::<F, Cdc>("x").unwrap().into_inner(),
+        value
+    );
+    assert_eq!(
+        verifier.challenge_scalar::<F, Cdc>("r").into_inner(),
+        challenge
+    );
+    verifier.finalize().unwrap();
+}
+
+proptest! {
+    #[test]
+    fn binary_seed_recovers_every_byte(bytes in prop::collection::vec(any::<u8>(), 0..65)) {
+        let encoded = seed(&bytes);
+        prop_assert_eq!(encoded[0].to_repr(), bytes.len() as u128);
+        let recovered: Vec<u8> = encoded[1..].iter()
+            .flat_map(|value| value.to_repr().to_le_bytes())
+            .take(bytes.len()).collect();
+        prop_assert_eq!(recovered, bytes);
+    }
+
+    #[test]
+    fn binary_wire_round_trips(raw in any::<u128>()) {
+        let mut bytes = Vec::new();
+        <Cdc as Codec<Ch, F>>::encode(&F::from_repr(raw), &mut bytes);
+        prop_assert_eq!(<Cdc as Codec<Ch, F>>::decode(&bytes).unwrap().to_repr(), raw);
+    }
+}

--- a/binary-pcs/src/prover.rs
+++ b/binary-pcs/src/prover.rs
@@ -21,7 +21,7 @@ use p3_commit::{Encoder, Mmcs};
 use p3_matrix::dense::{DenseMatrix, RowMajorMatrix};
 use p3_multilinear_util::point::Point;
 use p3_sumcheck::SumcheckData;
-use p3_sumcheck::layout::{Layout, Witness};
+use p3_sumcheck::layout::{Layout, Table, Witness};
 
 use crate::PcsLayout;
 use crate::fold::fold_codeword;
@@ -39,7 +39,9 @@ const FOLDING: usize = 0;
 /// Data produced by committing the base codeword: the layout used to build the residual
 /// sumcheck, and the base commitment's Merkle prover data.
 ///
-/// Opaque to callers, who receive it from `commit` and hand it back to `open`.
+/// Retains the source tables for AIR evaluation between `commit` and `open`.
+/// Cloning reuses the encoding and Merkle tree for another opening of the commitment.
+#[derive(Clone)]
 pub struct BinaryPcsProverData<MT: Mmcs<BinaryField128>> {
     /// The layout that ran the commit phase, carried forward to build the residual sumcheck
     /// and, later, to evaluate opening claims against the committed polynomial.
@@ -47,6 +49,13 @@ pub struct BinaryPcsProverData<MT: Mmcs<BinaryField128>> {
     /// The base codeword's Merkle prover data, needed to open base-round queries once the
     /// query phase samples its indices.
     pub(crate) merkle_data: MT::ProverData<DenseMatrix<BinaryField128>>,
+}
+
+impl<MT: Mmcs<BinaryField128>> BinaryPcsProverData<MT> {
+    /// Returns source table `id` retained by the committed layout.
+    pub fn table(&self, id: usize) -> &Table<BinaryField128> {
+        self.layout.table(id)
+    }
 }
 
 /// One folding round's prover-side output.

--- a/challenger/src/fs/codecs/field_to_field.rs
+++ b/challenger/src/fs/codecs/field_to_field.rs
@@ -3,9 +3,8 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
-use p3_field::PrimeField64;
-
-use crate::fs::codecs::{Codec, decode_field_be_canonical, encode_field_be, field_byte_size};
+use crate::fs::TranscriptField;
+use crate::fs::codecs::Codec;
 use crate::fs::error::TranscriptError;
 use crate::{CanObserve, CanSample};
 
@@ -13,13 +12,13 @@ use crate::{CanObserve, CanSample};
 ///
 /// The sponge half is a straight pass-through.
 ///
-/// The wire half is the same canonical big-endian encoding every other codec
-/// uses, so a proof stays byte-identical whichever sponge produced it.
+/// The wire half uses the field's canonical encoding. For prime fields, this is
+/// the same big-endian encoding as the byte-sponge codec.
 pub struct FieldToFieldCodec<F>(PhantomData<F>);
 
 impl<C, F> Codec<C, F> for FieldToFieldCodec<F>
 where
-    F: PrimeField64,
+    F: TranscriptField,
     C: CanObserve<F> + CanSample<F>,
 {
     /// A sample is exactly the sponge's own output.
@@ -30,7 +29,7 @@ where
     const SECURITY_BITS: u32 = 128;
 
     fn wire_len() -> usize {
-        field_byte_size::<F>()
+        F::wire_len()
     }
 
     fn observe(challenger: &mut C, value: &F) {
@@ -42,11 +41,11 @@ where
     }
 
     fn encode(value: &F, out: &mut Vec<u8>) {
-        encode_field_be(value, out);
+        F::encode(value, out);
     }
 
     fn decode(bytes: &[u8]) -> Result<F, TranscriptError> {
-        decode_field_be_canonical(bytes)
+        F::decode(bytes)
     }
 }
 

--- a/challenger/src/fs/mod.rs
+++ b/challenger/src/fs/mod.rs
@@ -10,6 +10,7 @@ mod domain_separator;
 mod error;
 mod pattern;
 mod state;
+mod transcript_field;
 mod unit;
 
 pub use bound::TranscriptBound;
@@ -25,4 +26,5 @@ pub use pattern::{
     PatternState, TypeTag,
 };
 pub use state::{ProverState, VerifierState};
+pub use transcript_field::TranscriptField;
 pub use unit::{FieldUnit, Unit};

--- a/challenger/src/fs/pattern/step.rs
+++ b/challenger/src/fs/pattern/step.rs
@@ -14,7 +14,9 @@
 use core::any::type_name;
 use core::fmt::{Display, Formatter};
 
-use p3_field::{BasedVectorSpace, PrimeField64};
+use p3_field::BasedVectorSpace;
+
+use crate::fs::TranscriptField;
 
 /// Position of a step in the hierarchical structure of a transcript.
 ///
@@ -111,6 +113,16 @@ pub enum TypeTag {
         /// Number of base-field coefficients per value.
         degree: usize,
     },
+    /// Coefficients in the recursively defined Wiedemann binary tower basis.
+    ///
+    /// Distinct from an algebra over `GF(2)`: each coefficient is one whole tower
+    /// element, with its own fixed-width encoding and native challenge sampling.
+    BinaryTower {
+        /// Number of bits in each tower-field coefficient.
+        bits: usize,
+        /// Number of tower-field coefficients per value.
+        degree: usize,
+    },
 }
 
 /// Compile-time identifier of a step.
@@ -138,7 +150,7 @@ pub struct Interaction {
 }
 
 impl Interaction {
-    /// Build a step carrying `A` values, where `A` is an algebra over the prime field `F`.
+    /// Build a step carrying `A` values, where `A` is an algebra over the field `F`.
     ///
     /// A base-field step is the `A = F` case, which has degree 1.
     ///
@@ -151,18 +163,15 @@ impl Interaction {
     #[must_use]
     pub fn algebra<F, A>(hierarchy: Hierarchy, kind: Kind, label: Label, length: Length) -> Self
     where
-        F: PrimeField64,
+        F: TranscriptField,
         A: BasedVectorSpace<F>,
     {
         Self {
             hierarchy,
             kind,
             label,
-            // Modulus plus degree pins the element width across compilers and crates.
-            type_tag: TypeTag::Algebra {
-                modulus: F::ORDER_U64,
-                degree: A::DIMENSION,
-            },
+            // Stable field identity plus degree binds the coefficient representation.
+            type_tag: F::algebra_tag(A::DIMENSION),
             type_name: type_name::<A>(),
             length,
         }
@@ -316,6 +325,7 @@ impl Display for TypeTag {
             Self::Marker => write!(f, "Marker"),
             Self::Bytes => write!(f, "Bytes"),
             Self::Algebra { modulus, degree } => write!(f, "Algebra({modulus}^{degree})"),
+            Self::BinaryTower { bits, degree } => write!(f, "BinaryTower({bits}^{degree})"),
         }
     }
 }
@@ -325,6 +335,7 @@ mod tests {
     use alloc::format;
 
     use p3_baby_bear::BabyBear;
+    use p3_field::PrimeField64;
     use p3_field::extension::BinomialExtensionField;
     use p3_goldilocks::Goldilocks;
     use p3_koala_bear::KoalaBear;

--- a/challenger/src/fs/state/prover.rs
+++ b/challenger/src/fs/state/prover.rs
@@ -5,6 +5,7 @@ use core::marker::PhantomData;
 
 use p3_field::{BasedVectorSpace, Field, PrimeField64};
 
+use crate::fs::TranscriptField;
 use crate::fs::bound::TranscriptBound;
 use crate::fs::codecs::{
     Codec, ExtensionFieldCodec, bound_byte_width, encode_field_be, encode_len_be,
@@ -135,7 +136,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// The verifier re-absorbs the same value from its own inputs.
     pub fn add_public_scalar<F, Cdc>(&mut self, label: Label, value: &F) -> TranscriptBound<F>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a public scalar of type `F`.
@@ -159,7 +160,7 @@ impl<C, U: Unit> ProverState<C, U> {
         values: &[F],
     ) -> Vec<TranscriptBound<F>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a fixed-length list of public scalars.
@@ -182,7 +183,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// Absorb one prover scalar through the supplied codec.
     pub fn add_scalar<F, Cdc>(&mut self, label: Label, value: &F) -> TranscriptBound<F>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a scalar message of type `F`.
@@ -203,7 +204,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// No length prefix is written; the recorded pattern is the source of truth.
     pub fn add_scalars<F, Cdc>(&mut self, label: Label, values: &[F]) -> Vec<TranscriptBound<F>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a fixed-length list of scalars.
@@ -253,7 +254,7 @@ impl<C, U: Unit> ProverState<C, U> {
         max: usize,
     ) -> Vec<TranscriptBound<F>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         C: CanObserve<U::Item>,
         Cdc: Codec<C, F>,
     {
@@ -297,7 +298,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// The coefficient layout therefore has one definition, shared with the verifier.
     pub fn add_extension<F, EF, Cdc>(&mut self, label: Label, value: &EF) -> TranscriptBound<EF>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -337,7 +338,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// So the two sides cannot silently disagree about who carries a value.
     pub fn observe_extension<F, EF, Cdc>(&mut self, label: Label, value: &EF) -> TranscriptBound<EF>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -363,7 +364,7 @@ impl<C, U: Unit> ProverState<C, U> {
         values: &[EF],
     ) -> Vec<TranscriptBound<EF>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -505,7 +506,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// Sample one challenge scalar of type `F` via codec `Cdc`.
     pub fn challenge_scalar<F, Cdc>(&mut self, label: Label) -> TranscriptBound<F>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         assert_challenge_security::<C, F, Cdc>();
@@ -521,7 +522,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// Sample `n` challenge scalars of type `F` under a single pattern step.
     pub fn challenge_scalars<F, Cdc>(&mut self, label: Label, n: usize) -> Vec<TranscriptBound<F>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         assert_challenge_security::<C, F, Cdc>();
@@ -539,7 +540,7 @@ impl<C, U: Unit> ProverState<C, U> {
     /// Sample one challenge extension-field element coefficient by coefficient.
     pub fn challenge_extension<F, EF, Cdc>(&mut self, label: Label) -> TranscriptBound<EF>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -592,7 +593,7 @@ impl<C, U: Unit> ProverState<C, U> {
     pub fn observe_pow(&mut self, label: Label, bits: usize) -> C::Witness
     where
         C: GrindingChallenger,
-        <C as GrindingChallenger>::Witness: PrimeField64,
+        <C as GrindingChallenger>::Witness: TranscriptField,
     {
         // Validate: the next pattern step is a proof-of-work step of this difficulty.
         self.player

--- a/challenger/src/fs/state/verifier.rs
+++ b/challenger/src/fs/state/verifier.rs
@@ -5,6 +5,7 @@ use core::marker::PhantomData;
 
 use p3_field::{BasedVectorSpace, Field, PrimeField64};
 
+use crate::fs::TranscriptField;
 use crate::fs::bound::TranscriptBound;
 use crate::fs::codecs::{
     Codec, ExtensionFieldCodec, bound_byte_width, decode_field_be_canonical, decode_len_be,
@@ -199,7 +200,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
     /// Binding it stops the prover choosing it after seeing the next challenge.
     pub fn observe_extension<F, EF, Cdc>(&mut self, label: Label, value: &EF) -> TranscriptBound<EF>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -231,7 +232,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
         values: &[EF],
     ) -> Result<Vec<TranscriptBound<EF>>, TranscriptError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -282,7 +283,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
     ) -> Result<(), TranscriptError>
     where
         C: GrindingChallenger,
-        <C as GrindingChallenger>::Witness: PrimeField64,
+        <C as GrindingChallenger>::Witness: TranscriptField,
     {
         // Validate: the next pattern step is a proof-of-work step of this difficulty.
         self.player
@@ -309,7 +310,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
     /// The verifier holds them as its own input and absorbs them as the prover did.
     pub fn observe_public_scalar<F, Cdc>(&mut self, label: Label, value: &F) -> TranscriptBound<F>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a public scalar of type `F`.
@@ -333,7 +334,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
         values: &[F],
     ) -> Vec<TranscriptBound<F>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a fixed-length list of public scalars.
@@ -359,7 +360,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
         label: Label,
     ) -> Result<TranscriptBound<F>, TranscriptError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a scalar message of type `F`.
@@ -383,7 +384,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
         n: usize,
     ) -> Result<Vec<TranscriptBound<F>>, TranscriptError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         // Validate: the next pattern step is a fixed-length list of `n` scalars.
@@ -418,7 +419,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
         max: usize,
     ) -> Result<Vec<TranscriptBound<F>>, TranscriptError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         C: CanObserve<U::Item>,
         Cdc: Codec<C, F>,
     {
@@ -449,7 +450,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
         label: Label,
     ) -> Result<TranscriptBound<EF>, TranscriptError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {
@@ -573,7 +574,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
     /// Sample one challenge scalar in lockstep with the prover.
     pub fn challenge_scalar<F, Cdc>(&mut self, label: Label) -> TranscriptBound<F>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         assert_challenge_security::<C, F, Cdc>();
@@ -589,7 +590,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
     /// Sample `n` challenge scalars in lockstep with the prover.
     pub fn challenge_scalars<F, Cdc>(&mut self, label: Label, n: usize) -> Vec<TranscriptBound<F>>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         Cdc: Codec<C, F>,
     {
         assert_challenge_security::<C, F, Cdc>();
@@ -607,7 +608,7 @@ impl<'a, C, U: Unit> VerifierState<'a, C, U> {
     /// Sample one challenge extension-field element in lockstep with the prover.
     pub fn challenge_extension<F, EF, Cdc>(&mut self, label: Label) -> TranscriptBound<EF>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: Field + BasedVectorSpace<F>,
         Cdc: Codec<C, F>,
     {

--- a/challenger/src/fs/transcript_field.rs
+++ b/challenger/src/fs/transcript_field.rs
@@ -1,0 +1,78 @@
+//! Field representation hooks for typed, native-field transcripts.
+
+use alloc::vec::Vec;
+
+use p3_field::{Field, PrimeField64};
+
+use super::codecs::{decode_field_be_canonical, encode_field_be, field_byte_size};
+use super::{FieldUnit, TranscriptError, TypeTag};
+use crate::CanObserve;
+
+/// A field with stable encodings for a typed native-field transcript.
+///
+/// Implementations must make seed absorption injective and use a unique, fixed-width
+/// wire encoding for every element. The algebra tag must identify the coefficient
+/// field and its representation independently of Rust type names, and bind the
+/// supplied extension degree. These contracts are required for transcript binding.
+///
+/// Prime fields below `2^64` retain their canonical big-endian wire format and
+/// length-prefixed little-endian seed packing through the blanket implementation.
+pub trait TranscriptField: Field {
+    /// Stable identity of an algebra with `degree` coefficients over this field.
+    fn algebra_tag(degree: usize) -> TypeTag;
+
+    /// Absorb a byte string injectively into this field's sponge alphabet.
+    fn observe_seed<C: CanObserve<Self>>(challenger: &mut C, bytes: &[u8]);
+
+    /// Byte length of the canonical encoding of one element.
+    fn wire_len() -> usize;
+
+    /// Append exactly `Self::wire_len()` bytes identifying this element uniquely.
+    fn encode(value: &Self, out: &mut Vec<u8>);
+
+    /// Decode the first `Self::wire_len()` bytes, rejecting short or noncanonical inputs.
+    fn decode(bytes: &[u8]) -> Result<Self, TranscriptError>;
+}
+
+impl<F: PrimeField64> TranscriptField for F {
+    fn algebra_tag(degree: usize) -> TypeTag {
+        TypeTag::Algebra {
+            modulus: F::ORDER_U64,
+            degree,
+        }
+    }
+
+    fn observe_seed<C: CanObserve<F>>(challenger: &mut C, bytes: &[u8]) {
+        let chunk = FieldUnit::<F>::bytes_per_element();
+        // Length below the modulus keeps the length element itself injective.
+        assert!(
+            (bytes.len() as u128) < F::ORDER_U64 as u128,
+            "byte string of {} bytes does not fit in one field element",
+            bytes.len(),
+        );
+        // One element for the length, then one per chunk.
+        let mut packed: Vec<F> = Vec::with_capacity(1 + bytes.len().div_ceil(chunk));
+        packed.push(F::from_u64(bytes.len() as u64));
+        for window in bytes.chunks(chunk) {
+            // Little-endian fold of at most `chunk` bytes: value < 2^(8*chunk) < p.
+            let mut acc = 0u64;
+            for (i, &b) in window.iter().enumerate() {
+                acc |= (b as u64) << (8 * i);
+            }
+            packed.push(F::from_u64(acc));
+        }
+        challenger.observe_slice(&packed);
+    }
+
+    fn wire_len() -> usize {
+        field_byte_size::<F>()
+    }
+
+    fn encode(value: &Self, out: &mut Vec<u8>) {
+        encode_field_be(value, out);
+    }
+
+    fn decode(bytes: &[u8]) -> Result<Self, TranscriptError> {
+        decode_field_be_canonical(bytes)
+    }
+}

--- a/challenger/src/fs/unit.rs
+++ b/challenger/src/fs/unit.rs
@@ -10,12 +10,12 @@
 //!
 //! That single hook is what lets one driver run over both families of challenger.
 
-use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use p3_field::PrimeField64;
 
 use crate::CanObserve;
+use crate::fs::TranscriptField;
 
 /// Alphabet of a sponge, together with the rule for absorbing a raw byte string into it.
 pub trait Unit {
@@ -38,7 +38,7 @@ impl Unit for u8 {
     }
 }
 
-/// Alphabet of a sponge that speaks the prime field `F` natively.
+/// Alphabet of a sponge that speaks the field `F` natively.
 ///
 /// Used as the `U` parameter of a transcript driven by `DuplexChallenger` or
 /// `SerializingChallenger32/64`.
@@ -62,45 +62,18 @@ impl<F: PrimeField64> FieldUnit<F> {
     }
 }
 
-impl<F: PrimeField64> Unit for FieldUnit<F> {
+impl<F: TranscriptField> Unit for FieldUnit<F> {
     type Item = F;
 
-    /// Absorb `bytes` as `[len] ++ [chunk_0, chunk_1, ...]`.
-    ///
-    /// Each chunk is `bytes_per_element()` bytes read little-endian, the last one zero-padded.
-    ///
-    /// The leading length element makes the encoding injective:
-    /// padding is only ambiguous without it.
-    ///
-    /// # Panics
-    ///
-    /// When `bytes.len()` does not fit in `F`.
     fn observe_bytes<C: CanObserve<F>>(challenger: &mut C, bytes: &[u8]) {
-        let chunk = Self::bytes_per_element();
-        // Length below the modulus keeps the length element itself injective.
-        assert!(
-            (bytes.len() as u128) < F::ORDER_U64 as u128,
-            "byte string of {} bytes does not fit in one field element",
-            bytes.len(),
-        );
-        // One element for the length, then one per chunk.
-        let mut packed: Vec<F> = Vec::with_capacity(1 + bytes.len().div_ceil(chunk));
-        packed.push(F::from_u64(bytes.len() as u64));
-        for window in bytes.chunks(chunk) {
-            // Little-endian fold of at most `chunk` bytes: value < 2^(8*chunk) < p.
-            let mut acc = 0u64;
-            for (i, &b) in window.iter().enumerate() {
-                acc |= (b as u64) << (8 * i);
-            }
-            packed.push(F::from_u64(acc));
-        }
-        challenger.observe_slice(&packed);
+        F::observe_seed(challenger, bytes);
     }
 }
 
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use alloc::vec::Vec;
 
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;

--- a/lookup/src/types.rs
+++ b/lookup/src/types.rs
@@ -8,7 +8,7 @@ use core::ops::Deref;
 use num_bigint::BigUint;
 use p3_air::symbolic::AirLayout;
 use p3_air::{Air, SymbolicExpression};
-use p3_field::{ExtensionField, Field, PrimeField};
+use p3_field::{ExtensionField, Field};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -355,7 +355,7 @@ impl<F: Field> Lookups<F> {
 /// # Errors
 ///
 /// - When the weighted sum reaches the field characteristic.
-pub fn check_multiplicity_height_bound<F: PrimeField>(
+pub fn check_multiplicity_height_bound<F: Field>(
     lookups: &[Lookups<F>],
     heights: &[usize],
 ) -> Result<(), LookupError> {

--- a/multi-stark/Cargo.toml
+++ b/multi-stark/Cargo.toml
@@ -35,14 +35,21 @@ tracing.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 p3-baby-bear = { path = "../baby-bear" }
+p3-binary-field.workspace = true
+p3-binary-pcs.workspace = true
 p3-blake3-air.workspace = true
 p3-dft.workspace = true
+p3-keccak.workspace = true
 p3-merkle-tree.workspace = true
 p3-poseidon2-air.workspace = true
 p3-symmetric.workspace = true
 p3-whir.workspace = true
 postcard = { workspace = true, features = ["alloc"] }
 rand = { workspace = true }
+
+[[example]]
+name = "prove_binary_field"
+test = true
 
 [[bench]]
 name = "poseidon2"

--- a/multi-stark/examples/prove_binary_field.rs
+++ b/multi-stark/examples/prove_binary_field.rs
@@ -1,0 +1,491 @@
+//! A complete AIR proof over GF(2^128), with the additive-domain binary PCS.
+//!
+//! Run with `cargo run --release -p p3-multi-stark --example prove_binary_field`.
+//! The PCS is binding but not hiding; this example does not provide zero knowledge.
+
+use std::time::Instant;
+
+use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
+use p3_binary_field::{BinaryChallenger, BinaryField128, TowerLevel};
+use p3_binary_pcs::{BinaryPcs, BinaryPcsConfig, BinaryPcsParams, BinaryPcsProverData};
+use p3_challenger::HashChallenger;
+use p3_keccak::Keccak256Hash;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_multi_stark::config::MultiStarkConfig;
+use p3_multi_stark::{
+    MultiStarkProof, ProverInstance, ProverInstances, VerifierInstance, VerifierInstances, prove,
+    setup, verify,
+};
+use p3_sumcheck::layout::{Layout, SuffixProver, Table, Witness};
+use p3_symmetric::{CompressionFunctionFromHasher, SerializingHasher};
+
+type F = BinaryField128;
+type Hash = SerializingHasher<Keccak256Hash>;
+type Compress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
+type Mmcs = p3_merkle_tree::MerkleTreeMmcs<F, u8, Hash, Compress, 2, 32>;
+type Challenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
+
+struct Config {
+    pcs: BinaryPcs<Mmcs>,
+}
+
+impl MultiStarkConfig for Config {
+    type Val = F;
+    type Challenge = F;
+    type Challenger = Challenger;
+    type Pcs = BinaryPcs<Mmcs>;
+
+    fn pcs(&self) -> &Self::Pcs {
+        &self.pcs
+    }
+
+    fn min_num_variables(&self) -> usize {
+        // The binary PCS folds at least one variable and does not pad individual tables.
+        1
+    }
+
+    fn build_witness(&self, tables: Vec<Table<F>>) -> Witness<F> {
+        SuffixProver::<F, F>::new_witness(tables, 0)
+    }
+
+    fn committed_table<'a>(
+        &self,
+        prover_data: &'a BinaryPcsProverData<Mmcs>,
+        table_index: usize,
+    ) -> &'a Table<F> {
+        prover_data.table(table_index)
+    }
+}
+
+fn config(log_height: usize) -> Config {
+    // Two trace columns add one variable to the stacked polynomial.
+    let params = BinaryPcsParams {
+        log_inv_rate: 2,
+        pow_bits: 0,
+        security_level: 100,
+    };
+    let pcs_config = BinaryPcsConfig::try_new(log_height + 1, params).unwrap();
+    let mmcs = Mmcs::new(Hash::new(Keccak256Hash), Compress::new(Keccak256Hash), 0);
+    Config {
+        pcs: BinaryPcs::new(pcs_config, mmcs),
+    }
+}
+
+fn challenger() -> Challenger {
+    Challenger::from_hasher(
+        b"p3-multi-stark-binary-recurrence-v1".to_vec(),
+        Keccak256Hash,
+    )
+}
+
+/// A nonlinear recurrence: (a, b) -> (b, a * b + a).
+///
+/// Addition is XOR and multiplication is tower-field multiplication. Nonlinear
+/// constraints exercise interpolation beyond the two prime-subfield elements.
+struct RecurrenceAir;
+
+impl<F> BaseAir<F> for RecurrenceAir {
+    fn width(&self) -> usize {
+        2
+    }
+
+    fn num_public_values(&self) -> usize {
+        3
+    }
+}
+
+impl<AB: AirBuilder> Air<AB> for RecurrenceAir {
+    fn eval(&self, builder: &mut AB) {
+        let main = builder.main();
+        let local = main.current_slice();
+        let next = main.next_slice();
+        let public = builder.public_values();
+        let (a, b, output) = (public[0], public[1], public[2]);
+
+        builder.when_first_row().assert_eq(local[0], a);
+        builder.when_first_row().assert_eq(local[1], b);
+        builder.when_transition().assert_eq(next[0], local[1]);
+        builder
+            .when_transition()
+            .assert_eq(next[1], local[0] * local[1] + local[0]);
+        builder.when_last_row().assert_eq(local[1], output);
+    }
+}
+
+fn trace(log_height: usize) -> (Table<F>, [F; 3]) {
+    // Integer constructors map into GF(2), so use tower representations for seeds.
+    let initial = [
+        F::from_repr(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210),
+        F::from_repr(0xfedc_ba98_7654_3210_0123_4567_89ab_cdef),
+    ];
+    let [mut a, mut b] = initial;
+    let mut values = Vec::with_capacity(2 << log_height);
+    for _ in 0..1 << log_height {
+        values.extend([a, b]);
+        (a, b) = (b, a * b + a);
+    }
+    let output = values[values.len() - 1];
+    let table = Table::new(RowMajorMatrix::new(values, 2).transpose());
+    (table, [initial[0], initial[1], output])
+}
+
+fn main() {
+    let log_height = 8;
+    let config = config(log_height);
+    let (table, public) = trace(log_height);
+    let (pk, vk) = setup(&config, &[&RecurrenceAir], &mut challenger());
+
+    let start = Instant::now();
+    let proof = prove(
+        &config,
+        ProverInstances::new(vec![ProverInstance::new(
+            &RecurrenceAir,
+            table,
+            &pk,
+            &public,
+        )]),
+        0,
+        &mut challenger(),
+    );
+    let proving_time = start.elapsed();
+    let bytes = postcard::to_allocvec(&proof).unwrap();
+    let proof: MultiStarkProof<Config> = postcard::from_bytes(&bytes).unwrap();
+
+    let start = Instant::now();
+    verify(
+        &config,
+        VerifierInstances::new(vec![VerifierInstance::new(
+            &RecurrenceAir,
+            &vk,
+            log_height,
+            &public,
+        )]),
+        &proof,
+        0,
+        &mut challenger(),
+    )
+    .expect("binary AIR proof must verify");
+    println!(
+        "Verified {} rows over GF(2^128) using BinaryPcs: {} bytes, prove {:?}, verify {:?}",
+        1 << log_height,
+        bytes.len(),
+        proving_time,
+        start.elapsed(),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use p3_binary_pcs::{BinaryPcsError, BinaryPcsProof};
+    use p3_field::PrimeCharacteristicRing;
+    use p3_multi_stark::config::PcsError;
+    use p3_multi_stark::{VerificationError, VerifyingKey};
+
+    use super::*;
+
+    struct Fixture {
+        config: Config,
+        vk: VerifyingKey<Config>,
+        proof: MultiStarkProof<Config>,
+        public: [F; 3],
+        log_height: usize,
+        pow_bits: usize,
+    }
+
+    impl Fixture {
+        fn new(log_height: usize, pow_bits: usize) -> Self {
+            let config = config(log_height);
+            let (table, public) = trace(log_height);
+            let (pk, vk) = setup(&config, &[&RecurrenceAir], &mut challenger());
+            let proof = prove(
+                &config,
+                ProverInstances::new(vec![ProverInstance::new(
+                    &RecurrenceAir,
+                    table,
+                    &pk,
+                    &public,
+                )]),
+                pow_bits,
+                &mut challenger(),
+            );
+            // Exercise the wire boundary before checking either honest or tampered proofs.
+            let bytes = postcard::to_allocvec(&proof).unwrap();
+            let proof = postcard::from_bytes(&bytes).unwrap();
+            Self {
+                config,
+                vk,
+                proof,
+                public,
+                log_height,
+                pow_bits,
+            }
+        }
+
+        fn verify(&self) -> Result<(), VerificationError<PcsError<Config>>> {
+            verify(
+                &self.config,
+                VerifierInstances::new(vec![VerifierInstance::new(
+                    &RecurrenceAir,
+                    &self.vk,
+                    self.log_height,
+                    &self.public,
+                )]),
+                &self.proof,
+                self.pow_bits,
+                &mut challenger(),
+            )
+        }
+    }
+
+    #[test]
+    fn binary_air_proof_round_trips() {
+        for log_height in [1, 2, 5] {
+            for pow_bits in [0, 2] {
+                Fixture::new(log_height, pow_bits).verify().unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn rejects_changed_public_values() {
+        for index in 0..3 {
+            let mut fixture = Fixture::new(3, 0);
+            fixture.public[index] += F::ONE;
+            assert!(fixture.verify().is_err());
+        }
+    }
+
+    #[test]
+    fn rejects_changed_sumcheck_polynomial() {
+        let mut fixture = Fixture::new(3, 0);
+        fixture.proof.sumcheck.round_polys[0][0] += F::ONE;
+        assert!(fixture.verify().is_err());
+    }
+
+    #[test]
+    fn rejects_changed_binary_pcs_codeword() {
+        let mut fixture = Fixture::new(3, 0);
+        fixture.proof.opening.final_codeword.as_mut_slice()[1] += F::ONE;
+        assert!(matches!(
+            fixture.verify(),
+            Err(VerificationError::Opening(BinaryPcsError::FinalCheck))
+        ));
+    }
+
+    #[test]
+    fn rejects_an_invalid_trace() {
+        let log_height = 3;
+        let config = config(log_height);
+        let (table, public) = trace(log_height);
+        let mut columns = table.iter_polys().flatten().copied().collect::<Vec<_>>();
+        // Corrupt an interior row while preserving all public boundary values.
+        columns[2] += F::ONE;
+        let table = Table::new(RowMajorMatrix::new(columns, 1 << log_height));
+        let (pk, vk) = setup(&config, &[&RecurrenceAir], &mut challenger());
+        let proof = prove(
+            &config,
+            ProverInstances::new(vec![ProverInstance::new(
+                &RecurrenceAir,
+                table,
+                &pk,
+                &public,
+            )]),
+            0,
+            &mut challenger(),
+        );
+        let fixture = Fixture {
+            config,
+            vk,
+            proof,
+            public,
+            log_height,
+            pow_bits: 0,
+        };
+        assert!(fixture.verify().is_err());
+    }
+
+    #[test]
+    fn cloned_commitment_data_opens_independently() {
+        use p3_commit::MultilinearPcs;
+        use p3_sumcheck::{OpeningBatch, OpeningProtocol, TableSpec};
+
+        let log_height = 3;
+        let config = config(log_height);
+        let (table, _) = trace(log_height);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            table.shape(),
+            vec![OpeningBatch::new(vec![0, 1], vec![0, 1])],
+        )]);
+        let expected = table.clone();
+        let (commitment, data) = config
+            .pcs
+            .commit(config.build_witness(vec![table]), &mut challenger());
+        for seed in [b"first opening".as_slice(), b"second opening".as_slice()] {
+            use p3_challenger::CanObserve;
+
+            let mut prover = Challenger::from_hasher(seed.to_vec(), Keccak256Hash);
+            prover.observe(commitment.clone());
+            let cloned = data.clone();
+            for (actual, expected) in cloned.table(0).iter_polys().zip(expected.iter_polys()) {
+                assert_eq!(actual, expected);
+            }
+            let proof: BinaryPcsProof<Mmcs> =
+                config.pcs.open(cloned, protocol.clone(), &mut prover);
+            let mut verifier = Challenger::from_hasher(seed.to_vec(), Keccak256Hash);
+            config
+                .pcs
+                .verify(&commitment, &proof, &mut verifier, protocol.clone())
+                .unwrap();
+        }
+    }
+
+    #[test]
+    fn mixed_height_binary_air_batch_round_trips() {
+        // Two columns at heights 8 and 2 stack into 32 padded entries (arity 5).
+        let config = config(4);
+        let (tall, tall_public) = trace(3);
+        let (short, short_public) = trace(1);
+        let (pk, vk) = setup(
+            &config,
+            &[&RecurrenceAir, &RecurrenceAir],
+            &mut challenger(),
+        );
+        let proof = prove(
+            &config,
+            ProverInstances::new(vec![
+                ProverInstance::new(&RecurrenceAir, short, &pk, &short_public),
+                ProverInstance::new(&RecurrenceAir, tall, &pk, &tall_public),
+            ]),
+            0,
+            &mut challenger(),
+        );
+        verify(
+            &config,
+            VerifierInstances::new(vec![
+                VerifierInstance::new(&RecurrenceAir, &vk, 1, &short_public),
+                VerifierInstance::new(&RecurrenceAir, &vk, 3, &tall_public),
+            ]),
+            &proof,
+            0,
+            &mut challenger(),
+        )
+        .unwrap();
+    }
+
+    /// Uses the same PCS arity for equally wide main and preprocessed tables.
+    struct PreprocessedConfig(Config);
+
+    impl MultiStarkConfig for PreprocessedConfig {
+        type Val = F;
+        type Challenge = F;
+        type Challenger = Challenger;
+        type Pcs = BinaryPcs<Mmcs>;
+
+        fn pcs(&self) -> &Self::Pcs {
+            self.0.pcs()
+        }
+        fn preprocessed_pcs(&self) -> &Self::Pcs {
+            self.0.pcs()
+        }
+        fn min_num_variables(&self) -> usize {
+            self.0.min_num_variables()
+        }
+        fn build_witness(&self, tables: Vec<Table<F>>) -> Witness<F> {
+            self.0.build_witness(tables)
+        }
+        fn committed_table<'a>(
+            &self,
+            data: &'a BinaryPcsProverData<Mmcs>,
+            index: usize,
+        ) -> &'a Table<F> {
+            self.0.committed_table(data, index)
+        }
+    }
+
+    struct PreprocessedAir;
+
+    impl BaseAir<F> for PreprocessedAir {
+        fn width(&self) -> usize {
+            2
+        }
+        fn num_public_values(&self) -> usize {
+            3
+        }
+        fn preprocessed_width(&self) -> usize {
+            2
+        }
+        fn preprocessed_trace(&self) -> Option<RowMajorMatrix<F>> {
+            let (table, _) = trace(3);
+            let columns = table.iter_polys().flatten().copied().collect();
+            Some(RowMajorMatrix::new(columns, 8).transpose())
+        }
+    }
+
+    impl<AB: AirBuilder<F = F>> Air<AB> for PreprocessedAir {
+        fn eval(&self, builder: &mut AB) {
+            RecurrenceAir.eval(builder);
+            let main = builder.main();
+            let preprocessed = builder.preprocessed();
+            let local = [
+                preprocessed.current_slice()[0],
+                preprocessed.current_slice()[1],
+            ];
+            let next = [preprocessed.next_slice()[0], preprocessed.next_slice()[1]];
+            for column in 0..2 {
+                builder.assert_eq(main.current_slice()[column], local[column]);
+                builder
+                    .when_transition()
+                    .assert_eq(main.next_slice()[column], next[column]);
+            }
+        }
+    }
+
+    #[test]
+    fn binary_preprocessed_key_is_reusable_and_openings_are_checked() {
+        use p3_challenger::CanObserve;
+
+        let config = PreprocessedConfig(config(3));
+        let (pk, vk) = setup(&config, &[&PreprocessedAir], &mut challenger());
+        for seed in [2, 3] {
+            let fresh = || {
+                let mut ch = challenger();
+                ch.observe(F::from_repr(seed));
+                ch
+            };
+            let (table, public) = trace(3);
+            let mut proof = prove(
+                &config,
+                ProverInstances::new(vec![ProverInstance::new(
+                    &PreprocessedAir,
+                    table,
+                    &pk,
+                    &public,
+                )]),
+                0,
+                &mut fresh(),
+            );
+            let check = |proof: &MultiStarkProof<PreprocessedConfig>| {
+                verify(
+                    &config,
+                    VerifierInstances::new(vec![VerifierInstance::new(
+                        &PreprocessedAir,
+                        &vk,
+                        3,
+                        &public,
+                    )]),
+                    proof,
+                    0,
+                    &mut fresh(),
+                )
+            };
+            check(&proof).unwrap();
+            proof
+                .preprocessed_opening
+                .as_mut()
+                .unwrap()
+                .final_codeword
+                .as_mut_slice()[1] += F::ONE;
+            assert!(check(&proof).is_err());
+        }
+    }
+}

--- a/multi-stark/src/config.rs
+++ b/multi-stark/src/config.rs
@@ -2,8 +2,9 @@
 
 use alloc::vec::Vec;
 
+use p3_challenger::fs::TranscriptField;
 use p3_commit::MultilinearPcs;
-use p3_field::{ExtensionField, PrimeField64};
+use p3_field::ExtensionField;
 use p3_sumcheck::layout::Table;
 
 /// The wiring a multilinear AIR proof depends on.
@@ -14,10 +15,9 @@ use p3_sumcheck::layout::Table;
 pub trait MultiStarkConfig {
     /// Base field the trace and committed columns live in.
     ///
-    /// The transcript packs its seed bytes into base-field elements.
-    /// The modulus therefore has to fit in 64 bits.
-    /// Every field a grinding challenger works over already does.
-    type Val: PrimeField64;
+    /// The transcript requires an injective byte encoding for its domain separator.
+    /// Both supported prime fields and binary tower fields provide one.
+    type Val: TranscriptField;
 
     /// Extension field that challenges are drawn from.
     ///

--- a/multi-stark/src/fractional_gkr/materialize.rs
+++ b/multi-stark/src/fractional_gkr/materialize.rs
@@ -608,7 +608,9 @@ pub(super) mod tests {
 
         assert!(matches!(
             result,
-            Err(p3_lookup::LookupError::MultiplicityHeightBoundExceeded { .. })
+            Err(crate::lookup::LookupError::MultiplicityHeightBound(
+                p3_lookup::LookupError::MultiplicityHeightBoundExceeded { .. }
+            ))
         ));
     }
 

--- a/multi-stark/src/lookup.rs
+++ b/multi-stark/src/lookup.rs
@@ -21,7 +21,7 @@ use core::cmp::Reverse;
 use p3_air::symbolic::{BaseEntry, BaseLeaf, SymbolicExpr};
 use p3_air::{Air, BaseAir, SymbolicExpression};
 use p3_challenger::FieldChallenger;
-use p3_field::{ExtensionField, Field, PackedValue, PrimeField};
+use p3_field::{ExtensionField, Field, PackedValue};
 use p3_lookup::{
     Challenges, InteractionSymbolicBuilder, Kind, Lookups, check_multiplicity_height_bound,
 };
@@ -121,6 +121,8 @@ impl<F: Field> LookupPlan<F> {
     ///
     /// Returns an error if the worst-case multiplicity sum reaches the field characteristic.
     /// A multiplicity could otherwise wrap around and forge a balanced bus.
+    /// Returns an error for active characteristic-two lookups: the counting argument and
+    /// fractional-GKR interpolation used here require an odd-characteristic field.
     ///
     /// # Panics
     ///
@@ -128,12 +130,8 @@ impl<F: Field> LookupPlan<F> {
     /// Panics if a lookup expression reads a periodic column.
     /// Panics if two declarations share a bus name but disagree on payload width.
     /// Panics if no declaration carries a payload element.
-    pub fn build<EF, A>(
-        airs: &[&A],
-        num_variables: &[usize],
-    ) -> Result<Option<Self>, p3_lookup::LookupError>
+    pub fn build<EF, A>(airs: &[&A], num_variables: &[usize]) -> Result<Option<Self>, LookupError>
     where
-        F: PrimeField,
         EF: ExtensionField<F>,
         A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
     {
@@ -145,6 +143,14 @@ impl<F: Field> LookupPlan<F> {
             .iter()
             .map(|&air| Lookups::from_air::<EF, _>(air))
             .collect::<Vec<_>>();
+        if F::ONE + F::ONE == F::ZERO
+            && lookups
+                .iter()
+                .flat_map(|lookups| lookups.iter())
+                .any(|lookup| !lookup.elements.is_empty())
+        {
+            return Err(LookupError::UnsupportedCharacteristic);
+        }
         for lookup in lookups.iter().flat_map(|lookups| lookups.iter()) {
             assert!(
                 lookup.flags.is_none(),
@@ -591,6 +597,9 @@ impl<EF: Field> ActiveLookupRuntime<EF> {
 /// Reasons the lookup phase rejects a proof.
 #[derive(Debug, Error)]
 pub enum LookupError {
+    /// The counting argument and fractional-GKR kernels do not support binary fields.
+    #[error("multi-STARK lookups do not support characteristic two")]
+    UnsupportedCharacteristic,
     /// An AIR declares a lookup, but the proof carries no reduction for it.
     #[error("lookup proof expected but absent")]
     MissingProof,
@@ -618,6 +627,7 @@ pub enum LookupError {
 ///
 /// Panics if the input slices disagree on length.
 /// Panics if the worst-case multiplicity sum reaches the field characteristic.
+/// Panics if a characteristic-two AIR declares an active lookup.
 /// Panics if a lookup-active trace is shorter than the prover's SIMD packing width.
 pub(crate) fn prove_lookup<F, EF, A, Challenger>(
     airs: &[&A],
@@ -627,7 +637,7 @@ pub(crate) fn prove_lookup<F, EF, A, Challenger>(
     challenger: &mut Challenger,
 ) -> (Option<FractionGkrProof<EF>>, LookupRuntime<EF>)
 where
-    F: PrimeField,
+    F: Field,
     EF: ExtensionField<F>,
     A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
     Challenger: FieldChallenger<F>,
@@ -645,7 +655,7 @@ where
         .map(|table| table.num_variables())
         .collect::<Vec<_>>();
     let Some(plan) = LookupPlan::build::<EF, A>(airs, &num_variables)
-        .expect("lookup multiplicity height bound must hold")
+        .expect("lookup field and multiplicity height bound must be supported")
     else {
         return (None, LookupRuntime::Inactive);
     };
@@ -694,6 +704,7 @@ where
 ///
 /// Returns an error when the proof and the AIRs disagree on whether a lookup exists.
 /// Returns an error when the worst-case multiplicity sum reaches the field characteristic.
+/// Returns an error when a characteristic-two AIR declares an active lookup.
 /// Returns an error when the reduction fails its own consistency checks.
 ///
 /// # Panics
@@ -706,7 +717,7 @@ pub(crate) fn verify_lookup<F, EF, A, Challenger>(
     challenger: &mut Challenger,
 ) -> Result<Option<AirLinkClaim<EF>>, LookupError>
 where
-    F: PrimeField,
+    F: Field,
     EF: ExtensionField<F>,
     A: BaseAir<F> + Air<InteractionSymbolicBuilder<F, EF>>,
     Challenger: FieldChallenger<F>,
@@ -765,6 +776,37 @@ mod tests {
     type EF = BinomialExtensionField<F, 4>;
     type Perm = Poseidon2BabyBear<16>;
     type Challenger = DuplexChallenger<F, Perm, 16, 8>;
+
+    struct BinaryLookupAir;
+
+    impl BaseAir<p3_binary_field::BinaryField128> for BinaryLookupAir {
+        fn width(&self) -> usize {
+            1
+        }
+    }
+
+    impl<AB> Air<AB> for BinaryLookupAir
+    where
+        AB: AirBuilder<F = p3_binary_field::BinaryField128> + InteractionBuilder,
+    {
+        fn eval(&self, builder: &mut AB) {
+            let value = builder.main().current_slice()[0];
+            // Provided-only declarations have zero query weight and pass the height
+            // bound. They still must not enter the unsupported binary lookup path.
+            builder.push_local_interaction([
+                (vec![value.into()], Count::provided(AB::Expr::ONE)),
+                (vec![value.into()], Count::provided(-AB::Expr::ONE)),
+            ]);
+        }
+    }
+
+    #[test]
+    fn binary_lookup_plan_is_rejected_even_without_query_weight() {
+        assert!(matches!(
+            LookupPlan::build::<p3_binary_field::BinaryField128, _>(&[&BinaryLookupAir], &[2]),
+            Err(LookupError::UnsupportedCharacteristic)
+        ));
+    }
 
     struct BalancedLookupAir;
 

--- a/multi-stark/src/prover.rs
+++ b/multi-stark/src/prover.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::MultilinearPcs;
-use p3_field::{ExtensionField, Field, PrimeField};
+use p3_field::{ExtensionField, Field};
 use p3_sumcheck::PrescribedPointPcs;
 
 use crate::ProverInstances;
@@ -65,7 +65,6 @@ pub fn prove<'a, C, A>(
 ) -> MultiStarkProof<C>
 where
     C: MultiStarkConfig,
-    C::Val: PrimeField,
     C::Pcs: PrescribedPointPcs<C::Challenge, C::Challenger>,
     C::Challenger: FieldChallenger<C::Val>
         + GrindingChallenger<Witness = C::Val>

--- a/multi-stark/src/rounds.rs
+++ b/multi-stark/src/rounds.rs
@@ -475,11 +475,11 @@ struct Scratch<F, EF> {
     interaction_evals: Vec<Vec<EF>>,
     /// Current-row value of each column at the active interpolation node.
     local_point: Vec<F>,
-    /// Step added to advance each current-row value to the next node.
+    /// Difference between the high and low current-row values.
     local_diff: Vec<F>,
     /// Successor-row value of each column at the active interpolation node.
     next_point: Vec<F>,
-    /// Step added to advance each successor-row value to the next node.
+    /// Difference between the high and low successor-row values.
     next_diff: Vec<F>,
 }
 
@@ -494,11 +494,11 @@ struct PackedScratch<P, EF> {
     interaction_evals: Vec<Vec<EF>>,
     /// Current-row lanes of each column at the active interpolation node.
     local_point: Vec<P>,
-    /// Step added to advance each current-row lane to the next node.
+    /// Difference between the high and low current-row lanes.
     local_diff: Vec<P>,
     /// Successor-row lanes of each column at the active interpolation node.
     next_point: Vec<P>,
-    /// Step added to advance each successor-row lane to the next node.
+    /// Difference between the high and low successor-row lanes.
     next_diff: Vec<P>,
 }
 
@@ -531,6 +531,11 @@ impl<F: Field, EF> Scratch<F, EF> {
     fn add_diffs(&mut self) {
         F::add_slices(&mut self.local_point, &self.local_diff);
         F::add_slices(&mut self.next_point, &self.next_diff);
+    }
+
+    fn add_scaled_diffs(&mut self, step: F) {
+        add_scaled_slice(&mut self.local_point, &self.local_diff, step);
+        add_scaled_slice(&mut self.next_point, &self.next_diff, step);
     }
 }
 
@@ -572,6 +577,29 @@ where
                 *next += *next_diff;
             });
     }
+
+    fn add_scaled_diffs(&mut self, step: P)
+    where
+        P: Copy,
+    {
+        add_scaled_slice(&mut self.local_point, &self.local_diff, step);
+        add_scaled_slice(&mut self.next_point, &self.next_diff, step);
+    }
+}
+
+fn add_scaled_slice<P: PrimeCharacteristicRing + Copy>(point: &mut [P], diff: &[P], step: P) {
+    point
+        .iter_mut()
+        .zip(diff)
+        .for_each(|(value, &diff)| *value += diff * step);
+}
+
+/// Consecutive node differences, computed once outside the row loops.
+/// Binary-field interpolation nodes need not differ by one.
+fn interpolation_steps<F: Field>(degree: usize) -> Vec<F> {
+    (0..degree)
+        .map(|node| F::interpolation_node(node + 1) - F::interpolation_node(node))
+        .collect()
 }
 
 /// Where one AIR's lookup link lands, for an AIR that declares one.
@@ -1192,6 +1220,7 @@ where
         let packing_width = F::Packing::WIDTH;
         let packed_half = scalar_half / packing_width;
         let degree = self.degree();
+        let node_steps = interpolation_steps::<F>(degree);
         let alpha = EF::ExtensionPacking::from(self.alpha);
 
         let coupling = InteractionCoupling {
@@ -1338,9 +1367,15 @@ where
                                 }
                             }
                         }
-                        if node != degree {
-                            scratch.add_diffs();
-                            boundary += boundary_diff;
+                        if let Some(&step) = node_steps.get(node) {
+                            if step == F::ONE {
+                                scratch.add_diffs();
+                                boundary += boundary_diff;
+                            } else {
+                                let step = F::Packing::from(step);
+                                scratch.add_scaled_diffs(step);
+                                boundary.add_scaled(boundary_diff, step);
+                            }
                         }
                     }
 
@@ -1379,6 +1414,7 @@ where
         let height = self.num_evals();
         let half = height / 2;
         let degree = self.degree();
+        let node_steps = interpolation_steps::<F>(degree);
 
         let constraint_degrees = self
             .slots
@@ -1476,9 +1512,14 @@ where
                         }
                     }
                 }
-                if node != degree {
-                    scratch.add_diffs();
-                    boundary += boundary_diff;
+                if let Some(&step) = node_steps.get(node) {
+                    if step == F::ONE {
+                        scratch.add_diffs();
+                        boundary += boundary_diff;
+                    } else {
+                        scratch.add_scaled_diffs(step);
+                        boundary.add_scaled(boundary_diff, step);
+                    }
                 }
             }
         }
@@ -1715,6 +1756,7 @@ where
         let num_evals = self.num_evals();
         let half = num_evals / 2;
         let degree = self.degree();
+        let node_steps = interpolation_steps::<EF>(degree);
         let constraint_degrees = self
             .slots
             .iter()
@@ -1797,9 +1839,14 @@ where
                             }
                         }
                     }
-                    if node != degree {
-                        scratch.add_diffs();
-                        boundary += boundary_diff;
+                    if let Some(&step) = node_steps.get(node) {
+                        if step == EF::ONE {
+                            scratch.add_diffs();
+                            boundary += boundary_diff;
+                        } else {
+                            scratch.add_scaled_diffs(step);
+                            boundary.add_scaled(boundary_diff, step);
+                        }
                     }
                 }
 
@@ -1865,6 +1912,7 @@ where
         let packing_width = F::Packing::WIDTH;
         let packed_half = scalar_half / packing_width;
         let degree = self.degree();
+        let node_steps = interpolation_steps::<EF>(degree);
         let alpha = PackedExt::new(EF::ExtensionPacking::from(self.alpha));
         let coupling = InteractionCoupling {
             links: self
@@ -2006,9 +2054,15 @@ where
                                 }
                             }
                         }
-                        if node != degree {
-                            scratch.add_diffs();
-                            boundary += boundary_diff;
+                        if let Some(&step) = node_steps.get(node) {
+                            if step == EF::ONE {
+                                scratch.add_diffs();
+                                boundary += boundary_diff;
+                            } else {
+                                let step = PackedExt::new(EF::ExtensionPacking::from(step));
+                                scratch.add_scaled_diffs(step);
+                                boundary.add_scaled(boundary_diff, step);
+                            }
                         }
                     }
 
@@ -2076,5 +2130,133 @@ where
 
         self.boundary.apply(r);
         self.round += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_air::{AirBuilder, WindowAccess};
+    use p3_binary_field::BinaryField128;
+
+    use super::*;
+
+    type F = BinaryField128;
+
+    struct BooleanAir;
+
+    impl BaseAir<F> for BooleanAir {
+        fn width(&self) -> usize {
+            1
+        }
+    }
+
+    impl<AB: AirBuilder<F = F>> Air<AB> for BooleanAir {
+        fn eval(&self, builder: &mut AB) {
+            let main = builder.main();
+            let local = main.current_slice()[0];
+            let next = main.next_slice()[0];
+            builder.when_first_row().assert_bool(local);
+            builder.when_last_row().assert_bool(local);
+            builder.when_transition().assert_bool(next);
+        }
+    }
+
+    /// Compare each kernel with direct MLE evaluation at the field's distinct nodes.
+    /// Boolean trace entries satisfy the AIR, but its cubic round polynomial is
+    /// nonzero away from the Boolean nodes, exposing repeated-node interpolation.
+    fn check_binary_round_nodes(packed: bool, extension: bool) {
+        let trace = [false, true, true, false, true, false, false, true].map(F::from_bool);
+        let table = Table::new(RowMajorMatrix::new(trace.to_vec(), trace.len()));
+        let stage = Stage::new(
+            vec![&BooleanAir],
+            vec![&[]],
+            vec![0],
+            vec![None],
+            vec![&table],
+            vec![AirDegrees {
+                constraints: 3,
+                interactions: 0,
+            }],
+            StageCoupling::new(BTreeMap::new(), BTreeMap::new(), vec![]),
+        );
+        let alpha = F::interpolation_node(11);
+        let tau = [5, 6, 7].map(F::interpolation_node);
+        let mut base =
+            RoundStateBase::new(stage, alpha, F::ONE, vec![F::ONE], Point::new(tau.to_vec()));
+        let prefix = if extension {
+            vec![F::interpolation_node(9)]
+        } else {
+            vec![]
+        };
+        let round = prefix.len();
+        let eq_suffix = Poly::new_from_point(&tau[round + 1..], F::ONE);
+        let actual = if extension {
+            base.round_poly(&Poly::new_from_point(&tau[1..], F::ONE));
+            let mut ext = base.fold(prefix[0]);
+            if packed {
+                ext.round_poly_packed(&eq_suffix)
+            } else {
+                let ExtColumns::Packed(columns) = ext.columns else {
+                    unreachable!("binary packing has width one");
+                };
+                ext.columns = ExtColumns::Scalar(
+                    columns
+                        .into_iter()
+                        .map(|col| col.unpack::<F, F>())
+                        .collect(),
+                );
+                ext.round_poly_unpacked(&eq_suffix)
+            }
+        } else if packed {
+            base.round_poly_packed(&eq_suffix)
+        } else {
+            base.round_poly_unpacked(&eq_suffix)
+        };
+
+        let shifted = core::array::from_fn::<_, 8, _>(|row| trace[(row + 1).min(7)]);
+        let expected = [0, 2, 3].map(|node| {
+            eq_suffix
+                .as_slice()
+                .iter()
+                .enumerate()
+                .map(|(row, &weight)| {
+                    let mut coordinates = prefix.clone();
+                    coordinates.push(F::interpolation_node(node));
+                    coordinates.extend_from_slice(Point::hypercube(row, 2 - round).as_slice());
+                    let point = Point::new(coordinates);
+                    let local = PolyView::new(trace.as_slice()).eval_base(&point);
+                    let next = PolyView::new(shifted.as_slice()).eval_base(&point);
+                    let boundary = BoundaryEvals::at(point.as_slice());
+                    let local_bool = local.square() - local;
+                    weight
+                        * ((boundary.first * local_bool * alpha + boundary.last * local_bool)
+                            * alpha
+                            + boundary.transition * (next.square() - next))
+                })
+                .sum::<F>()
+        });
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn binary_base_scalar_uses_distinct_interpolation_nodes() {
+        check_binary_round_nodes(false, false);
+    }
+
+    #[test]
+    fn binary_base_packed_uses_distinct_interpolation_nodes() {
+        check_binary_round_nodes(true, false);
+    }
+
+    #[test]
+    fn binary_extension_scalar_uses_distinct_interpolation_nodes() {
+        check_binary_round_nodes(false, true);
+    }
+
+    #[test]
+    fn binary_extension_packed_uses_distinct_interpolation_nodes() {
+        check_binary_round_nodes(true, true);
     }
 }

--- a/multi-stark/src/selectors.rs
+++ b/multi-stark/src/selectors.rs
@@ -29,6 +29,16 @@ impl<EF> BoundaryEvals<EF> {
             transition,
         }
     }
+
+    /// Advance the selectors by a scalar multiple of their high-minus-low differences.
+    pub(super) fn add_scaled(&mut self, diff: Self, step: EF)
+    where
+        EF: PrimeCharacteristicRing + Copy,
+    {
+        self.first += diff.first * step;
+        self.last += diff.last * step;
+        self.transition += diff.transition * step;
+    }
 }
 
 impl<Packed> BoundaryEvals<Packed>
@@ -314,9 +324,7 @@ impl<EF> AddAssign for BoundaryEvals<EF>
 where
     EF: AddAssign,
 {
-    /// Advance all three selectors by one interpolation step.
-    ///
-    /// Adding the per-step difference moves each selector to the next integer node.
+    /// Add the corresponding selector values componentwise.
     fn add_assign(&mut self, rhs: Self) {
         self.first += rhs.first;
         self.last += rhs.last;

--- a/multi-stark/src/verifier.rs
+++ b/multi-stark/src/verifier.rs
@@ -4,7 +4,6 @@ use alloc::vec::Vec;
 use core::fmt::Debug;
 
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
-use p3_field::PrimeField;
 use p3_sumcheck::PrescribedPointPcs;
 use thiserror::Error;
 
@@ -104,7 +103,6 @@ pub fn verify<'a, C, A>(
 ) -> Result<(), VerificationError<PcsError<C>>>
 where
     C: MultiStarkConfig,
-    C::Val: PrimeField,
     C::Pcs: PrescribedPointPcs<C::Challenge, C::Challenger>,
     C::Challenger: FieldChallenger<C::Val>
         + GrindingChallenger<Witness = C::Val>

--- a/multi-stark/src/zerocheck.rs
+++ b/multi-stark/src/zerocheck.rs
@@ -16,8 +16,9 @@ use alloc::vec::Vec;
 use core::iter;
 
 use p3_air::{Air, AirLayout, BaseAir};
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, Field, PrimeField64};
+use p3_field::{ExtensionField, Field};
 use p3_lookup::InteractionSymbolicBuilder as SymbolicAirBuilder;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
@@ -350,7 +351,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         challenger: &mut Challenger,
     ) -> (ZerocheckProof<F, EF>, Point<EF>)
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: ProverAir<F, EF>,
         <EF as ExtensionField<F>>::ExtensionPacking: From<EF> + From<<F as Field>::Packing>,
@@ -387,7 +388,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         challenger: &mut Challenger,
     ) -> (ZerocheckProof<F, EF>, Point<EF>)
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: ProverAir<F, EF>,
         <EF as ExtensionField<F>>::ExtensionPacking: From<EF> + From<<F as Field>::Packing>,
@@ -763,7 +764,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         challenger: &mut Challenger,
     ) -> Result<Point<EF>, ZerocheckError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: VerifierAir<F, EF>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
@@ -787,7 +788,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         challenger: &mut Challenger,
     ) -> Result<Point<EF>, ZerocheckError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: VerifierAir<F, EF>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
@@ -915,7 +916,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         challenger: &mut Challenger,
     ) -> Result<ZerocheckReduction<EF>, ZerocheckError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: Air<SymbolicAirBuilder<F, EF>>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
@@ -943,7 +944,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         challenger: &mut Challenger,
     ) -> Result<ZerocheckReduction<EF>, ZerocheckError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: Air<SymbolicAirBuilder<F, EF>>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
@@ -1029,7 +1030,7 @@ impl<'a, A> AirZerocheck<'a, A> {
         public_values: &[&[F]],
     ) -> Result<(), ZerocheckError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         A: VerifierAir<F, EF>,
     {

--- a/sumcheck/src/generic_degree/proof.rs
+++ b/sumcheck/src/generic_degree/proof.rs
@@ -4,8 +4,9 @@
 
 use alloc::vec::Vec;
 
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, PrimeField64};
+use p3_field::ExtensionField;
 use p3_multilinear_util::point::Point;
 use serde::{Deserialize, Serialize};
 
@@ -88,7 +89,7 @@ impl<F, EF> GenericDegreeProof<F, EF> {
         pow_bits: usize,
     ) -> Result<(Point<EF>, EF), GenericDegreeError>
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {

--- a/sumcheck/src/generic_degree/prover.rs
+++ b/sumcheck/src/generic_degree/prover.rs
@@ -2,8 +2,9 @@
 
 use alloc::vec::Vec;
 
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{FieldChallenger, GrindingChallenger};
-use p3_field::{ExtensionField, PrimeField64};
+use p3_field::ExtensionField;
 use p3_multilinear_util::point::Point;
 
 use super::proof::GenericDegreeProof;
@@ -65,7 +66,7 @@ pub trait RoundProver<EF> {
         claimed_sum: EF,
     ) -> (GenericDegreeProof<F, EF>, Point<EF>)
     where
-        F: PrimeField64,
+        F: TranscriptField,
         EF: ExtensionField<F>,
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
@@ -331,5 +332,104 @@ mod tests {
                 Err(other) => panic!("expected an invalid pow witness error, got {other:?}"),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod binary_tests {
+    use alloc::vec::Vec;
+
+    use p3_binary_field::{BinaryChallenger, BinaryField128, TowerLevel};
+    use p3_challenger::{CanSample, HashChallenger};
+    use p3_field::Field;
+    use p3_keccak::Keccak256Hash;
+    use p3_multilinear_util::poly::Poly;
+
+    use super::RoundProver;
+    use crate::generic_degree::transcript::domain_separator;
+
+    type F = BinaryField128;
+    type Ch = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
+
+    fn fresh_challenger() -> Ch {
+        Ch::from_hasher(Vec::new(), Keccak256Hash)
+    }
+
+    struct ProductProver([Poly<F>; 3]);
+
+    impl RoundProver<F> for ProductProver {
+        fn fold(&mut self, r: F) {
+            for factor in &mut self.0 {
+                factor.fix_prefix_var_mut(r);
+            }
+        }
+
+        fn round_poly(&self) -> Vec<F> {
+            [0, 2, 3]
+                .into_iter()
+                .map(|i| {
+                    let node = F::interpolation_node(i);
+                    let half = self.0[0].num_evals() / 2;
+                    (0..half)
+                        .map(|j| {
+                            self.0
+                                .iter()
+                                .map(|factor| {
+                                    let values = factor.as_slice();
+                                    values[j] + (values[j + half] - values[j]) * node
+                                })
+                                .product::<F>()
+                        })
+                        .sum()
+                })
+                .collect()
+        }
+    }
+
+    #[test]
+    fn binary_sumcheck_round_trips_with_and_without_grinding() {
+        let factors: [Poly<F>; 3] = core::array::from_fn(|column| {
+            Poly::new(
+                (0..16)
+                    .map(|row| {
+                        F::from_repr(((row + 1) as u128) << (column * 40) | (column + 1) as u128)
+                    })
+                    .collect::<Vec<_>>(),
+            )
+        });
+        let claimed_sum: F = (0..16)
+            .map(|row| factors.iter().map(|f| f.as_slice()[row]).product::<F>())
+            .sum();
+        for pow_bits in [0, 4] {
+            let mut prover = ProductProver(factors.clone());
+            let mut p_ch = fresh_challenger();
+            let (proof, p_point) = prover.prove::<F, _>(&mut p_ch, 4, 3, pow_bits, claimed_sum);
+            assert_eq!(proof.pow_witnesses.len(), if pow_bits == 0 { 0 } else { 4 });
+            let mut v_ch = fresh_challenger();
+            let (v_point, final_sum) = proof.verify(&mut v_ch, 4, 3, pow_bits).unwrap();
+            assert_eq!(p_point, v_point);
+            assert_eq!(
+                final_sum,
+                factors.iter().map(|f| f.eval_base(&v_point)).product::<F>()
+            );
+            assert_eq!(
+                CanSample::<F>::sample(&mut p_ch),
+                CanSample::<F>::sample(&mut v_ch)
+            );
+        }
+    }
+
+    #[test]
+    fn binary_sumcheck_seed_binds_rounds_degree_and_grinding() {
+        let sample = |rounds, degree, pow_bits| {
+            let mut challenger = fresh_challenger();
+            domain_separator::<F, F>(rounds, degree, pow_bits).seed(&mut challenger);
+            CanSample::<F>::sample(&mut challenger)
+        };
+        let baseline = sample(4, 3, 0);
+        assert_ne!(baseline, sample(5, 3, 0));
+        assert_ne!(baseline, sample(4, 4, 0));
+        assert_ne!(baseline, sample(4, 3, 4));
+        assert_ne!(sample(4, 3, 4), sample(4, 3, 5));
     }
 }

--- a/sumcheck/src/generic_degree/transcript.rs
+++ b/sumcheck/src/generic_degree/transcript.rs
@@ -30,10 +30,10 @@ use core::marker::PhantomData;
 
 use p3_challenger::fs::{
     DomainSeparator, FieldToFieldCodec, FieldUnit, Hierarchy, Interaction, InteractionPattern,
-    Kind, Length, ProverState, VerifierState,
+    Kind, Length, ProverState, TranscriptField, VerifierState,
 };
 use p3_challenger::{CanObserve, CanSample, GrindingChallenger};
-use p3_field::{ExtensionField, PrimeField64};
+use p3_field::ExtensionField;
 
 use super::error::GenericDegreeError;
 
@@ -76,7 +76,7 @@ type Alphabet<F> = FieldUnit<F>;
 #[must_use]
 pub fn pattern<F, EF>(num_rounds: usize, degree: usize, pow_bits: usize) -> InteractionPattern
 where
-    F: PrimeField64,
+    F: TranscriptField,
     EF: ExtensionField<F>,
 {
     // One step for the claimed sum, then up to three per round.
@@ -136,7 +136,7 @@ pub fn domain_separator<F, EF>(
     pow_bits: usize,
 ) -> DomainSeparator<Alphabet<F>>
 where
-    F: PrimeField64,
+    F: TranscriptField,
     EF: ExtensionField<F>,
 {
     DomainSeparator::new(
@@ -161,7 +161,7 @@ where
 ///
 /// A sumcheck runs inside a larger protocol.
 /// That protocol's own transcript continues where this one stops.
-pub struct ProverTranscript<'a, C, F: PrimeField64, EF> {
+pub struct ProverTranscript<'a, C, F: TranscriptField, EF> {
     /// Driver walking the description and holding the borrowed sponge.
     state: ProverState<&'a mut C, Alphabet<F>>,
     /// Grinding difficulty per round, or zero to omit grinding.
@@ -172,7 +172,7 @@ pub struct ProverTranscript<'a, C, F: PrimeField64, EF> {
 
 impl<'a, C, F, EF> ProverTranscript<'a, C, F, EF>
 where
-    F: PrimeField64,
+    F: TranscriptField,
     EF: ExtensionField<F>,
     C: CanObserve<F> + CanSample<F> + GrindingChallenger<Witness = F>,
 {
@@ -253,7 +253,7 @@ where
 ///
 /// The values come from the proof rather than from a wire, so the caller must
 /// have checked their lengths against the described shape first.
-pub struct VerifierTranscript<'a, C, F: PrimeField64, EF> {
+pub struct VerifierTranscript<'a, C, F: TranscriptField, EF> {
     /// Driver walking the description and holding the borrowed sponge.
     ///
     /// The proof carries every value, so the driver reads an empty wire.
@@ -270,7 +270,7 @@ pub struct VerifierTranscript<'a, C, F: PrimeField64, EF> {
 
 impl<'a, C, F, EF> VerifierTranscript<'a, C, F, EF>
 where
-    F: PrimeField64,
+    F: TranscriptField,
     EF: ExtensionField<F>,
     C: CanObserve<F> + CanSample<F> + GrindingChallenger<Witness = F>,
 {


### PR DESCRIPTION
The multilinear STARK prover could not use `BinaryField128` and `BinaryPcs`: its typed sumcheck transcript required a 64-bit prime field, and AIR round kernels advanced interpolation nodes by adding one. This adds a complete binary AIR example that proves a nonlinear recurrence, serializes the proof, and verifies it with a fresh transcript.

## Changes

- Add `TranscriptField` hooks and a `BinaryField128` implementation for injective domain-separator absorption, canonical wire encoding, and stable field tags. Preserve existing prime-field transcript encodings.
- Advance all four base/extension, scalar/packed AIR round kernels through the field's distinct interpolation nodes, retaining addition-only stepping when consecutive nodes differ by one.
- Expose retained tables and cloning on binary PCS prover data, and connect binary fields to multi-STARK configuration and sumcheck APIs.
- Add a runnable example and tests for honest proofs, tampering, mixed-height batches, and reuse of preprocessed commitments.
- Explicitly reject active characteristic-two LogUp declarations, including zero-query-weight declarations. Binary LogUp is unsupported; the example uses ordinary AIR constraints and is not zero knowledge.

Run the example with:

```sh
cargo run --release -p p3-multi-stark --example prove_binary_field
```

## Validation

- The example verifies a serialized proof for 256 rows; all 8 E2E tests pass in serial and parallel modes.
- Multi-STARK and sumcheck release suites pass, including the existing WHIR compatibility fixture.
- Binary-field, binary-PCS, and challenger release tests pass. All 54 lookup tests pass in debug mode.
- Workspace Clippy with `--all-targets -- -D warnings`, nightly formatting, dependency sorting, TOML formatting, and whitespace checks pass.
- Documentation builds with broken-link errors enabled; two existing warnings remain in `challenger/src/multi_field_challenger.rs`.

The aggregate release test run hits two existing lookup `should_panic` tests that depend on `debug_assert!`: `generate_permutation_exclusive_rejects_non_boolean_flag` and `generate_permutation_exclusive_rejects_two_active_flags`. Their source and implementation are unchanged, and both pass in debug mode.
