### PR TITLE
perf(merkle-tree): reach the vectorized Keccak from the Merkle tree

### DIFF
--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -99,8 +99,8 @@ impl CryptographicPermutation<[u8; 200]> for KeccakF {}
 
 /// Byte rate of the Keccak-256 sponge.
 ///
-/// The permutation holds 1600 bits and the security target reserves twice the 256-bit digest
-/// as capacity, which leaves 1088 bits, exactly 136 bytes, absorbed per permutation.
+/// Capacity is twice the 256-bit digest, taken out of the 1600-bit permutation.
+/// That leaves 1088 bits, exactly 136 bytes, absorbed per permutation.
 const RATE: usize = (1600 - 2 * 256) / 8;
 
 /// Digest length of Keccak-256 in bytes.
@@ -149,8 +149,8 @@ fn absorb_into_lane(state: &mut [[u64; VECTOR_LEN]; 25], lane: usize, block: &[u
 ///                     offset                 rate - 1
 /// ```
 ///
-/// A message ending one byte short of the rate puts both marks in the same byte, and since both
-/// are applied by exclusive-or that byte simply becomes `0x81`, which is what the rule requires.
+/// A message ending one byte short of the rate puts both marks in the same byte.
+/// Exclusive-or makes that byte `0x81`, exactly what the rule requires.
 #[inline]
 fn pad_lane(state: &mut [[u64; VECTOR_LEN]; 25], lane: usize, offset: usize) {
     debug_assert!(offset < RATE);
@@ -233,22 +233,20 @@ impl CryptographicHasher<u8, [u8; 32]> for Keccak256Hash {
             return;
         }
 
-        // A message of `len` bytes fills this many whole rate blocks, leaving a shorter final
-        // block that carries the padding, possibly empty when the length divides the rate.
+        // Whole rate blocks are absorbed in lockstep, then one shorter final block.
+        // That final block carries the padding and is empty when the length divides the rate.
         let full_blocks = len / RATE;
         let final_block = len % RATE;
 
         // One message per lane per permutation.
-        // The last group may be short and simply leaves the unused lanes at their initial
-        // state, whose digests are never read.
+        // A short last group leaves the unused lanes at their initial state, never read.
         for (messages, digests) in input
             .chunks(len * VECTOR_LEN)
             .zip(out.chunks_mut(VECTOR_LEN))
         {
             let mut state = [[0u64; VECTOR_LEN]; 25];
 
-            // Absorb the whole blocks in lockstep: every lane contributes its block, then the
-            // single vectorized permutation advances all of the sponges together.
+            // Every lane contributes its block, then one permutation advances all the sponges.
             for block in 0..full_blocks {
                 for (lane, message) in messages.chunks_exact(len).enumerate() {
                     absorb_into_lane(&mut state, lane, &message[block * RATE..][..RATE]);
@@ -283,6 +281,7 @@ mod tests {
     /// Every message length that changes the shape of the absorb loop.
     ///
     /// The block boundaries are the interesting ones:
+    ///
     /// - A length one short of the rate folds both padding marks into a single byte.
     /// - A length that is an exact multiple of the rate pads a block carrying no message bytes.
     const SHAPE_LENGTHS: [usize; 14] = [
@@ -319,8 +318,8 @@ mod tests {
 
     #[test]
     fn hash_many_matches_scalar_across_block_shapes() {
-        // Batch sizes below, at, and above one full lane group, so the final short group is
-        // exercised at every lane count the target might compile to.
+        // Batch sizes below, at, and above one full lane group.
+        // The final short group is then exercised at every lane count the target compiles to.
         let counts: Vec<usize> = (1..=2 * VECTOR_LEN + 1).collect();
 
         for len in SHAPE_LENGTHS {
@@ -342,8 +341,8 @@ mod tests {
 
     #[test]
     fn hash_many_splits_input_by_digest_count() {
-        // The message length is derived from the input length divided by the digest count, so
-        // 64 bytes and 4 digests must be read as four adjacent 16-byte messages.
+        // The message length is the input length divided by the digest count.
+        // 64 bytes and 4 digests therefore read as four adjacent 16-byte messages.
         let messages: Vec<u8> = (0..64).map(|i| i as u8).collect();
 
         // 4 messages of 16 bytes each.
@@ -358,8 +357,8 @@ mod tests {
     #[test]
     #[should_panic(expected = "must be a whole multiple")]
     fn hash_many_rejects_ragged_input() {
-        // 5 bytes cannot split into 2 equal messages, so the contract is violated up front
-        // rather than producing digests over silently misaligned message boundaries.
+        // 5 bytes cannot split into 2 equal messages.
+        // The contract fails up front rather than misaligning message boundaries.
         let mut digests = [[0u8; 32]; 2];
         Keccak256Hash.hash_many(&[1, 2, 3, 4, 5], &mut digests);
     }

--- a/keccak/src/lib.rs
+++ b/keccak/src/lib.rs
@@ -2,6 +2,9 @@
 
 #![no_std]
 
+#[cfg(test)]
+extern crate alloc;
+
 use p3_symmetric::{CryptographicHasher, CryptographicPermutation, Permutation};
 use tiny_keccak::{Hasher, Keccak, keccakf};
 
@@ -94,12 +97,92 @@ impl Permutation<[u8; 200]> for KeccakF {
 
 impl CryptographicPermutation<[u8; 200]> for KeccakF {}
 
+/// Byte rate of the Keccak-256 sponge.
+///
+/// The permutation holds 1600 bits and the security target reserves twice the 256-bit digest
+/// as capacity, which leaves 1088 bits, exactly 136 bytes, absorbed per permutation.
+const RATE: usize = (1600 - 2 * 256) / 8;
+
+/// Digest length of Keccak-256 in bytes.
+const DIGEST_BYTES: usize = 32;
+
+/// Absorb up to one rate block of a single message into one lane of a vectorized state.
+///
+/// A vectorized state keeps one independent sponge per lane, side by side.
+/// The lane count is whatever the target's permutation is wide.
+///
+/// ```text
+///     state[word][lane]      word = 0..25, lane = 0..L
+///
+///     state[0]  [ s_0^(0)  s_0^(1)  ...  s_0^(L-1) ]
+///     state[1]  [ s_1^(0)  s_1^(1)  ...  s_1^(L-1) ]
+///     ...
+/// ```
+///
+/// Absorbing writes only the given lane's column, so the messages never need transposing.
+/// Bytes enter the state little-endian, eight to a state word, matching the Keccak convention.
+#[inline]
+fn absorb_into_lane(state: &mut [[u64; VECTOR_LEN]; 25], lane: usize, block: &[u8]) {
+    debug_assert!(block.len() <= RATE);
+
+    // Whole state words come straight from eight consecutive message bytes.
+    let (words, tail) = block.as_chunks::<8>();
+    for (word_index, word) in words.iter().enumerate() {
+        state[word_index][lane] ^= u64::from_le_bytes(*word);
+    }
+
+    // A short final run occupies the low bytes of the next state word, the rest staying zero.
+    if !tail.is_empty() {
+        let mut last = [0u8; 8];
+        last[..tail.len()].copy_from_slice(tail);
+        state[words.len()][lane] ^= u64::from_le_bytes(last);
+    }
+}
+
+/// Apply the Keccak padding to one lane after its final partial block was absorbed.
+///
+/// The rule is `pad10*1` with the original Keccak domain byte, so the block becomes
+///
+/// ```text
+///     [ message bytes | 0x01 | 0x00 ... 0x00 | 0x80 ]
+///                        ^                      ^
+///                     offset                 rate - 1
+/// ```
+///
+/// A message ending one byte short of the rate puts both marks in the same byte, and since both
+/// are applied by exclusive-or that byte simply becomes `0x81`, which is what the rule requires.
+#[inline]
+fn pad_lane(state: &mut [[u64; VECTOR_LEN]; 25], lane: usize, offset: usize) {
+    debug_assert!(offset < RATE);
+
+    // First mark sits immediately after the last absorbed byte of the final block.
+    state[offset / 8][lane] ^= 0x01u64 << (8 * (offset % 8));
+
+    // Second mark closes the block at its very last byte.
+    state[(RATE - 1) / 8][lane] ^= 0x80u64 << (8 * ((RATE - 1) % 8));
+}
+
+/// Read the digest of one lane out of a permuted vectorized state.
+#[inline]
+fn squeeze_lane(state: &[[u64; VECTOR_LEN]; 25], lane: usize) -> [u8; DIGEST_BYTES] {
+    let mut digest = [0u8; DIGEST_BYTES];
+
+    // The digest is the leading bytes of the rate portion, little-endian per state word.
+    for (word_index, word) in digest.as_chunks_mut::<8>().0.iter_mut().enumerate() {
+        *word = state[word_index][lane].to_le_bytes();
+    }
+
+    digest
+}
+
 /// The `Keccak` hash functions defined in
 /// [Keccak SHA3 submission](https://keccak.team/files/Keccak-submission-3.pdf).
 #[derive(Copy, Clone, Debug)]
 pub struct Keccak256Hash;
 
 impl CryptographicHasher<u8, [u8; 32]> for Keccak256Hash {
+    const LANES: usize = VECTOR_LEN;
+
     fn hash_iter<I>(&self, input: I) -> [u8; 32]
     where
         I: IntoIterator<Item = u8>,
@@ -125,5 +208,184 @@ impl CryptographicHasher<u8, [u8; 32]> for Keccak256Hash {
         let mut output = [0u8; 32];
         hasher.finalize(&mut output);
         output
+    }
+
+    fn hash_many(&self, input: &[u8], out: &mut [[u8; 32]]) {
+        // No digests requested means there is nothing to read from the input.
+        if out.is_empty() {
+            return;
+        }
+
+        // Every message has the same length, so the split is exact by contract.
+        assert!(
+            input.len().is_multiple_of(out.len()),
+            "input length ({}) must be a whole multiple of the digest count ({})",
+            input.len(),
+            out.len()
+        );
+        let len = input.len() / out.len();
+
+        // Empty messages all share one digest and drive no absorb loop at all.
+        if len == 0 {
+            for digest in out.iter_mut() {
+                *digest = self.hash_iter(core::iter::empty());
+            }
+            return;
+        }
+
+        // A message of `len` bytes fills this many whole rate blocks, leaving a shorter final
+        // block that carries the padding, possibly empty when the length divides the rate.
+        let full_blocks = len / RATE;
+        let final_block = len % RATE;
+
+        // One message per lane per permutation.
+        // The last group may be short and simply leaves the unused lanes at their initial
+        // state, whose digests are never read.
+        for (messages, digests) in input
+            .chunks(len * VECTOR_LEN)
+            .zip(out.chunks_mut(VECTOR_LEN))
+        {
+            let mut state = [[0u64; VECTOR_LEN]; 25];
+
+            // Absorb the whole blocks in lockstep: every lane contributes its block, then the
+            // single vectorized permutation advances all of the sponges together.
+            for block in 0..full_blocks {
+                for (lane, message) in messages.chunks_exact(len).enumerate() {
+                    absorb_into_lane(&mut state, lane, &message[block * RATE..][..RATE]);
+                }
+                KeccakF.permute_mut(&mut state);
+            }
+
+            // Absorb each final partial block and mark it, still without permuting in between.
+            for (lane, message) in messages.chunks_exact(len).enumerate() {
+                absorb_into_lane(&mut state, lane, &message[full_blocks * RATE..]);
+                pad_lane(&mut state, lane, final_block);
+            }
+            KeccakF.permute_mut(&mut state);
+
+            // Squeeze one digest per requested message.
+            for (lane, digest) in digests.iter_mut().enumerate() {
+                *digest = squeeze_lane(&state, lane);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use proptest::prelude::*;
+
+    use super::*;
+
+    /// Every message length that changes the shape of the absorb loop.
+    ///
+    /// The block boundaries are the interesting ones:
+    /// - A length one short of the rate folds both padding marks into a single byte.
+    /// - A length that is an exact multiple of the rate pads a block carrying no message bytes.
+    const SHAPE_LENGTHS: [usize; 14] = [
+        0,
+        1,
+        7,
+        8,
+        9,
+        RATE - 1,
+        RATE,
+        RATE + 1,
+        2 * RATE - 1,
+        2 * RATE,
+        2 * RATE + 1,
+        3 * RATE,
+        400,
+        1000,
+    ];
+
+    /// Hash each message on its own, which is the behaviour the batched path must reproduce.
+    fn reference(messages: &[u8], len: usize, count: usize) -> Vec<[u8; 32]> {
+        (0..count)
+            .map(|k| {
+                // A zero-length message still has a digest, so slice defensively.
+                let message = if len == 0 {
+                    &messages[..0]
+                } else {
+                    &messages[k * len..(k + 1) * len]
+                };
+                Keccak256Hash.hash_slice(message)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn hash_many_matches_scalar_across_block_shapes() {
+        // Batch sizes below, at, and above one full lane group, so the final short group is
+        // exercised at every lane count the target might compile to.
+        let counts: Vec<usize> = (1..=2 * VECTOR_LEN + 1).collect();
+
+        for len in SHAPE_LENGTHS {
+            for &count in &counts {
+                // Fixture: a deterministic byte ramp, distinct per position.
+                let messages: Vec<u8> = (0..len * count).map(|i| (i * 31 + 7) as u8).collect();
+
+                let mut batched = vec![[0u8; 32]; count];
+                Keccak256Hash.hash_many(&messages, &mut batched);
+
+                assert_eq!(
+                    batched,
+                    reference(&messages, len, count),
+                    "len {len}, count {count}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hash_many_splits_input_by_digest_count() {
+        // The message length is derived from the input length divided by the digest count, so
+        // 64 bytes and 4 digests must be read as four adjacent 16-byte messages.
+        let messages: Vec<u8> = (0..64).map(|i| i as u8).collect();
+
+        // 4 messages of 16 bytes each.
+        let mut digests = [[0u8; 32]; 4];
+        Keccak256Hash.hash_many(&messages, &mut digests);
+
+        for (k, digest) in digests.iter().enumerate() {
+            assert_eq!(*digest, Keccak256Hash.hash_slice(&messages[k * 16..][..16]));
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a whole multiple")]
+    fn hash_many_rejects_ragged_input() {
+        // 5 bytes cannot split into 2 equal messages, so the contract is violated up front
+        // rather than producing digests over silently misaligned message boundaries.
+        let mut digests = [[0u8; 32]; 2];
+        Keccak256Hash.hash_many(&[1, 2, 3, 4, 5], &mut digests);
+    }
+
+    proptest! {
+        #[test]
+        fn hash_many_matches_scalar_on_random_batches(
+            len in 0usize..=400,
+            count in 1usize..=17,
+            seed in any::<u64>(),
+        ) {
+            // Fixture: a cheap deterministic stream so the case shrinks reproducibly.
+            let mut x = seed | 1;
+            let messages: Vec<u8> = (0..len * count)
+                .map(|_| {
+                    x ^= x << 13;
+                    x ^= x >> 7;
+                    x ^= x << 17;
+                    x as u8
+                })
+                .collect();
+
+            let mut batched = vec![[0u8; 32]; count];
+            Keccak256Hash.hash_many(&messages, &mut batched);
+
+            prop_assert_eq!(batched, reference(&messages, len, count));
+        }
     }
 }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -243,6 +243,61 @@ pub(crate) fn select_arity_step<const N: usize>(
     if has_intermediate { 2 } else { N }
 }
 
+/// Allocate a digest layer of `len` slots, every slot set to the default digest.
+///
+/// Every slot of a layer is overwritten by the level that produces it, apart from a short
+/// padding tail, so the fill is pure overhead and worth getting for free from the allocator.
+///
+/// A zero-filled allocation is free: the operating system hands back pages that are already
+/// zero and only faults them in when the hashing threads write them.
+/// The standard vector constructor reaches that path only when it can see at run time that the
+/// element is all zero bits, and it deliberately gives up on that check for arrays longer than
+/// sixteen elements, which is exactly the shape of a thirty-two-byte digest.
+///
+/// Building the layer as one flat run of digest words restores the check, because a word is a
+/// primitive the constructor still inspects.
+/// The flat run and the run of digests have the very same allocation layout, so viewing one as
+/// the other costs nothing:
+///
+/// ```text
+///     flat:    [ w_0 w_1 ... w_{D-1} | w_D ... w_{2D-1} | ... ]   len * D words
+///     digests: [       digest_0      |     digest_1     | ... ]   len digests
+/// ```
+///
+/// # Panics
+/// Panics if the layer is too large for the address space.
+fn default_digest_layer<W, const DIGEST_ELEMS: usize>(len: usize) -> Vec<[W; DIGEST_ELEMS]>
+where
+    W: Copy + Default,
+{
+    // A layer with no slots, or a digest of no words, owns no allocation worth reinterpreting.
+    if len == 0 || DIGEST_ELEMS == 0 {
+        return vec![[W::default(); DIGEST_ELEMS]; len];
+    }
+
+    // Guard the multiply so a wrapped word count can never under-allocate the layer.
+    let words = len
+        .checked_mul(DIGEST_ELEMS)
+        .expect("digest layer length overflows");
+
+    let mut flat: Vec<W> = vec![W::default(); words];
+
+    // A vector may reserve more than requested, and only an exact allocation converts.
+    if flat.capacity() != words {
+        return vec![[W::default(); DIGEST_ELEMS]; len];
+    }
+
+    let ptr = flat.as_mut_ptr().cast::<[W; DIGEST_ELEMS]>();
+    core::mem::forget(flat);
+
+    // SAFETY: an array of `DIGEST_ELEMS` words has no padding, so `len` digests occupy exactly
+    // the `len * DIGEST_ELEMS` words allocated above, with the same alignment as one word.
+    // The requested length equals the reserved capacity, so the layout handed back to the
+    // allocator on drop is byte for byte the layout it handed out.
+    // Every word is initialized, so every digest slot reads as the default digest.
+    unsafe { Vec::from_raw_parts(ptr, len, len) }
+}
+
 /// Output nodes below which a level is hashed on the calling thread.
 ///
 /// A parallel dispatch costs a fixed amount per level, and the levels near the root hold so few
@@ -378,9 +433,9 @@ where
     let max_height = tallest_matrices[0].height();
     let max_height_padded = padded_len(max_height, N);
 
-    // Slots past the real rows exist only so the next level can form whole groups.
-    let default_digest = [W::default(); DIGEST_ELEMS];
-    let mut digests = vec![default_digest; max_height_padded];
+    // Slots past the real rows exist only so the next level can form whole groups, and the
+    // allocation already leaves them at the default digest.
+    let mut digests = default_digest_layer::<W, DIGEST_ELEMS>(max_height_padded);
 
     hash_rows_batched(h, tallest_matrices, 0, &mut digests[..max_height]);
 
@@ -413,8 +468,7 @@ where
     let next_len = prev_layer.len() / N;
     let next_len_padded = padded_len(next_len, N);
 
-    let default_digest = [W::default(); DIGEST_ELEMS];
-    let mut next_digests = vec![default_digest; next_len_padded];
+    let mut next_digests = default_digest_layer::<W, DIGEST_ELEMS>(next_len_padded);
 
     // Any trailing child that cannot complete a group takes no part in this level.
     let (groups, _) = prev_layer[..next_len * N].as_chunks::<N>();
@@ -457,7 +511,7 @@ where
     let next_len_padded = padded_len(raw_next, N);
 
     let default_digest = [W::default(); DIGEST_ELEMS];
-    let mut next_digests = vec![default_digest; next_len_padded];
+    let mut next_digests = default_digest_layer::<W, DIGEST_ELEMS>(next_len_padded);
 
     let (groups, _) = prev_layer[..raw_next * N].as_chunks::<N>();
 
@@ -554,11 +608,9 @@ where
 
     let max_height_padded = padded_len(max_height, N);
 
-    // Prepare a default digest value to fill unused slots or padding.
-    let default_digest = [PW::Value::default(); DIGEST_ELEMS];
-
-    // Allocate the digest vector with padded size, initialized to default digest.
-    let mut digests = vec![default_digest; max_height_padded];
+    // Allocate the digest vector with padded size, every slot at the default digest so the
+    // padding tail past the real rows is already correct.
+    let mut digests = default_digest_layer::<PW::Value, DIGEST_ELEMS>(max_height_padded);
 
     // Parallel loop: process complete batches of `width` rows at a time.
     digests[0..max_height]
@@ -657,7 +709,7 @@ where
     let next_len_padded = padded_len(raw_next, N);
 
     let default_digest = [PW::Value::default(); DIGEST_ELEMS];
-    let mut next_digests = vec![default_digest; next_len_padded];
+    let mut next_digests = default_digest_layer::<PW::Value, DIGEST_ELEMS>(next_len_padded);
 
     let default_packed: [PW; DIGEST_ELEMS] =
         array::from_fn(|_| PW::broadcast(PW::Value::default()));
@@ -794,7 +846,7 @@ where
     let next_len_padded = padded_len(next_len, N);
 
     let default_digest = [P::Value::default(); DIGEST_ELEMS];
-    let mut next_digests = vec![default_digest; next_len_padded];
+    let mut next_digests = default_digest_layer::<P::Value, DIGEST_ELEMS>(next_len_padded);
 
     let default_packed: [P; DIGEST_ELEMS] = array::from_fn(|_| P::broadcast(P::Value::default()));
 
@@ -1010,6 +1062,24 @@ mod tests {
             );
         }
         assert_eq!(batched.root(), unbatched.root());
+    }
+
+    #[test]
+    fn default_digest_layer_is_all_default() {
+        // Byte digests: the word type is a primitive, so the allocation takes the zeroed path
+        // and the reinterpretation back to digests must still read as the default digest.
+        let bytes = default_digest_layer::<u8, 32>(5);
+        assert_eq!(bytes, vec![[0u8; 32]; 5]);
+
+        // A field word type whose default is not a primitive zero follows the plain fill path.
+        let words = default_digest_layer::<F, 8>(3);
+        assert_eq!(words, vec![[F::default(); 8]; 3]);
+
+        // An empty layer is legal: a height-zero tree allocates nothing.
+        assert!(default_digest_layer::<u8, 32>(0).is_empty());
+
+        // A digest width of one exercises the case where a digest is a single word.
+        assert_eq!(default_digest_layer::<u8, 1>(7), vec![[0u8; 1]; 7]);
     }
 
     #[test]

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -243,6 +243,266 @@ pub(crate) fn select_arity_step<const N: usize>(
     if has_intermediate { 2 } else { N }
 }
 
+/// Output nodes below which a level is hashed on the calling thread.
+///
+/// A parallel dispatch costs a fixed amount per level, and the levels near the root hold so few
+/// nodes that the dispatch outweighs the hashing itself.
+/// Grouping messages is independent of threading, so a small level keeps the full vector width
+/// even while it runs on one thread.
+/// 1024 is the point where the two costs balance in practice: it still leaves tens of nodes per
+/// thread on a many-core machine, and every wider level fans out.
+const SERIAL_LEVEL_NODES: usize = 1024;
+
+/// Output nodes handed to one parallel task.
+///
+/// Matching the serial threshold keeps a task large enough to amortize the dispatch and small
+/// enough that its scratch buffers stay in the mid-level cache.
+const TASK_NODES: usize = 1024;
+
+/// Target size in bytes of the buffer holding one group of copied rows.
+///
+/// A batched hasher wants its messages back to back in memory, and a matrix only promises access
+/// one row at a time, so a group of rows is copied into a buffer first.
+/// 16 KiB keeps that buffer inside the first-level cache, so the hasher reads the rows back while
+/// they are still hot.
+const ROW_SCRATCH_BYTES: usize = 16 * 1024;
+
+/// Hash a run of rows from a set of equal-height matrices, several messages per hash call.
+///
+/// The message for a row is the concatenation of that row across every matrix, in matrix order,
+/// which is exactly what the unbatched path feeds its hasher one row at a time.
+///
+/// # Arguments
+/// - `h`: hasher applied to each row message.
+/// - `matrices`: matrices of equal height whose rows are concatenated.
+/// - `first_row`: index of the row whose digest lands in the first output slot.
+/// - `out`: one slot per consecutive row starting at that index.
+///
+/// # Panics
+/// Panics if any matrix is shorter than the requested row range.
+fn hash_rows_batched<F, W, H, M, const DIGEST_ELEMS: usize>(
+    h: &H,
+    matrices: &[&M],
+    first_row: usize,
+    out: &mut [[W; DIGEST_ELEMS]],
+) where
+    F: Clone + Send + Sync,
+    W: Send + Sync,
+    H: CryptographicHasher<F, [W; DIGEST_ELEMS]> + Sync,
+    M: Matrix<F>,
+{
+    // Bound the row range up front, since the copy loop below skips per-row bounds checks.
+    assert!(
+        matrices.iter().all(|m| m.height() >= first_row + out.len()),
+        "row range {}..{} exceeds a matrix height",
+        first_row,
+        first_row + out.len()
+    );
+
+    // A message spans one row of every matrix.
+    let total_width: usize = matrices.iter().map(|m| m.width()).sum();
+    let row_bytes = (total_width * size_of::<F>()).max(1);
+
+    // Fill as many whole lane groups as the scratch budget allows, and never fewer than one,
+    // so every hash call keeps the hasher's vector width busy.
+    let lanes = H::LANES;
+    let rows_per_call = (ROW_SCRATCH_BYTES / row_bytes / lanes).max(1) * lanes;
+
+    let hash_chunk = |base: usize, digests: &mut [[W; DIGEST_ELEMS]]| {
+        // One buffer per task, reused by every group inside it.
+        let mut scratch: Vec<F> = Vec::with_capacity(rows_per_call * total_width);
+
+        for (group, group_digests) in digests.chunks_mut(rows_per_call).enumerate() {
+            let first = base + group * rows_per_call;
+
+            // Lay the group's messages back to back: row by row, matrix by matrix.
+            scratch.clear();
+            for row in first..first + group_digests.len() {
+                for m in matrices {
+                    // SAFETY: the assertion above bounds every requested row by every height.
+                    let slice = unsafe { m.row_slice_unchecked(row) };
+                    scratch.extend_from_slice(&slice);
+                }
+            }
+
+            h.hash_many(&scratch, group_digests);
+        }
+    };
+
+    if out.len() <= SERIAL_LEVEL_NODES {
+        // Small level: one task would be shared by nobody, so skip the dispatch.
+        hash_chunk(first_row, out);
+    } else {
+        // Keep each task a whole number of groups so only the final group is ever short.
+        let task = rows_per_call * TASK_NODES.div_ceil(rows_per_call);
+        out.par_chunks_mut(task)
+            .enumerate()
+            .for_each(|(task_index, digests)| hash_chunk(first_row + task_index * task, digests));
+    }
+}
+
+/// Compress a run of already-grouped children, several groups per compression call.
+///
+/// # Arguments
+/// - `c`: compression function applied to each group.
+/// - `groups`: one array of `N` children per output node.
+/// - `out`: one slot per group.
+fn compress_groups_batched<T, C, const N: usize>(c: &C, groups: &[[T; N]], out: &mut [T])
+where
+    T: Clone + Send + Sync,
+    C: PseudoCompressionFunction<T, N> + Sync,
+{
+    if out.len() <= SERIAL_LEVEL_NODES {
+        // Small level: one task would be shared by nobody, so skip the dispatch.
+        c.compress_many(groups, out);
+    } else {
+        groups
+            .par_chunks(TASK_NODES)
+            .zip(out.par_chunks_mut(TASK_NODES))
+            .for_each(|(group_chunk, digest_chunk)| c.compress_many(group_chunk, digest_chunk));
+    }
+}
+
+/// Build the first digest layer with a hasher that hashes several messages per call.
+fn first_digest_layer_batched<F, W, H, M, const N: usize, const DIGEST_ELEMS: usize>(
+    h: &H,
+    tallest_matrices: &[&M],
+) -> Vec<[W; DIGEST_ELEMS]>
+where
+    F: Clone + Send + Sync,
+    W: Copy + Default + Send + Sync,
+    H: CryptographicHasher<F, [W; DIGEST_ELEMS]> + Sync,
+    M: Matrix<F>,
+{
+    // All of the tallest matrices share one height by construction.
+    let max_height = tallest_matrices[0].height();
+    let max_height_padded = padded_len(max_height, N);
+
+    // Slots past the real rows exist only so the next level can form whole groups.
+    let default_digest = [W::default(); DIGEST_ELEMS];
+    let mut digests = vec![default_digest; max_height_padded];
+
+    hash_rows_batched(h, tallest_matrices, 0, &mut digests[..max_height]);
+
+    digests
+}
+
+/// Fold one digest layer into the next with a compression function that compresses several
+/// groups per call.
+///
+/// A node's children sit next to each other in the layer below, so a run of `N` children is
+/// already the contiguous preimage of one parent and a run of parents is a contiguous run of
+/// those preimages:
+///
+/// ```text
+///     prev_layer: [ c_0 c_1 | c_2 c_3 | c_4 c_5 | ... ]     N = 2
+///                   \-----/   \-----/   \-----/
+///     out:            d_0       d_1       d_2       ...
+/// ```
+///
+/// Reading the layer as groups is therefore a reinterpretation of the same memory, with no
+/// transposition and no gathering.
+fn compress_batched<W, C, const N: usize, const DIGEST_ELEMS: usize>(
+    prev_layer: &[[W; DIGEST_ELEMS]],
+    c: &C,
+) -> Vec<[W; DIGEST_ELEMS]>
+where
+    W: Copy + Default + Send + Sync,
+    C: PseudoCompressionFunction<[W; DIGEST_ELEMS], N> + Sync,
+{
+    let next_len = prev_layer.len() / N;
+    let next_len_padded = padded_len(next_len, N);
+
+    let default_digest = [W::default(); DIGEST_ELEMS];
+    let mut next_digests = vec![default_digest; next_len_padded];
+
+    // Any trailing child that cannot complete a group takes no part in this level.
+    let (groups, _) = prev_layer[..next_len * N].as_chunks::<N>();
+    compress_groups_batched(c, groups, &mut next_digests[..next_len]);
+
+    next_digests
+}
+
+/// Fold one digest layer into the next and mix in rows of smaller matrices, batching both the
+/// compressions and the row hashes.
+///
+/// Each output node is built in three passes over the same chunk, so the intermediate buffers
+/// stay proportional to a task rather than to the whole level:
+///
+/// ```text
+///     pass 1: compress N children            -> folded
+///     pass 2: hash one row per output node    -> injected
+///     pass 3: compress [folded, injected]    -> out
+/// ```
+///
+/// Output nodes past the injected matrices' height get the default digest in place of a row
+/// digest, matching the unbatched path.
+fn compress_and_inject_batched<F, W, H, C, M, const N: usize, const DIGEST_ELEMS: usize>(
+    prev_layer: &[[W; DIGEST_ELEMS]],
+    matrices_to_inject: &[&M],
+    h: &H,
+    c: &C,
+) -> Vec<[W; DIGEST_ELEMS]>
+where
+    F: Clone + Send + Sync,
+    W: Copy + Default + Send + Sync,
+    H: CryptographicHasher<F, [W; DIGEST_ELEMS]> + Sync,
+    C: PseudoCompressionFunction<[W; DIGEST_ELEMS], N> + Sync,
+    M: Matrix<F>,
+{
+    // Rows are injected for the leading nodes only.
+    // The nodes past the injected matrices' height are pure compressions.
+    let inject_len = matrices_to_inject[0].height();
+    let raw_next = prev_layer.len() / N;
+    let next_len_padded = padded_len(raw_next, N);
+
+    let default_digest = [W::default(); DIGEST_ELEMS];
+    let mut next_digests = vec![default_digest; next_len_padded];
+
+    let (groups, _) = prev_layer[..raw_next * N].as_chunks::<N>();
+
+    let build = |base: usize,
+                 group_chunk: &[[[W; DIGEST_ELEMS]; N]],
+                 digest_chunk: &mut [[W; DIGEST_ELEMS]]| {
+        let count = digest_chunk.len();
+
+        // Pass 1: fold the children of every node in this chunk.
+        let mut folded = vec![default_digest; count];
+        c.compress_many(group_chunk, &mut folded);
+
+        // Pass 2: hash one row per node, for as many nodes as the matrices are tall.
+        let injected_count = count.min(inject_len.saturating_sub(base));
+        let mut injected = vec![default_digest; injected_count];
+        hash_rows_batched(h, matrices_to_inject, base, &mut injected);
+
+        // Pass 3: pair each folded digest with its row digest, padding the group to `N`.
+        let mut pairs = vec![[default_digest; N]; count];
+        for (node, pair) in pairs.iter_mut().enumerate() {
+            *pair = array::from_fn(|slot| match slot {
+                0 => folded[node],
+                1 if node < injected_count => injected[node],
+                _ => default_digest,
+            });
+        }
+        c.compress_many(&pairs, digest_chunk);
+    };
+
+    if raw_next <= SERIAL_LEVEL_NODES {
+        // Small level: one task would be shared by nobody, so skip the dispatch.
+        build(0, groups, &mut next_digests[..raw_next]);
+    } else {
+        groups
+            .par_chunks(TASK_NODES)
+            .zip(next_digests[..raw_next].par_chunks_mut(TASK_NODES))
+            .enumerate()
+            .for_each(|(task_index, (group_chunk, digest_chunk))| {
+                build(task_index * TASK_NODES, group_chunk, digest_chunk);
+            });
+    }
+
+    next_digests
+}
+
 /// Hash every row of the tallest matrices and build the first digest layer.
 ///
 /// This function is responsible for creating the first layer of Merkle digests,
@@ -277,6 +537,15 @@ where
         + Sync,
     M: Matrix<P::Value>,
 {
+    // A hasher that hashes several messages per call wants whole rows, not packed columns,
+    // so it takes a separate driver.
+    if <H as CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>>::LANES > 1 {
+        return first_digest_layer_batched::<P::Value, PW::Value, H, M, N, DIGEST_ELEMS>(
+            h,
+            tallest_matrices,
+        );
+    }
+
     // The number of rows to pack and hash together in one SIMD batch.
     let width = PW::WIDTH;
 
@@ -365,6 +634,21 @@ where
 {
     if matrices_to_inject.is_empty() {
         return compress::<PW, _, N, DIGEST_ELEMS>(prev_layer, step, c);
+    }
+
+    // The batched arm reads a node's children as one contiguous group, which only lines up
+    // when the level takes a full `N`-ary step.
+    // A binary bridge step keeps the packed arm.
+    if step == N
+        && <H as CryptographicHasher<P::Value, [PW::Value; DIGEST_ELEMS]>>::LANES > 1
+        && <C as PseudoCompressionFunction<[PW::Value; DIGEST_ELEMS], N>>::LANES > 1
+    {
+        return compress_and_inject_batched::<P::Value, PW::Value, H, C, M, N, DIGEST_ELEMS>(
+            prev_layer,
+            matrices_to_inject,
+            h,
+            c,
+        );
     }
 
     let width = PW::WIDTH;
@@ -498,6 +782,13 @@ where
         + PseudoCompressionFunction<[P; DIGEST_ELEMS], N>
         + Sync,
 {
+    // Same reinterpretation rule as the injecting level.
+    // A full `N`-ary step makes a node's children one contiguous group, a binary bridge step
+    // does not.
+    if step == N && <C as PseudoCompressionFunction<[P::Value; DIGEST_ELEMS], N>>::LANES > 1 {
+        return compress_batched::<P::Value, C, N, DIGEST_ELEMS>(prev_layer, c);
+    }
+
     let width = P::WIDTH;
     let next_len = prev_layer.len() / step;
     let next_len_padded = padded_len(next_len, N);
@@ -541,8 +832,12 @@ where
 mod tests {
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_field::Field;
+    use p3_keccak::Keccak256Hash;
     use p3_matrix::dense::RowMajorMatrix;
-    use p3_symmetric::{PaddingFreeSponge, PseudoCompressionFunction, TruncatedPermutation};
+    use p3_symmetric::{
+        CompressionFunctionFromHasher, PaddingFreeSponge, PseudoCompressionFunction,
+        SerializingHasher, TruncatedPermutation,
+    };
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
@@ -565,6 +860,215 @@ mod tests {
             }
             output
         }
+    }
+
+    /// Tree shapes the batched and unbatched drivers must agree on, as matrix heights and width.
+    ///
+    /// Between them they cover every boundary the batching introduces:
+    /// - A tree of a single row, which has no level above the leaves at all.
+    /// - Odd heights, which leave a padding tail at the top of a level.
+    /// - Node counts that leave a partial final group in a hash call.
+    /// - Several matrices sharing the tallest height, so a leaf message spans two rows.
+    /// - A ragged height ladder, which forces injection levels.
+    /// - Levels wide enough to fan out across threads instead of staying serial.
+    /// - Rows long enough to make the sponge absorb more than one block.
+    const SHAPES: &[(&[usize], usize)] = &[
+        (&[1], 1),
+        (&[3], 4),
+        (&[13], 1),
+        (&[8, 8, 4], 3),
+        (&[17, 9, 5, 3], 2),
+        (&[1100], 1),
+        (&[2049, 1025, 513], 5),
+        (&[64], 135),
+    ];
+
+    /// A hasher and compressor pair that reports one lane, forcing the unbatched driver.
+    ///
+    /// Every digest it produces is the wrapped primitive's, so the two drivers are compared on
+    /// the same hash function and any difference is the driver's alone.
+    #[derive(Clone, Copy, Debug)]
+    struct Unbatched<T>(T);
+
+    impl<Item, Out, T> CryptographicHasher<Item, Out> for Unbatched<T>
+    where
+        Item: Clone,
+        T: CryptographicHasher<Item, Out>,
+    {
+        const LANES: usize = 1;
+
+        fn hash_iter<I>(&self, input: I) -> Out
+        where
+            I: IntoIterator<Item = Item>,
+        {
+            self.0.hash_iter(input)
+        }
+
+        fn hash_iter_slices<'a, I>(&self, input: I) -> Out
+        where
+            I: IntoIterator<Item = &'a [Item]>,
+            Item: 'a,
+        {
+            self.0.hash_iter_slices(input)
+        }
+    }
+
+    impl<T, Inner, const N: usize> PseudoCompressionFunction<T, N> for Unbatched<Inner>
+    where
+        Inner: PseudoCompressionFunction<T, N>,
+    {
+        const LANES: usize = 1;
+
+        fn compress(&self, input: [T; N]) -> T {
+            self.0.compress(input)
+        }
+    }
+
+    /// A byte hasher reporting three lanes, with no batched implementation of its own.
+    ///
+    /// Three is deliberately neither a power of two nor a divisor of any test height, so every
+    /// group the driver forms ends in a short remainder.
+    /// Leaving the batched hash at its default also isolates the driver: any disagreement comes
+    /// from how the driver assembles messages, not from a vectorized sponge.
+    #[derive(Clone, Copy, Debug)]
+    struct ThreeLaneMix;
+
+    impl CryptographicHasher<u8, [u8; 32]> for ThreeLaneMix {
+        const LANES: usize = 3;
+
+        fn hash_iter<I>(&self, input: I) -> [u8; 32]
+        where
+            I: IntoIterator<Item = u8>,
+        {
+            // A four-word state absorbing one byte per step, mixed with an odd multiplier and a
+            // rotation so that byte order and message length both change the result.
+            let mut state = [0x243f_6a88_85a3_08d3u64; 4];
+            let mut count = 0u64;
+            for byte in input {
+                let word = &mut state[(count % 4) as usize];
+                *word = word.rotate_left(11).wrapping_mul(0x9e37_79b9_7f4a_7c15) ^ u64::from(byte);
+                count += 1;
+            }
+
+            // Fold the length in so a truncated message cannot collide with a longer one.
+            state[0] ^= count.wrapping_mul(0xc2b2_ae3d_27d4_eb4f);
+
+            let mut digest = [0u8; 32];
+            for (word, slot) in state.iter().zip(digest.as_chunks_mut::<8>().0) {
+                *slot = word.to_le_bytes();
+            }
+            digest
+        }
+    }
+
+    /// Build the same tree with both drivers and compare every node of every layer.
+    ///
+    /// Comparing whole layers rather than just the root pins where a divergence begins, and a
+    /// root match alone could hide two compensating errors at a lower level.
+    fn assert_drivers_agree<H, C, const N: usize>(h: &H, c: &C, heights: &[usize], width: usize)
+    where
+        H: CryptographicHasher<F, [u8; 32]> + Sync,
+        C: PseudoCompressionFunction<[u8; 32], N> + Sync,
+    {
+        // Fixture: one random matrix per requested height, all at the same width.
+        let mut rng = SmallRng::seed_from_u64(heights[0] as u64 * 1_000_003 + width as u64);
+        let leaves: Vec<RowMajorMatrix<F>> = heights
+            .iter()
+            .map(|&height| RowMajorMatrix::rand(&mut rng, height, width))
+            .collect();
+
+        let batched =
+            MerkleTree::<F, u8, RowMajorMatrix<F>, N, 32>::new::<F, u8, H, C>(h, c, leaves.clone());
+
+        let unbatched_h = Unbatched(h.clone());
+        let unbatched_c = Unbatched(c.clone());
+        let unbatched = MerkleTree::<F, u8, RowMajorMatrix<F>, N, 32>::new::<
+            F,
+            u8,
+            Unbatched<H>,
+            Unbatched<C>,
+        >(&unbatched_h, &unbatched_c, leaves);
+
+        assert_eq!(
+            batched.arity_schedule, unbatched.arity_schedule,
+            "arity schedule differs for heights {heights:?} width {width}"
+        );
+        assert_eq!(
+            batched.digest_layers.len(),
+            unbatched.digest_layers.len(),
+            "layer count differs for heights {heights:?} width {width}"
+        );
+        for (level, (left, right)) in batched
+            .digest_layers
+            .iter()
+            .zip(&unbatched.digest_layers)
+            .enumerate()
+        {
+            assert_eq!(
+                left, right,
+                "layer {level} differs for heights {heights:?} width {width}"
+            );
+        }
+        assert_eq!(batched.root(), unbatched.root());
+    }
+
+    #[test]
+    fn keccak_batched_tree_matches_unbatched_binary() {
+        // Binary arity is the configuration every byte-digest scheme in the workspace uses.
+        let h = SerializingHasher::new(Keccak256Hash);
+        let c = CompressionFunctionFromHasher::<_, 2, 32>::new(Keccak256Hash);
+
+        for &(heights, width) in SHAPES {
+            assert_drivers_agree::<_, _, 2>(&h, &c, heights, width);
+        }
+    }
+
+    #[test]
+    fn keccak_batched_tree_matches_unbatched_quaternary() {
+        // At arity four a level takes either a full four-to-one step, which the batched arm
+        // handles, or a binary bridge step before an injection, which falls back to the
+        // unbatched arm.
+        // Both must land on the same digests.
+        let h = SerializingHasher::new(Keccak256Hash);
+        let c = CompressionFunctionFromHasher::<_, 4, 32>::new(Keccak256Hash);
+
+        for &(heights, width) in SHAPES {
+            assert_drivers_agree::<_, _, 4>(&h, &c, heights, width);
+        }
+    }
+
+    #[test]
+    fn three_lane_batched_tree_matches_unbatched() {
+        // A lane count of three exercises the driver's group arithmetic away from the powers of
+        // two the vectorized sponges use.
+        let h = SerializingHasher::new(ThreeLaneMix);
+        let c = CompressionFunctionFromHasher::<_, 2, 32>::new(ThreeLaneMix);
+
+        for &(heights, width) in SHAPES {
+            assert_drivers_agree::<_, _, 2>(&h, &c, heights, width);
+        }
+    }
+
+    #[test]
+    fn keccak_tree_is_deterministic_across_builds() {
+        // Padding slots take part in the next level's compression, so an unwritten slot would
+        // show up as a root that changes between two builds of the same input.
+        let h = SerializingHasher::new(Keccak256Hash);
+        let c = CompressionFunctionFromHasher::<_, 2, 32>::new(Keccak256Hash);
+
+        let mut rng = SmallRng::seed_from_u64(7);
+        // Height 13 pads the leaf layer to 14 and every level above it to an even count.
+        let leaves = vec![RowMajorMatrix::<F>::rand(&mut rng, 13, 3)];
+
+        let first = MerkleTree::<F, u8, RowMajorMatrix<F>, 2, 32>::new::<F, u8, _, _>(
+            &h,
+            &c,
+            leaves.clone(),
+        );
+        let second =
+            MerkleTree::<F, u8, RowMajorMatrix<F>, 2, 32>::new::<F, u8, _, _>(&h, &c, leaves);
+
+        assert_eq!(first.digest_layers, second.digest_layers);
     }
 
     #[test]

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -250,12 +250,16 @@ pub(crate) fn select_arity_step<const N: usize>(
 ///
 /// A zero-filled allocation is free: the operating system hands back pages that are already
 /// zero and only faults them in when the hashing threads write them.
+///
 /// The standard vector constructor reaches that path only when it can see at run time that the
-/// element is all zero bits, and it deliberately gives up on that check for arrays longer than
-/// sixteen elements, which is exactly the shape of a thirty-two-byte digest.
+/// element is all zero bits.
+///
+/// It gives up on that check for arrays longer than sixteen elements, which is exactly the
+/// shape of a thirty-two-byte digest.
 ///
 /// Building the layer as one flat run of digest words restores the check, because a word is a
 /// primitive the constructor still inspects.
+///
 /// The flat run and the run of digests have the very same allocation layout, so viewing one as
 /// the other costs nothing:
 ///
@@ -265,6 +269,7 @@ pub(crate) fn select_arity_step<const N: usize>(
 /// ```
 ///
 /// # Panics
+///
 /// Panics if the layer is too large for the address space.
 fn default_digest_layer<W, const DIGEST_ELEMS: usize>(len: usize) -> Vec<[W; DIGEST_ELEMS]>
 where
@@ -292,8 +297,10 @@ where
 
     // SAFETY: an array of `DIGEST_ELEMS` words has no padding, so `len` digests occupy exactly
     // the `len * DIGEST_ELEMS` words allocated above, with the same alignment as one word.
+    //
     // The requested length equals the reserved capacity, so the layout handed back to the
     // allocator on drop is byte for byte the layout it handed out.
+    //
     // Every word is initialized, so every digest slot reads as the default digest.
     unsafe { Vec::from_raw_parts(ptr, len, len) }
 }
@@ -302,10 +309,14 @@ where
 ///
 /// A parallel dispatch costs a fixed amount per level, and the levels near the root hold so few
 /// nodes that the dispatch outweighs the hashing itself.
+///
 /// Grouping messages is independent of threading, so a small level keeps the full vector width
 /// even while it runs on one thread.
-/// 1024 is the point where the two costs balance in practice: it still leaves tens of nodes per
-/// thread on a many-core machine, and every wider level fans out.
+///
+/// 1024 is the point where the two costs balance in practice.
+///
+/// It still leaves tens of nodes per thread on a many-core machine, and every wider level fans
+/// out.
 const SERIAL_LEVEL_NODES: usize = 1024;
 
 /// Output nodes handed to one parallel task.
@@ -318,8 +329,9 @@ const TASK_NODES: usize = 1024;
 ///
 /// A batched hasher wants its messages back to back in memory, and a matrix only promises access
 /// one row at a time, so a group of rows is copied into a buffer first.
-/// 16 KiB keeps that buffer inside the first-level cache, so the hasher reads the rows back while
-/// they are still hot.
+///
+/// 16 KiB keeps that buffer inside the first-level cache, so the hasher reads the rows back
+/// while they are still hot.
 const ROW_SCRATCH_BYTES: usize = 16 * 1024;
 
 /// Hash a run of rows from a set of equal-height matrices, several messages per hash call.
@@ -328,12 +340,15 @@ const ROW_SCRATCH_BYTES: usize = 16 * 1024;
 /// which is exactly what the unbatched path feeds its hasher one row at a time.
 ///
 /// # Arguments
+///
 /// - `h`: hasher applied to each row message.
 /// - `matrices`: matrices of equal height whose rows are concatenated.
+///
 /// - `first_row`: index of the row whose digest lands in the first output slot.
 /// - `out`: one slot per consecutive row starting at that index.
 ///
 /// # Panics
+///
 /// Panics if any matrix is shorter than the requested row range.
 fn hash_rows_batched<F, W, H, M, const DIGEST_ELEMS: usize>(
     h: &H,
@@ -399,8 +414,10 @@ fn hash_rows_batched<F, W, H, M, const DIGEST_ELEMS: usize>(
 /// Compress a run of already-grouped children, several groups per compression call.
 ///
 /// # Arguments
+///
 /// - `c`: compression function applied to each group.
 /// - `groups`: one array of `N` children per output node.
+///
 /// - `out`: one slot per group.
 fn compress_groups_batched<T, C, const N: usize>(c: &C, groups: &[[T; N]], out: &mut [T])
 where
@@ -917,11 +934,14 @@ mod tests {
     /// Tree shapes the batched and unbatched drivers must agree on, as matrix heights and width.
     ///
     /// Between them they cover every boundary the batching introduces:
+    ///
     /// - A tree of a single row, which has no level above the leaves at all.
     /// - Odd heights, which leave a padding tail at the top of a level.
     /// - Node counts that leave a partial final group in a hash call.
+    ///
     /// - Several matrices sharing the tallest height, so a leaf message spans two rows.
     /// - A ragged height ladder, which forces injection levels.
+    ///
     /// - Levels wide enough to fan out across threads instead of staying serial.
     /// - Rows long enough to make the sponge absorb more than one block.
     const SHAPES: &[(&[usize], usize)] = &[
@@ -980,6 +1000,7 @@ mod tests {
     ///
     /// Three is deliberately neither a power of two nor a divisor of any test height, so every
     /// group the driver forms ends in a short remainder.
+    ///
     /// Leaving the batched hash at its default also isolates the driver: any disagreement comes
     /// from how the driver assembles messages, not from a vectorized sponge.
     #[derive(Clone, Copy, Debug)]
@@ -1098,6 +1119,7 @@ mod tests {
         // At arity four a level takes either a full four-to-one step, which the batched arm
         // handles, or a binary bridge step before an injection, which falls back to the
         // unbatched arm.
+        //
         // Both must land on the same digests.
         let h = SerializingHasher::new(Keccak256Hash);
         let c = CompressionFunctionFromHasher::<_, 4, 32>::new(Keccak256Hash);

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -386,12 +386,14 @@ fn hash_rows_batched<F, W, H, M, const DIGEST_ELEMS: usize>(
             let first = base + group * rows_per_call;
 
             // Lay the group's messages back to back: row by row, matrix by matrix.
+            //
+            // Extending from the row iterator keeps this allocation free for every `Matrix`.
+            // Asking for the row as a slice would let an impl materialize one Vec per row.
             scratch.clear();
             for row in first..first + group_digests.len() {
                 for m in matrices {
                     // SAFETY: the assertion above bounds every requested row by every height.
-                    let slice = unsafe { m.row_slice_unchecked(row) };
-                    scratch.extend_from_slice(&slice);
+                    scratch.extend(unsafe { m.row_unchecked(row) });
                 }
             }
 
@@ -944,6 +946,9 @@ mod tests {
     ///
     /// - Levels wide enough to fan out across threads instead of staying serial.
     /// - Rows long enough to make the sponge absorb more than one block.
+    ///
+    /// - A row too wide to group, which the serializing hasher must hash one row at a time.
+    ///   2100 `BabyBear` columns are 8400 bytes, past that hasher's 8 KiB group budget.
     const SHAPES: &[(&[usize], usize)] = &[
         (&[1], 1),
         (&[3], 4),
@@ -953,6 +958,7 @@ mod tests {
         (&[1100], 1),
         (&[2049, 1025, 513], 5),
         (&[64], 135),
+        (&[3], 2100),
     ];
 
     /// A hasher and compressor pair that reports one lane, forcing the unbatched driver.

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -7,7 +7,35 @@ use crate::permutation::CryptographicPermutation;
 /// Instead it is only collision-resistant in hash-tree like settings where
 /// the preimage of a non-leaf node must consist of compression outputs.
 pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
+    /// Number of independent compressions this implementation performs most efficiently in one call.
+    ///
+    /// One means every group is compressed on its own, which is the behaviour of a plain scalar permutation.
+    /// A vectorized implementation reports how many independent states its permutation advances at once.
+    /// Callers read this only to decide whether grouping compressions is worth the bookkeeping.
+    const LANES: usize = 1;
+
     fn compress(&self, input: [T; N]) -> T;
+
+    /// Compress a batch of input groups, one output per group.
+    ///
+    /// ```text
+    ///     inputs: [ grp_0 | grp_1 | ... | grp_{m-1} ]   m groups of N inputs
+    ///     out:    [ dig_0 | dig_1 | ... | dig_{m-1} ]   m outputs
+    /// ```
+    ///
+    /// The default compresses the groups one at a time.
+    /// An override exists purely to exploit vector hardware and must return the very same outputs.
+    ///
+    /// Groups beyond the shorter of the two slices are ignored, so the caller controls the count.
+    fn compress_many(&self, inputs: &[[T; N]], out: &mut [T])
+    where
+        T: Clone,
+    {
+        // Walk the groups in order so the outputs land in the caller's order.
+        for (output, group) in out.iter_mut().zip(inputs) {
+            *output = self.compress(group.clone());
+        }
+    }
 }
 
 /// An `N`-to-1 compression function.
@@ -64,8 +92,27 @@ where
     T: Clone,
     H: CryptographicHasher<T, [T; CHUNK]>,
 {
+    const LANES: usize = <H as CryptographicHasher<T, [T; CHUNK]>>::LANES;
+
     fn compress(&self, input: [[T; CHUNK]; N]) -> [T; CHUNK] {
         self.hasher.hash_iter(input.into_iter().flatten())
+    }
+
+    fn compress_many(&self, inputs: &[[[T; CHUNK]; N]], out: &mut [[T; CHUNK]]) {
+        // A group is `N` adjacent chunks of `CHUNK` items, so a run of groups is already one
+        // flat run of items with nothing between the groups:
+        //
+        //     inputs: [[c0 c1] [c2 c3] ...]  ->  flat: [c0 c1 c2 c3 ...]
+        //
+        // Flattening twice therefore hands the hasher exactly the concatenated preimages that
+        // the single-group path builds one group at a time, with no copying.
+        let messages = inputs.as_flattened().as_flattened();
+
+        // Each message is `N * CHUNK` items long, so the batch hasher can split them itself.
+        // Trim the input to the number of requested outputs to keep that split exact.
+        let requested = out.len().min(inputs.len());
+        self.hasher
+            .hash_many(&messages[..requested * N * CHUNK], &mut out[..requested]);
     }
 }
 

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -11,6 +11,7 @@ pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
     ///
     /// One means every group is compressed on its own, which is the behaviour of a plain scalar permutation.
     /// A vectorized implementation reports how many independent states its permutation advances at once.
+    ///
     /// Callers read this only to decide whether grouping compressions is worth the bookkeeping.
     const LANES: usize = 1;
 

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -27,11 +27,22 @@ pub trait PseudoCompressionFunction<T, const N: usize>: Clone {
     /// The default compresses the groups one at a time.
     /// An override exists purely to exploit vector hardware and must return the very same outputs.
     ///
-    /// Groups beyond the shorter of the two slices are ignored, so the caller controls the count.
+    /// # Panics
+    ///
+    /// Panics if the batch is ragged: the group count must equal the output count.
     fn compress_many(&self, inputs: &[[T; N]], out: &mut [T])
     where
         T: Clone,
     {
+        // A ragged batch is a caller bug, so it fails loudly rather than dropping groups.
+        assert_eq!(
+            inputs.len(),
+            out.len(),
+            "group count ({}) must equal the output count ({})",
+            inputs.len(),
+            out.len()
+        );
+
         // Walk the groups in order so the outputs land in the caller's order.
         for (output, group) in out.iter_mut().zip(inputs) {
             *output = self.compress(group.clone());
@@ -100,6 +111,15 @@ where
     }
 
     fn compress_many(&self, inputs: &[[[T; CHUNK]; N]], out: &mut [[T; CHUNK]]) {
+        // A ragged batch is a caller bug, so it fails loudly rather than dropping groups.
+        assert_eq!(
+            inputs.len(),
+            out.len(),
+            "group count ({}) must equal the output count ({})",
+            inputs.len(),
+            out.len()
+        );
+
         // A group is `N` adjacent chunks of `CHUNK` items.
         // A run of groups is therefore already one flat run of items:
         //
@@ -110,10 +130,8 @@ where
         let messages = inputs.as_flattened().as_flattened();
 
         // Each message is `N * CHUNK` items long, so the batch hasher can split them itself.
-        // Trim the input to the number of requested outputs to keep that split exact.
-        let requested = out.len().min(inputs.len());
-        self.hasher
-            .hash_many(&messages[..requested * N * CHUNK], &mut out[..requested]);
+        // Equal counts make that split exact.
+        self.hasher.hash_many(messages, out);
     }
 }
 
@@ -127,6 +145,10 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+    use core::array;
+
     use super::*;
     use crate::Permutation;
 
@@ -224,5 +246,85 @@ mod tests {
             output, [expected_sum; CHUNK],
             "Compression should correctly handle extra WIDTH space."
         );
+    }
+
+    #[test]
+    fn compress_many_matches_compressing_each_group_alone() {
+        const N: usize = 2;
+        const CHUNK: usize = 4;
+        const WIDTH: usize = 8;
+
+        let compressor = TruncatedPermutation::<_, N, CHUNK, WIDTH>::new(MockPermutation);
+
+        // Three groups of two four-word children.
+        let groups: [[[u64; CHUNK]; N]; 3] =
+            array::from_fn(|g| array::from_fn(|n| array::from_fn(|i| (g * 8 + n * 4 + i) as u64)));
+
+        let mut batched = [[0u64; CHUNK]; 3];
+        compressor.compress_many(&groups, &mut batched);
+
+        let expected: [[u64; CHUNK]; 3] = groups.map(|group| compressor.compress(group));
+        assert_eq!(batched, expected);
+    }
+
+    #[test]
+    fn compress_many_of_an_empty_batch_writes_nothing() {
+        const N: usize = 2;
+        const CHUNK: usize = 4;
+        const WIDTH: usize = 8;
+
+        let compressor = TruncatedPermutation::<_, N, CHUNK, WIDTH>::new(MockPermutation);
+
+        // Both counts are zero, which is a well-formed batch of no groups.
+        let groups: [[[u64; CHUNK]; N]; 0] = [];
+        compressor.compress_many(&groups, &mut []);
+    }
+
+    #[test]
+    #[should_panic(expected = "must equal the output count")]
+    fn compress_many_rejects_a_ragged_batch() {
+        const N: usize = 2;
+        const CHUNK: usize = 4;
+        const WIDTH: usize = 8;
+
+        let compressor = TruncatedPermutation::<_, N, CHUNK, WIDTH>::new(MockPermutation);
+
+        // Two groups with one slot for their outputs: the caller has miscounted, so the batch
+        // fails rather than quietly compressing only the first group.
+        let groups = [[[0u64; CHUNK]; N]; 2];
+        let mut out = [[0u64; CHUNK]; 1];
+        compressor.compress_many(&groups, &mut out);
+    }
+
+    #[test]
+    fn compress_many_from_hasher_matches_compressing_each_group_alone() {
+        const N: usize = 2;
+        const CHUNK: usize = 4;
+
+        let compressor = CompressionFunctionFromHasher::<MockHasher, N, CHUNK>::new(MockHasher);
+
+        let groups: [[[u64; CHUNK]; N]; 3] =
+            array::from_fn(|g| array::from_fn(|n| array::from_fn(|i| (g * 8 + n * 4 + i) as u64)));
+
+        let mut batched = vec![[0u64; CHUNK]; 3];
+        compressor.compress_many(&groups, &mut batched);
+
+        let expected: Vec<[u64; CHUNK]> = groups.iter().map(|&g| compressor.compress(g)).collect();
+        assert_eq!(batched, expected);
+    }
+
+    #[test]
+    #[should_panic(expected = "must equal the output count")]
+    fn compress_many_from_hasher_rejects_a_ragged_batch() {
+        const N: usize = 2;
+        const CHUNK: usize = 4;
+
+        let compressor = CompressionFunctionFromHasher::<MockHasher, N, CHUNK>::new(MockHasher);
+
+        // The adapter hands the whole flattened run to the batch hasher, so unequal counts would
+        // silently redraw every message boundary.
+        let groups = [[[0u64; CHUNK]; N]; 3];
+        let mut out = [[0u64; CHUNK]; 2];
+        compressor.compress_many(&groups, &mut out);
     }
 }

--- a/symmetric/src/compression.rs
+++ b/symmetric/src/compression.rs
@@ -100,13 +100,13 @@ where
     }
 
     fn compress_many(&self, inputs: &[[[T; CHUNK]; N]], out: &mut [[T; CHUNK]]) {
-        // A group is `N` adjacent chunks of `CHUNK` items, so a run of groups is already one
-        // flat run of items with nothing between the groups:
+        // A group is `N` adjacent chunks of `CHUNK` items.
+        // A run of groups is therefore already one flat run of items:
         //
         //     inputs: [[c0 c1] [c2 c3] ...]  ->  flat: [c0 c1 c2 c3 ...]
         //
-        // Flattening twice therefore hands the hasher exactly the concatenated preimages that
-        // the single-group path builds one group at a time, with no copying.
+        // Flattening twice hands the hasher the concatenated preimages directly.
+        // No copying is needed.
         let messages = inputs.as_flattened().as_flattened();
 
         // Each message is `N * CHUNK` items long, so the batch hasher can split them itself.

--- a/symmetric/src/hasher.rs
+++ b/symmetric/src/hasher.rs
@@ -61,8 +61,8 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
 
     /// Hash a batch of equal-length messages, one digest per message.
     ///
-    /// All messages sit back to back in a single slice, so the common message length is
-    /// the input length divided by the number of requested digests:
+    /// All messages sit back to back in a single slice.
+    /// The common message length is the input length divided by the digest count:
     ///
     /// ```text
     ///     input: [ msg_0 | msg_1 | ... | msg_{m-1} ]   m * len items

--- a/symmetric/src/hasher.rs
+++ b/symmetric/src/hasher.rs
@@ -8,6 +8,7 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
     ///
     /// One means every message is hashed on its own, which is the behaviour of a plain scalar sponge.
     /// A vectorized implementation reports how many independent states its permutation advances at once.
+    ///
     /// Callers read this only to decide whether grouping messages is worth the bookkeeping.
     const LANES: usize = 1;
 
@@ -72,6 +73,7 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
     /// An override exists purely to exploit vector hardware and must return the very same digests.
     ///
     /// # Panics
+    ///
     /// Panics if the input length is not a whole multiple of the number of requested digests.
     fn hash_many(&self, input: &[Item], out: &mut [Out]) {
         // No digests requested means there is nothing to read from the input.

--- a/symmetric/src/hasher.rs
+++ b/symmetric/src/hasher.rs
@@ -74,7 +74,7 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
     ///
     /// # Panics
     ///
-    /// Panics if the input length is not a whole multiple of the number of requested digests.
+    /// Panics if the batch is ragged: the input length must be a whole multiple of the digest count.
     fn hash_many(&self, input: &[Item], out: &mut [Out]) {
         // No digests requested means there is nothing to read from the input.
         if out.is_empty() {
@@ -103,5 +103,71 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
         for (digest, message) in out.iter_mut().zip(input.chunks_exact(len)) {
             *digest = self.hash_slice(message);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use core::array;
+
+    use crate::CryptographicHasher;
+
+    /// A byte hasher whose digest carries both a running fold and the message length.
+    ///
+    /// The multiplier makes the digest order sensitive.
+    /// The counter makes a message of a different length impossible to collide with.
+    #[derive(Clone)]
+    struct Fold;
+
+    impl CryptographicHasher<u8, [u8; 2]> for Fold {
+        fn hash_iter<I>(&self, input: I) -> [u8; 2]
+        where
+            I: IntoIterator<Item = u8>,
+        {
+            let mut acc = 0u8;
+            let mut count = 0u8;
+            for byte in input {
+                acc = acc.wrapping_mul(31).wrapping_add(byte);
+                count = count.wrapping_add(1);
+            }
+            [acc, count]
+        }
+    }
+
+    #[test]
+    fn hash_many_matches_hashing_each_message_alone() {
+        // Four messages of three bytes, laid out back to back.
+        let input: [u8; 12] = array::from_fn(|i| i as u8);
+
+        let mut batched = [[0u8; 2]; 4];
+        Fold.hash_many(&input, &mut batched);
+
+        let expected: [[u8; 2]; 4] = array::from_fn(|i| Fold.hash_slice(&input[3 * i..][..3]));
+        assert_eq!(batched, expected);
+    }
+
+    #[test]
+    fn hash_many_of_zero_length_messages_hashes_the_empty_message() {
+        // No input with digests requested means every message is empty.
+        let mut out = vec![[1u8; 2]; 3];
+        Fold.hash_many(&[], &mut out);
+
+        assert_eq!(out, vec![Fold.hash_slice(&[]); 3]);
+    }
+
+    #[test]
+    fn hash_many_reads_nothing_when_no_digests_are_requested() {
+        // A message length cannot be derived from zero digests, so the input is left untouched
+        // instead of tripping the multiple check on a length that divides nothing.
+        Fold.hash_many(&[1, 2, 3], &mut []);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a whole multiple")]
+    fn hash_many_rejects_ragged_input() {
+        // Five bytes cannot split into two equal messages.
+        let mut out = [[0u8; 2]; 2];
+        Fold.hash_many(&[1, 2, 3, 4, 5], &mut out);
     }
 }

--- a/symmetric/src/hasher.rs
+++ b/symmetric/src/hasher.rs
@@ -4,6 +4,13 @@
 /// This trait abstracts over hash functions in a flexible way, supporting both field elements,
 /// scalars, or any other data type that implements `Clone`.
 pub trait CryptographicHasher<Item: Clone, Out>: Clone {
+    /// Number of equal-length messages this implementation hashes most efficiently in one call.
+    ///
+    /// One means every message is hashed on its own, which is the behaviour of a plain scalar sponge.
+    /// A vectorized implementation reports how many independent states its permutation advances at once.
+    /// Callers read this only to decide whether grouping messages is worth the bookkeeping.
+    const LANES: usize = 1;
+
     /// Hash an iterator of input items.
     /// # Arguments
     /// - `input`: An iterator over items to be hashed.
@@ -49,5 +56,50 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
     /// A fixed-size digest of type `Out`.
     fn hash_item(&self, input: Item) -> Out {
         self.hash_slice(&[input])
+    }
+
+    /// Hash a batch of equal-length messages, one digest per message.
+    ///
+    /// All messages sit back to back in a single slice, so the common message length is
+    /// the input length divided by the number of requested digests:
+    ///
+    /// ```text
+    ///     input: [ msg_0 | msg_1 | ... | msg_{m-1} ]   m * len items
+    ///     out:   [ dig_0 | dig_1 | ... | dig_{m-1} ]   m digests
+    /// ```
+    ///
+    /// The default hashes the messages one at a time.
+    /// An override exists purely to exploit vector hardware and must return the very same digests.
+    ///
+    /// # Panics
+    /// Panics if the input length is not a whole multiple of the number of requested digests.
+    fn hash_many(&self, input: &[Item], out: &mut [Out]) {
+        // No digests requested means there is nothing to read from the input.
+        if out.is_empty() {
+            return;
+        }
+
+        // Every message has the same length, so the split is exact by contract.
+        assert!(
+            input.len().is_multiple_of(out.len()),
+            "input length ({}) must be a whole multiple of the digest count ({})",
+            input.len(),
+            out.len()
+        );
+        let len = input.len() / out.len();
+
+        // Zero-length messages all hash to the same digest.
+        // They are also the one case a chunked walk over the input cannot express.
+        if len == 0 {
+            for digest in out.iter_mut() {
+                *digest = self.hash_slice(&[]);
+            }
+            return;
+        }
+
+        // Walk the messages in order so the digests land in the caller's order.
+        for (digest, message) in out.iter_mut().zip(input.chunks_exact(len)) {
+            *digest = self.hash_slice(message);
+        }
     }
 }

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -2,6 +2,14 @@ use p3_field::Field;
 
 use crate::CryptographicHasher;
 
+/// Size of the stack buffer that holds the serialized bytes of one group of rows.
+///
+/// The batched inner hash needs its messages back to back in memory, and a field element only
+/// becomes bytes through a serializing iterator, so the bytes have to be materialized somewhere.
+/// 8 KiB stays inside a typical 32 KiB L1 data cache and still holds eight messages for rows of
+/// up to 1 KiB, which keeps every lane of a vector sponge busy at the widths a Merkle leaf uses.
+const ROW_BYTES_SCRATCH: usize = 8 * 1024;
+
 /// Converts a hasher which can hash bytes, u32's or u64's into a hasher which can hash field elements.
 ///
 /// Supports two types of hashing.
@@ -24,11 +32,83 @@ where
     F: Field,
     Inner: CryptographicHasher<u8, [u8; N]>,
 {
+    const LANES: usize = <Inner as CryptographicHasher<u8, [u8; N]>>::LANES;
+
     fn hash_iter<I>(&self, input: I) -> [u8; N]
     where
         I: IntoIterator<Item = F>,
     {
         self.inner.hash_iter(F::into_byte_stream(input))
+    }
+
+    fn hash_many(&self, input: &[F], out: &mut [[u8; N]]) {
+        // No digests requested means there is nothing to read from the input.
+        if out.is_empty() {
+            return;
+        }
+
+        // Every message has the same length, so the split into rows is exact by contract.
+        assert!(
+            input.len().is_multiple_of(out.len()),
+            "input length ({}) must be a whole multiple of the digest count ({})",
+            input.len(),
+            out.len()
+        );
+        let row_len = input.len() / out.len();
+        let row_bytes = row_len * F::NUM_BYTES;
+
+        // Width-zero rows all hash to the same digest of the empty message.
+        if row_len == 0 {
+            for digest in out.iter_mut() {
+                *digest = self.hash_iter(core::iter::empty::<F>());
+            }
+            return;
+        }
+
+        // A row too wide for the stack buffer gains nothing from grouping, and the unbatched
+        // path serializes straight into the sponge with no buffer at all.
+        if row_bytes > ROW_BYTES_SCRATCH {
+            for (digest, row) in out.iter_mut().zip(input.chunks_exact(row_len)) {
+                *digest = self.hash_iter(row.iter().copied());
+            }
+            return;
+        }
+
+        // Serialize as many whole rows at a time as the buffer holds, so the inner hasher sees a
+        // long run of equal-length byte messages and can fill every lane of its permutation:
+        //
+        //     rows:    [ r_0 | r_1 | ... ]              row_len field elements each
+        //     scratch: [ b_0 | b_1 | ... ]              row_bytes bytes each
+        let rows_per_group = ROW_BYTES_SCRATCH / row_bytes;
+        let mut scratch = [0u8; ROW_BYTES_SCRATCH];
+
+        for (rows, digests) in input
+            .chunks(rows_per_group * row_len)
+            .zip(out.chunks_mut(rows_per_group))
+        {
+            // Only the leading part of the buffer is used when the final group is short.
+            let bytes = &mut scratch[..digests.len() * row_bytes];
+
+            // Serialize row by row so each message starts on its own row boundary.
+            //
+            // The row boundaries are computed from the declared serialized width of one field
+            // element, so a stream of any other length would shift every later message and
+            // silently change its digest; both directions are therefore checked.
+            for (slot, row) in bytes.chunks_mut(row_bytes).zip(rows.chunks(row_len)) {
+                let mut stream = F::into_byte_stream(row.iter().copied()).into_iter();
+                for dst in slot.iter_mut() {
+                    *dst = stream
+                        .next()
+                        .expect("field serialization is shorter than its declared width");
+                }
+                assert!(
+                    stream.next().is_none(),
+                    "field serialization is longer than its declared width"
+                );
+            }
+
+            self.inner.hash_many(bytes, digests);
+        }
     }
 }
 

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -4,10 +4,15 @@ use crate::CryptographicHasher;
 
 /// Size of the stack buffer that holds the serialized bytes of one group of rows.
 ///
-/// The batched inner hash needs its messages back to back in memory, and a field element only
-/// becomes bytes through a serializing iterator, so the bytes have to be materialized somewhere.
-/// 8 KiB stays inside a typical 32 KiB L1 data cache and still holds eight messages for rows of
-/// up to 1 KiB, which keeps every lane of a vector sponge busy at the widths a Merkle leaf uses.
+/// The batched inner hash needs its messages back to back in memory.
+///
+/// A field element only becomes bytes through a serializing iterator, so the bytes have to be
+/// materialized somewhere.
+///
+/// 8 KiB stays inside a typical 32 KiB L1 data cache.
+///
+/// It still holds eight messages for rows of up to 1 KiB, which keeps every lane of a vector
+/// sponge busy at the widths a Merkle leaf uses.
 const ROW_BYTES_SCRATCH: usize = 8 * 1024;
 
 /// Converts a hasher which can hash bytes, u32's or u64's into a hasher which can hash field elements.
@@ -91,9 +96,10 @@ where
 
             // Serialize row by row so each message starts on its own row boundary.
             //
-            // The row boundaries are computed from the declared serialized width of one field
-            // element, so a stream of any other length would shift every later message and
-            // silently change its digest; both directions are therefore checked.
+            // The row boundaries come from the declared serialized width of one field element.
+            //
+            // A stream of any other length would shift every later message and silently change
+            // its digest, so both directions are checked.
             for (slot, row) in bytes.chunks_mut(row_bytes).zip(rows.chunks(row_len)) {
                 let mut stream = F::into_byte_stream(row.iter().copied()).into_iter();
                 for dst in slot.iter_mut() {

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -1,18 +1,16 @@
+use alloc::vec::Vec;
+
 use p3_field::Field;
 
 use crate::CryptographicHasher;
 
-/// Size of the stack buffer that holds the serialized bytes of one group of rows.
+/// Byte budget for the buffer holding the serialized bytes of one group of rows.
 ///
 /// The batched inner hash needs its messages back to back in memory.
-///
-/// A field element only becomes bytes through a serializing iterator, so the bytes have to be
-/// materialized somewhere.
+/// Field elements reach byte form only through a serializing iterator.
 ///
 /// 8 KiB stays inside a typical 32 KiB L1 data cache.
-///
-/// It still holds eight messages for rows of up to 1 KiB, which keeps every lane of a vector
-/// sponge busy at the widths a Merkle leaf uses.
+/// It still holds eight messages of 1 KiB, enough to fill a vector sponge's lanes.
 const ROW_BYTES_SCRATCH: usize = 8 * 1024;
 
 /// Converts a hasher which can hash bytes, u32's or u64's into a hasher which can hash field elements.
@@ -37,6 +35,12 @@ where
     F: Field,
     Inner: CryptographicHasher<u8, [u8; N]>,
 {
+    /// Forwarded from the inner byte hasher, the one digest shape here that batches.
+    ///
+    /// The `[u32; N]` and `[u64; N]` shapes wrap word sponges that hash a single message per call.
+    /// The packed `[[uX; M]; N]` shapes already drive a vector permutation, one lane per packed slot.
+    ///
+    /// Both keep the trait default of one lane, which routes a Merkle tree through its packed arm.
     const LANES: usize = <Inner as CryptographicHasher<u8, [u8; N]>>::LANES;
 
     fn hash_iter<I>(&self, input: I) -> [u8; N]
@@ -70,8 +74,8 @@ where
             return;
         }
 
-        // A row too wide for the stack buffer gains nothing from grouping, and the unbatched
-        // path serializes straight into the sponge with no buffer at all.
+        // A row too wide for the byte budget gains nothing from grouping.
+        // Hash it straight from the serializing iterator, with no buffer at all.
         if row_bytes > ROW_BYTES_SCRATCH {
             for (digest, row) in out.iter_mut().zip(input.chunks_exact(row_len)) {
                 *digest = self.hash_iter(row.iter().copied());
@@ -79,41 +83,50 @@ where
             return;
         }
 
-        // Serialize as many whole rows at a time as the buffer holds, so the inner hasher sees a
-        // long run of equal-length byte messages and can fill every lane of its permutation:
+        // Serialize as many whole rows at a time as the budget holds.
+        // The inner hasher then sees a long run of equal-length byte messages:
         //
         //     rows:    [ r_0 | r_1 | ... ]              row_len field elements each
         //     scratch: [ b_0 | b_1 | ... ]              row_bytes bytes each
-        let rows_per_group = ROW_BYTES_SCRATCH / row_bytes;
-        let mut scratch = [0u8; ROW_BYTES_SCRATCH];
+        //
+        // Rounding the group down to whole lane groups keeps every permutation of every call
+        // fully occupied.
+        //
+        // Invariant: 1 <= rows_per_group <= ROW_BYTES_SCRATCH / row_bytes
+        //     the wide-row case returned above, so at least one row fits the budget
+        //     a budget too small for one lane group keeps every row that does fit
+        let lanes = Inner::LANES.max(1);
+        let rows_fitting = ROW_BYTES_SCRATCH / row_bytes;
+        let rows_per_group = match rows_fitting / lanes {
+            0 => rows_fitting,
+            groups => groups * lanes,
+        };
+
+        // One buffer per call, refilled group by group, holding the largest group exactly.
+        // Every byte of a group is written before it is read, so none of it is zeroed first.
+        let mut scratch: Vec<u8> = Vec::with_capacity(rows_per_group.min(out.len()) * row_bytes);
 
         for (rows, digests) in input
             .chunks(rows_per_group * row_len)
             .zip(out.chunks_mut(rows_per_group))
         {
-            // Only the leading part of the buffer is used when the final group is short.
-            let bytes = &mut scratch[..digests.len() * row_bytes];
-
             // Serialize row by row so each message starts on its own row boundary.
+            // Boundaries come from the declared serialized width of one field element.
             //
-            // The row boundaries come from the declared serialized width of one field element.
-            //
-            // A stream of any other length would shift every later message and silently change
-            // its digest, so both directions are checked.
-            for (slot, row) in bytes.chunks_mut(row_bytes).zip(rows.chunks(row_len)) {
-                let mut stream = F::into_byte_stream(row.iter().copied()).into_iter();
-                for dst in slot.iter_mut() {
-                    *dst = stream
-                        .next()
-                        .expect("field serialization is shorter than its declared width");
-                }
-                assert!(
-                    stream.next().is_none(),
-                    "field serialization is longer than its declared width"
+            // A stream of any other length shifts every later message.
+            // Checking the running length after each row catches both directions.
+            scratch.clear();
+            for (index, row) in rows.chunks(row_len).enumerate() {
+                scratch.extend(F::into_byte_stream(row.iter().copied()));
+                assert_eq!(
+                    scratch.len(),
+                    (index + 1) * row_bytes,
+                    "field serialization must be its declared width of {} bytes per element",
+                    F::NUM_BYTES
                 );
             }
 
-            self.inner.hash_many(bytes, digests);
+            self.inner.hash_many(&scratch, digests);
         }
     }
 }
@@ -188,8 +201,13 @@ where
 
 #[cfg(test)]
 mod tests {
+    use alloc::rc::Rc;
+    use alloc::vec;
+    use alloc::vec::Vec;
     use core::array;
+    use core::cell::RefCell;
 
+    use p3_field::PrimeCharacteristicRing;
     use p3_koala_bear::KoalaBear;
 
     use crate::{CryptographicHasher, SerializingHasher};
@@ -293,5 +311,167 @@ mod tests {
         assert_eq!(u8_output_parallel, u8_output_individual_transposed);
         assert_eq!(u32_output_parallel, u32_output_individual_transposed);
         assert_eq!(u64_output_parallel, u64_output_individual_transposed);
+    }
+
+    /// A byte hasher that records the digest count of every batched call it is handed.
+    ///
+    /// Three lanes is deliberately neither a power of two nor a divisor of the byte budget, so a
+    /// group that is not lane aligned shows up as a count that three does not divide.
+    #[derive(Clone)]
+    struct LaneRecorder {
+        calls: Rc<RefCell<Vec<usize>>>,
+    }
+
+    impl LaneRecorder {
+        fn new() -> (Self, Rc<RefCell<Vec<usize>>>) {
+            let calls = Rc::new(RefCell::new(Vec::new()));
+            (
+                Self {
+                    calls: Rc::clone(&calls),
+                },
+                calls,
+            )
+        }
+    }
+
+    impl CryptographicHasher<u8, [u8; 4]> for LaneRecorder {
+        const LANES: usize = 3;
+
+        fn hash_iter<I: IntoIterator<Item = u8>>(&self, iter: I) -> [u8; 4] {
+            MockHasher.hash_iter(iter)
+        }
+
+        fn hash_many(&self, input: &[u8], out: &mut [[u8; 4]]) {
+            if out.is_empty() {
+                return;
+            }
+            self.calls.borrow_mut().push(out.len());
+
+            let len = input.len() / out.len();
+            for (digest, message) in out.iter_mut().zip(input.chunks_exact(len)) {
+                *digest = self.hash_iter(message.iter().copied());
+            }
+        }
+    }
+
+    /// A run of `rows * row_len` distinct field elements, laid out row by row.
+    fn rows_of(rows: usize, row_len: usize) -> Vec<KoalaBear> {
+        (0..rows * row_len)
+            .map(|i| KoalaBear::from_u32(i as u32))
+            .collect()
+    }
+
+    /// Digests of the same rows taken one at a time through the unbatched path.
+    fn digests_one_by_one<H>(
+        hasher: &SerializingHasher<H>,
+        input: &[KoalaBear],
+        row_len: usize,
+    ) -> Vec<[u8; 4]>
+    where
+        H: CryptographicHasher<u8, [u8; 4]>,
+    {
+        input
+            .chunks(row_len)
+            .map(|row| hasher.hash_iter(row.iter().copied()))
+            .collect()
+    }
+
+    #[test]
+    fn hash_many_matches_the_unbatched_digests() {
+        let hasher = SerializingHasher::new(MockHasher);
+
+        // Row widths around the group boundaries: one element, a lane group, the widest row the
+        // 8 KiB budget still groups, and one element past it.
+        for row_len in [1, 3, 7, 100, 2048, 2049, 2100] {
+            for rows in [1, 2, 3, 4, 7] {
+                let input = rows_of(rows, row_len);
+                let mut batched = vec![[0u8; 4]; rows];
+                hasher.hash_many(&input, &mut batched);
+
+                assert_eq!(
+                    batched,
+                    digests_one_by_one(&hasher, &input, row_len),
+                    "rows {rows} of width {row_len}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn hash_many_hands_the_inner_hasher_whole_lane_groups() {
+        let (inner, calls) = LaneRecorder::new();
+        let hasher = SerializingHasher::new(inner);
+
+        // 400 bytes a row lets 20 rows fit the 8 KiB budget, which rounds down to six lane
+        // groups of three.
+        let input = rows_of(40, 100);
+        let mut out = vec![[0u8; 4]; 40];
+        hasher.hash_many(&input, &mut out);
+
+        // Only the final call is short, and it is short because the input ran out.
+        assert_eq!(*calls.borrow(), vec![18, 18, 4]);
+        assert_eq!(out, digests_one_by_one(&hasher, &input, 100));
+    }
+
+    #[test]
+    fn hash_many_keeps_single_rows_when_a_lane_group_will_not_fit() {
+        let (inner, calls) = LaneRecorder::new();
+        let hasher = SerializingHasher::new(inner);
+
+        // 2800 bytes a row leaves room for two rows, fewer than the three a lane group needs, so
+        // the group falls back to as many rows as do fit rather than overrunning the budget.
+        let input = rows_of(3, 700);
+        let mut out = vec![[0u8; 4]; 3];
+        hasher.hash_many(&input, &mut out);
+
+        assert_eq!(*calls.borrow(), vec![2, 1]);
+        assert_eq!(out, digests_one_by_one(&hasher, &input, 700));
+    }
+
+    #[test]
+    fn hash_many_hashes_a_row_wider_than_the_budget_on_its_own() {
+        let (inner, calls) = LaneRecorder::new();
+        let hasher = SerializingHasher::new(inner);
+
+        // 2049 elements are 8196 bytes, past the 8 KiB budget, so grouping is skipped entirely
+        // and every row is serialized straight into the sponge.
+        let input = rows_of(4, 2049);
+        let mut out = vec![[0u8; 4]; 4];
+        hasher.hash_many(&input, &mut out);
+
+        assert!(calls.borrow().is_empty());
+        assert_eq!(out, digests_one_by_one(&hasher, &input, 2049));
+    }
+
+    #[test]
+    fn hash_many_of_width_zero_rows_hashes_the_empty_message() {
+        let hasher = SerializingHasher::new(MockHasher);
+
+        // No input at all with digests requested means every row is empty.
+        let mut out = vec![[1u8; 4]; 3];
+        hasher.hash_many(&[] as &[KoalaBear], &mut out);
+
+        let empty: [u8; 4] = hasher.hash_iter(core::iter::empty::<KoalaBear>());
+        assert_eq!(out, vec![empty; 3]);
+    }
+
+    #[test]
+    fn hash_many_reads_nothing_when_no_digests_are_requested() {
+        let hasher = SerializingHasher::new(MockHasher);
+
+        // A row length cannot be derived from zero digests, so the input is left untouched
+        // instead of dividing by zero or tripping the multiple check.
+        let mut out: [[u8; 4]; 0] = [];
+        hasher.hash_many(&rows_of(3, 5), &mut out);
+    }
+
+    #[test]
+    #[should_panic(expected = "must be a whole multiple")]
+    fn hash_many_rejects_ragged_input() {
+        let hasher = SerializingHasher::new(MockHasher);
+
+        // Five elements cannot split into two equal rows.
+        let mut out = [[0u8; 4]; 2];
+        hasher.hash_many(&rows_of(5, 1), &mut out);
     }
 }


### PR DESCRIPTION
## Summary

- Merkle tree construction is where `binary-pcs` proving spends its time, and the vectorized Keccak permutations this repo already ships were unreachable from it: a byte digest has packing width 1, so the packed leaf and compression loops in `merkle-tree` degenerated to one scalar sponge per node, at every level of every tree.
- Adds a "hash many equal-length messages" entry point to `CryptographicHasher` and a "compress many groups" entry point to `PseudoCompressionFunction`, plus an associated constant declaring how many messages an implementation hashes most efficiently at once. Both methods default to exactly today's scalar behaviour and the constant defaults to 1, so every existing implementation keeps working untouched and no downstream crate breaks.
- `p3-keccak` overrides the batched hash with a multi-lane sponge driven by the `KeccakF` vector permutation that already lived in the crate with no caller outside it: absorb full rate blocks lane by lane, apply the `0x01`/`0x80` pad, permute once, squeeze. The lane count is the target's existing vector-width constant, so one body is correct at 1, 2, 4 and 8 lanes. `CompressionFunctionFromHasher` forwards its batched form to it over the concatenated child digests.
- The Merkle driver gains a batched arm for the leaf layer, the injection layer and the plain compression layer, taken when the hasher or the compression function declares more than one lane. Levels below 1024 output nodes stay batched but serial, since near the root a parallel dispatch costs more than the hashing.
- Second commit: every digest layer was allocated at the default digest and then completely overwritten. `Vec` only reaches the allocator's zeroed fast path when it can see at run time that the element is all zero bits, and the standard library deliberately skips that check for arrays longer than sixteen elements — so a thirty-two-word byte digest layer was filled word by word by a single thread before any hashing started. Building the layer as one flat run of digest words restores the fast path; a flat run of `len * D` words and a run of `len` digests have byte-identical allocation layout, so the view costs nothing and needs no initialization argument.
- **Commitments and proofs are byte-identical.** The only thing that changes is the order in which independent hashes are computed. A new test builds every tree twice — once through the batched arm, once through a wrapper that reports a single lane — and compares every node of every layer, not just the root.
- The algebraic path (Poseidon2 over a packed field) keeps `LANES = 1`, so it takes the existing packed arm unchanged. Benched to confirm no regression.

### Why the children-are-adjacent layout makes the batching free

A digest layer is one flat `Vec` of digests, and a node's `N` children sit next to each other in it. So the `N` children of one parent are already a contiguous run of digest words, and that run *is* the parent's preimage. The parents are consecutive too, so a run of `m` parents is a contiguous run of `m` preimages laid back to back — exactly the "equal-length messages, one after another" shape the batched hash asks for. Reading a layer as groups of `N` is therefore a reinterpretation of the same memory: no transposition, no gather, no copy at any internal level. Only the leaf layer needs a small scratch buffer, because a matrix only promises access one row at a time.

## Benchmarks

AMD Ryzen 9 9950X3D (Zen 5), 16 cores / 32 threads, AVX-512F + GFNI + VPCLMULQDQ, `RUSTFLAGS="-C target-cpu=native"`. **The machine was shared with other benchmark jobs during measurement**, so treat the ratios as approximate; every round measured all arms back to back, and each row shows two independent rounds.

### Tree construction — serial

`cargo bench -p p3-merkle-tree --bench merkle_tree`. This crate exposes no `parallel` feature, so this bench is single-threaded.

Keccak-256, arity 2, 32-byte digest, BabyBear rows of 135 columns (540-byte leaf messages, so the sponge absorbs four blocks per leaf):

| shape | main | + batched hashing | + zeroed alloc | ratio |
| --- | --- | --- | --- | --- |
| one matrix 32768 x 135 | 70.0 / 70.6 ms | 13.1 / 12.1 ms | 13.3 / 13.9 ms | **5.4x** |
| two matrices 32769 x 135, 16385 x 135 | 105.0 / 104.0 ms | 18.8 / 18.3 ms | 18.1 / 22.6 ms | **5.5x** |

The allocation commit does nothing at this size, as expected: these trees hold about 2^16 digest slots, worth well under a millisecond of fill.

Poseidon2 over packed BabyBear, same bench, to confirm the algebraic path is untouched:

| shape | main | both commits |
| --- | --- | --- |
| arity 2, one matrix | 35.0 / 36.2 ms | 35.3 / 33.9 ms |
| arity 2, two matrices | 52.3 / 59.6 ms | 57.3 / 51.7 ms |
| arity 4, one matrix | 34.0 / 34.3 ms | 34.2 / 35.2 ms |
| arity 4, two matrices | 43.6 / 44.2 ms | 43.3 / 42.9 ms |

Unchanged within run-to-run noise.

### End to end — parallel

`cargo bench -p p3-binary-pcs --features parallel --bench pcs`, 20 variables, `log_inv_rate = 2`, `pow_bits = 8`, 100-bit target. Feature unification through this crate is what actually turns rayon on for the Merkle code.

| stage | main | + batched hashing | + zeroed alloc | ratio |
| --- | --- | --- | --- | --- |
| `commit/20` | 243.8 ms | 82.8 ms | 49.3 ms | **4.9x** |
| `open/20` | 259.8 ms | 92.6 ms | 84.9 ms | **3.1x** |
| prove (`commit` + `open`) | 503.5 ms | 175.4 ms | 134.2 ms | **3.8x** |
| `verify/20` | 10.0 ms | 10.0 ms | 10.0 ms | 1.0x |

A second round of the same three arms measured `main` at 650 ms of proving against 132 ms, i.e. 4.9x; the `main` arm is the longest-running and therefore the most exposed to the other jobs on the box, so the 3.8x row above is the conservative reading. The verifier is deliberately untouched here: its per-level compressions are independent and would batch the same way, but that is a separate change.

### The digest-layer fill, measured on its own

A standalone program timing only `vec![[W::default(); D]; n]` in the exact generic shape the driver uses, at `n = 2^23` (256 MiB):

| digest element | before | after |
| --- | --- | --- |
| `[u8; 32]` | 42-52 ms | 11 us |
| `[Fp; 8]`, `Fp` a field newtype over `u32` | ~42 ms | ~42 ms (unchanged) |

This is worth stating plainly because two independent measurements of this fill disagreed: one put it at roughly 40 ms per large tree, the other at 1.6 ms of a 37 ms commit on the grounds that the allocator returns lazily-zeroed pages. The first held up and the second did not, and the deciding detail is the digest *width*: `Vec`'s zeroed-allocation specialization inspects the element at run time but gives up on arrays longer than sixteen elements, so a 32-word byte digest never reaches it while an 8-word digest of a primitive does. The end-to-end effect is visible in the table above — `commit/20` drops from 82.8 ms to 49.3 ms on this commit alone.

## Test plan

- [x] `cargo test -p p3-merkle-tree -p p3-symmetric -p p3-keccak` — 5 + 105 + 21 passed, 0 failed. Includes the new byte-identical-output tests: the batched and single-lane drivers are compared node for node across a single-row tree, odd heights that pad the layer, a batch count that leaves a partial final group, several matrices sharing the tallest height, a ragged height ladder that forces three injection levels, levels wide enough to fan out across threads, and rows long enough to make the sponge absorb four blocks — at arity 2, at arity 4, and at a deliberately awkward lane count of 3.
- [x] `cargo test -p p3-keccak` — the multi-lane sponge is pinned to `tiny_keccak` by a shape sweep over message lengths `{0, 1, 7, 8, 9, rate-1, rate, rate+1, 2*rate-1, 2*rate, 2*rate+1, 3*rate, 400, 1000}` crossed with batch sizes `1..=2*lanes+1`, plus a proptest over random lengths `0..=400` and batches `1..=17`.
- [x] `cargo test -p p3-binary-pcs` — 37 + 19 passed, 0 failed.
- [x] `cargo test --workspace` — all green. The traits are shared, so this is the gate that matters.
- [x] `cargo test -p p3-merkle-tree -p p3-symmetric -p p3-keccak --doc` — green.
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo +stable doc --no-deps --workspace --document-private-items` — no new warnings.
- [x] `cargo check --workspace --all-targets` — clean, so no existing implementor of either trait needed a change.
- [x] Target-feature legs, since the Keccak lane count is target-gated: default `cargo test` (SSE2, 2 lanes), `RUSTFLAGS="-C target-feature=+avx2"` (4 lanes) and `RUSTFLAGS="-C target-cpu=native"` (AVX-512, 8 lanes) all pass the full `p3-merkle-tree`, `p3-symmetric`, `p3-keccak` and `p3-binary-pcs` suites. The 1-lane fallback and the NEON build cannot execute on this host, so they were type-checked instead: `cargo check --target wasm32-unknown-unknown`, `--target thumbv7em-none-eabi` and `--target aarch64-unknown-linux-gnu`, all clean.
- [x] `cargo +nightly miri test -p p3-merkle-tree --lib -- test_compress default_digest_layer keccak_tree_is_deterministic` — 7 passed, 0 failed. Covers the one `unsafe` block introduced by the allocation commit and a full small Keccak tree built through the batched arm, including its padding tail.
- [x] `cargo +nightly miri test -p p3-keccak -p p3-symmetric --lib` — 5 + 21 passed, 0 failed, including the sponge proptests.
- [x] Parallel and serial both exercised: the `p3-binary-pcs` runs above have rayon on through feature unification, the `p3-merkle-tree` runs have it off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
