### PR TITLE
chore: expose the parallel feature on every crate that uses rayon

### DIFF
--- a/binary-field/Cargo.toml
+++ b/binary-field/Cargo.toml
@@ -13,6 +13,9 @@ categories.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 criterion.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-challenger.workspace = true
 p3-field.workspace = true

--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-field.workspace = true
 p3-keccak.workspace = true

--- a/circle/Cargo.toml
+++ b/circle/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-challenger.workspace = true
 p3-commit.workspace = true

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-maybe-rayon.workspace = true
 p3-util.workspace = true

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-challenger.workspace = true
 p3-commit.workspace = true

--- a/matrix/Cargo.toml
+++ b/matrix/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 
 itertools.workspace = true

--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-commit.workspace = true
 p3-field.workspace = true

--- a/monty-31/Cargo.toml
+++ b/monty-31/Cargo.toml
@@ -9,6 +9,9 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 
+[features]
+parallel = ["p3-maybe-rayon/parallel"]
+
 [dependencies]
 p3-dft.workspace = true
 p3-field.workspace = true


### PR DESCRIPTION
## Summary

- Eight crates depend on `p3-maybe-rayon` but declared no `parallel` feature: `p3-binary-field`, `p3-challenger`, `p3-circle`, `p3-field`, `p3-fri`, `p3-matrix`, `p3-merkle-tree`, `p3-monty-31`. Each now forwards it, matching what `p3-dft`, `p3-sumcheck`, `p3-lookup` and friends already do.
- The consequence was that these crates' own tests and benchmarks could never select the parallel implementation. `cargo bench -p p3-merkle-tree --features parallel` failed with *"the package 'p3-merkle-tree' does not contain this feature: parallel"*, so the Merkle tree benchmark only ever reported single-threaded numbers.
- Cargo's feature unification hides this in a full build: as soon as any crate in the graph enables `p3-maybe-rayon/parallel`, the switch flips for every crate compiled alongside it. So `--workspace --features parallel` was always genuinely parallel, and no existing build changes behaviour here. The gap only bites a crate that is measured or tested **on its own** — which is exactly what you do when attributing a regression to one crate.
- Manifest-only change. No source, no public API, no behaviour change.

Measured on the isolated Merkle tree benchmark, which previously had no way to run in parallel at all (AMD Ryzen 9 9950X3D, 32 threads, `RUSTFLAGS=-C target-cpu=native`, `--measurement-time 5`):

| benchmark | serial (only mode available before) | `--features parallel` (new) | ratio |
| --- | --- | --- | --- |
| `MerkleTreeMmcs::<2, Poseidon2…>` | 51.69 ms | 5.42 ms | 9.5x |
| `MerkleTree::<2, Poseidon2…>` | 34.28 ms | 3.55 ms | 9.6x |
| `MerkleTreeMmcs::<4, Poseidon2…>` | 44.47 ms | 5.15 ms | 8.6x |
| `MerkleTree::<4, Poseidon2…>` | 33.82 ms | 3.41 ms | 9.9x |

Worth noting as a side effect: enabling the feature also runs these crates' rayon code paths under their own test suites for the first time. All 1010 tests pass, so nothing was hiding there.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p <crate> --features parallel` for all eight crates — 1010 tests passed, 0 failures (`p3-binary-field` 327, `p3-challenger` 178, `p3-matrix` 174, `p3-merkle-tree` 100, `p3-fri` 81, `p3-field` 62, `p3-circle` 48, `p3-monty-31` 40)
- [x] `cargo +stable clippy --all-targets -- -D warnings` — clean
- [x] `cargo +stable clippy -p <crate> --all-targets --features parallel -- -D warnings` for all eight — clean
- [x] `cargo +stable sort --workspace --grouped --check` — clean
- [x] `taplo fmt --check` — clean
- [x] `cargo machete --with-metadata` — no unused dependencies
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo bench -p p3-merkle-tree --features parallel` — resolves and runs, where it previously errored

🤖 Generated with [Claude Code](https://claude.com/claude-code)