### PR TITLE
perf(binary-pcs): fold the codeword packed in the polynomial basis

### DIFF
--- a/binary-pcs/benches/pcs.rs
+++ b/binary-pcs/benches/pcs.rs
@@ -151,9 +151,9 @@ fn bench_verify(c: &mut Criterion) {
 }
 
 /// The per-pair form: one `domain_point` call per output symbol, exactly what `fold_pair`
-/// computes for a single query's verifier-side check. Benchmarked serially, alongside
-/// `fold_codeword`'s task-local XOR chain, so the two are compared under one measurement
-/// rather than one inferred from the other.
+/// computes for a single query's verifier-side check. Benchmarked serially, alongside the
+/// whole-codeword form, so the two are compared under one measurement rather than one inferred
+/// from the other.
 fn fold_codeword_per_pair(codeword: &[F], beta: F) -> Vec<F> {
     codeword
         .chunks(2)
@@ -163,8 +163,8 @@ fn fold_codeword_per_pair(codeword: &[F], beta: F) -> Vec<F> {
 }
 
 /// Folds a full base-round codeword (length `2^(num_variables + log_inv_rate)`) once, in both
-/// the chained and the per-pair form. This is the round every real proof spends the most time
-/// in. `fold_codeword` only borrows its input, so neither arm needs `iter_batched`'s per-call
+/// the whole-codeword and the per-pair form. This is the round every real proof spends the most
+/// time in. `fold_codeword` only borrows its input, so neither arm needs `iter_batched`'s per-call
 /// setup; `fold_codeword` produces half as many outputs as `codeword` has inputs, so per-output
 /// timing (not per-input-element) is what the ratio below is stated against.
 fn bench_fold_codeword(c: &mut Criterion) {
@@ -177,7 +177,7 @@ fn bench_fold_codeword(c: &mut Criterion) {
         let beta: F = rng.random();
 
         group.bench_with_input(
-            BenchmarkId::new("chained", num_variables),
+            BenchmarkId::new("codeword", num_variables),
             &codeword,
             |b, codeword| b.iter(|| fold_codeword(codeword, beta)),
         );

--- a/binary-pcs/benches/pcs.rs
+++ b/binary-pcs/benches/pcs.rs
@@ -150,10 +150,12 @@ fn bench_verify(c: &mut Criterion) {
     group.finish();
 }
 
-/// The per-pair form: one `domain_point` call per output symbol, exactly what `fold_pair`
-/// computes for a single query's verifier-side check. Benchmarked serially, alongside the
-/// whole-codeword form, so the two are compared under one measurement rather than one inferred
-/// from the other.
+/// The per-pair form, evaluating one domain point per output symbol.
+///
+/// This is the shape a single query's verifier-side check uses.
+///
+/// It runs alongside the whole-codeword form so the two are compared under one measurement
+/// rather than one being inferred from the other.
 fn fold_codeword_per_pair(codeword: &[F], beta: F) -> Vec<F> {
     codeword
         .chunks(2)
@@ -162,11 +164,14 @@ fn fold_codeword_per_pair(codeword: &[F], beta: F) -> Vec<F> {
         .collect()
 }
 
-/// Folds a full base-round codeword (length `2^(num_variables + log_inv_rate)`) once, in both
-/// the whole-codeword and the per-pair form. This is the round every real proof spends the most
-/// time in. `fold_codeword` only borrows its input, so neither arm needs `iter_batched`'s per-call
-/// setup; `fold_codeword` produces half as many outputs as `codeword` has inputs, so per-output
-/// timing (not per-input-element) is what the ratio below is stated against.
+/// Folds a full base-round codeword once, in both the whole-codeword and the per-pair form.
+///
+/// This is the round every real proof spends the most time in.
+///
+/// Folding only borrows its input, so neither arm needs per-call setup.
+///
+/// A fold halves the symbol count, so the ratios below are stated per output symbol rather than
+/// per input element.
 fn bench_fold_codeword(c: &mut Criterion) {
     let mut group = c.benchmark_group("fold_codeword");
     group.sample_size(10);

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -187,9 +187,9 @@ fn fold_task(
 
     // Phase 2: fewer output slots left than one packed group holds.
     //
-    // A task's slot count is either a whole grain or the whole codeword's pair count, and both
-    // the grain and a power-of-two pair count are multiples of the width unless the codeword has
-    // fewer pairs than the width, so this runs only for a codeword of two or four symbols.
+    // A task's slot count is either a whole grain or the whole codeword's pair count.
+    // The grain covers whole groups, and a power-of-two pair count is a multiple of the width
+    // unless it is below it, so this runs only for a codeword with fewer pairs than the width.
     // Each leftover evaluates its own domain point, so it rests on no group alignment at all.
     //
     // Twice as many symbols are left as slots, so the leftovers pair up exactly and the

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -127,9 +127,12 @@ pub fn fold_pair(
 /// The second term depends on the lane alone, so the whole fold needs one group base plus this
 /// vector, built once.
 ///
-fn lane_offsets() -> Packed {
+/// The packing is a type parameter rather than `Packed` itself.
+///
+/// That lets the lane arithmetic be exercised at widths this target compiles no register for.
+fn lane_offsets<P: PackedValue<Value = Ghash128>>() -> P {
     // Lane `k` carries `domain_point(2 * k)`, the offset from its group's first domain point.
-    Packed::from_fn(|lane| domain_point(lane << 1))
+    P::from_fn(|lane| domain_point(lane << 1))
 }
 
 /// The exclusive-or step from one packed group's first domain point to the next.
@@ -316,7 +319,7 @@ pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<B
 
     // The challenge crosses into the polynomial basis once for the whole codeword.
     let beta_poly = Ghash128::from(beta);
-    let offsets = lane_offsets();
+    let offsets = lane_offsets::<Packed>();
     let steps = group_steps::<WIDTH>(num_pairs);
 
     // Zeroed here and fully overwritten below, so the allocation is handed out already blank
@@ -340,9 +343,10 @@ pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<B
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
+    use core::array;
 
     use p3_binary_dft::{AdditiveNtt, NaiveAdditiveNtt, domain_point};
-    use p3_binary_field::{BinaryField128, TowerLevel};
+    use p3_binary_field::{BinaryField128, Ghash128, TowerLevel};
     use p3_field::PrimeCharacteristicRing;
     use p3_matrix::dense::RowMajorMatrix;
     use p3_multilinear_util::poly::Poly;
@@ -350,7 +354,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
-    use super::{FOLD_GRAIN, WIDTH, fold_codeword, fold_pair};
+    use super::{FOLD_GRAIN, WIDTH, fold_codeword, fold_pair, group_steps, lane_offsets};
 
     /// Encode novel-basis coefficients over the additive domain, through the oracle.
     ///
@@ -464,6 +468,128 @@ mod tests {
                 );
             }
         }
+    }
+
+    /// The task loop with `[Ghash128; W]` standing in for the packing.
+    ///
+    /// Every lane index, gather offset and step lookup is the one `fold_task` uses, and the two
+    /// helpers it calls are the production ones.
+    ///
+    /// A build compiles exactly one packing width, so this is what reaches the others.
+    fn fold_task_model<const W: usize>(
+        start: usize,
+        pairs: &[BinaryField128],
+        out: &mut [BinaryField128],
+        beta: Ghash128,
+        lane_offsets: [Ghash128; W],
+        group_steps: &[Ghash128],
+    ) {
+        // Whole groups, then the leftover slots, split where the packed form splits them.
+        let (slot_groups, tail) = out.as_chunks_mut::<W>();
+        let tail_offset = slot_groups.len() * W;
+
+        // A block of `2 * W` symbols per group, so the remainder starts at twice that offset.
+        let (symbol_blocks, tail_pairs) = pairs.split_at(2 * tail_offset);
+
+        let first_group = start / W;
+        let mut base: Ghash128 = domain_point(start << 1);
+
+        for (group, slots) in slot_groups.iter_mut().enumerate() {
+            if group != 0 {
+                base += group_steps[(first_group + group).trailing_zeros() as usize];
+            }
+
+            // The `2 * W` symbols this group consumes.
+            let block = &symbol_blocks[2 * W * group..][..2 * W];
+
+            // Broadcasting the base and adding the offset vector is this, lane by lane.
+            let x: [Ghash128; W] = array::from_fn(|lane| base + lane_offsets[lane]);
+
+            // The gather a packed block performs: even symbols low, odd symbols high.
+            let lo: [Ghash128; W] = array::from_fn(|lane| Ghash128::from(block[2 * lane]));
+            let hi: [Ghash128; W] = array::from_fn(|lane| Ghash128::from(block[2 * lane + 1]));
+
+            for (lane, slot) in slots.iter_mut().enumerate() {
+                let f1 = lo[lane] + hi[lane];
+                let f0 = lo[lane] + x[lane] * f1;
+                *slot = BinaryField128::from(f0 + beta * (f0 + f1));
+            }
+        }
+
+        let (tail_blocks, _) = tail_pairs.as_chunks::<2>();
+        for (offset, (slot, pair)) in tail.iter_mut().zip(tail_blocks).enumerate() {
+            let x: Ghash128 = domain_point((start + tail_offset + offset) << 1);
+            let lo = Ghash128::from(pair[0]);
+            let hi = Ghash128::from(pair[1]);
+            let f1 = lo + hi;
+            let f0 = lo + x * f1;
+            *slot = BinaryField128::from(f0 + beta * (f0 + f1));
+        }
+    }
+
+    /// `fold_codeword` driving the width-generic task loop, serially.
+    fn fold_codeword_model<const W: usize>(
+        codeword: &[BinaryField128],
+        beta: BinaryField128,
+    ) -> Vec<BinaryField128> {
+        let num_pairs = codeword.len() / 2;
+        let beta_poly = Ghash128::from(beta);
+        let offsets = lane_offsets::<[Ghash128; W]>();
+        let steps = group_steps::<W>(num_pairs);
+
+        let mut folded = BinaryField128::zero_vec(num_pairs);
+        for (task, (out, pairs)) in folded
+            .chunks_mut(FOLD_GRAIN)
+            .zip(codeword.chunks(2 * FOLD_GRAIN))
+            .enumerate()
+        {
+            fold_task_model::<W>(task * FOLD_GRAIN, pairs, out, beta_poly, offsets, &steps);
+        }
+        folded
+    }
+
+    /// Fold every shape at one packing width and compare against the tower reference.
+    fn check_width<const W: usize>() {
+        let mut rng = SmallRng::seed_from_u64(0x1A5E_0FF5_E750_0000);
+
+        // Shapes chosen so both phases run at all four widths:
+        //
+        //     0             no pairs at all
+        //     2, 4          fewer pairs than a group holds at the wider widths
+        //     8, 16, 1024   whole groups at every width, inside one task
+        //     2048          pairs exactly one grain
+        //     4096, 8192    several tasks, so more than one group base is evaluated
+        for len in [0usize, 2, 4, 8, 16, 1024, 2048, 4096, 8192] {
+            let codeword: Vec<BinaryField128> = (0..len).map(|_| rng.random()).collect();
+            let beta: BinaryField128 = rng.random();
+
+            assert_eq!(
+                fold_codeword_model::<W>(&codeword, beta),
+                fold_codeword_tower_reference(&codeword, beta),
+                "W={W} len={len}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_lane_arithmetic_holds_at_every_packing_width() {
+        // A target compiles one packing, so `the_packed_fold_matches_the_tower_reference` below
+        // only ever exercises that one width.
+        //
+        // Widths swept here, none of them requiring the register that would carry them:
+        //
+        //     1   no packing
+        //     2   the 256-bit carryless multiply
+        //     4   the 512-bit carryless multiply
+        //     8   past every packing this workspace defines
+        //
+        // The verifier folds pair by pair in the tower basis, so a lane-gather or step-table
+        // mistake at a width this host cannot compile would split the prover from the verifier
+        // on hosts that can.
+        check_width::<1>();
+        check_width::<2>();
+        check_width::<4>();
+        check_width::<8>();
     }
 
     #[test]

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -19,13 +19,44 @@
 //! domain is the same function at a halved index, so no per-round domain state is carried. The
 //! folding partners `domain_point(2j)` and `domain_point(2j + 1)` differ by `v_0 = 1`, so they
 //! are adjacent rows in memory.
+//!
+//! Each output symbol costs two field multiplications.
+//! In the tower basis one multiplication is a polynomial-basis multiplication wrapped in a
+//! change of basis on each operand and a change back on the result.
+//! Each change of basis is sixteen dependent byte-table lookups, so the wrapper dominates.
+//! Folding a whole codeword therefore crosses into the polynomial basis once per loaded symbol,
+//! multiplies there with the widest carryless-multiply register the target offers, and crosses
+//! back once per produced symbol.
+//! Input and output stay in the tower basis, so the folded codeword is unchanged bit for bit.
 
 use alloc::vec::Vec;
 
 use p3_binary_dft::domain_point;
-use p3_binary_field::{BinaryField128, TowerLevel};
-use p3_field::PrimeCharacteristicRing;
+use p3_binary_field::{BinaryField128, Ghash128};
+use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
 use p3_maybe_rayon::prelude::*;
+
+/// The polynomial-basis type the fold multiplies with.
+///
+/// This is the widest carryless-multiply register the target offers.
+/// Where the target has none it is a single element, and every loop below still holds.
+type Packed = <Ghash128 as Field>::Packing;
+
+/// How many output symbols one packed multiplication covers.
+const WIDTH: usize = Packed::WIDTH;
+
+/// Output symbols one parallel task owns.
+///
+/// Large enough that the task-opening domain evaluation is amortised over many folds; small
+/// enough to leave real parallelism at every codeword length this crate exercises.
+const FOLD_GRAIN: usize = 1 << 10;
+
+// A task's first output index is a multiple of the grain, and the lane-offset identity below
+// needs it to be a multiple of the packing width, so the grain must cover whole packed groups.
+const _: () = assert!(
+    FOLD_GRAIN.is_multiple_of(WIDTH),
+    "the fold grain must be a whole number of packed groups"
+);
 
 /// Fold one pair of the codeword.
 ///
@@ -43,47 +74,152 @@ pub fn fold_pair(
     f0 + beta * (f0 + f1)
 }
 
-/// Output pairs one parallel task chains together, opened by a single `domain_point` call.
+/// The domain point each lane adds on top of the one evaluated at its group's first index.
 ///
-/// Large enough that the task-opening `domain_point` call is amortised over many folds; small
-/// enough to leave real parallelism at every codeword length this crate exercises.
-const FOLD_GRAIN: usize = 1 << 10;
+/// # Algorithm
+///
+/// Write `v_r` for the `r`-th Cantor basis vector, so that
+///
+/// ```text
+///     domain_point(n) = sum_r bit_r(n) * v_r
+/// ```
+///
+/// That map is `F_2`-linear in the *bits* of its index, hence additive over exclusive-or:
+///
+/// ```text
+///     domain_point(m XOR n) = domain_point(m) + domain_point(n)
+/// ```
+///
+/// It is not additive over integer addition, because a carry moves a bit to a place the sum of
+/// the two basis vectors never reaches.
+/// Carries are absent exactly when the two bit patterns are disjoint, and then addition and
+/// exclusive-or agree:
+///
+/// ```text
+///     m AND n == 0   =>   m + n == m XOR n
+/// ```
+///
+/// A packed group's first output index `g` is a multiple of the width, which is a power of two,
+/// so every bit of `g` below `log2(width)` is clear.
+/// A lane index `k` is below the width, so every bit it sets is below `log2(width)`.
+/// The two patterns are therefore disjoint, and doubling shifts both up one place without
+/// disturbing that:
+///
+/// ```text
+///     g AND k == 0   =>   2 * (g + k) == (2 * g) XOR (2 * k)
+/// ```
+///
+/// Combining the two displays gives the identity the fold runs on:
+///
+/// ```text
+///     domain_point(2 * (g + k)) = domain_point(2 * g) + domain_point(2 * k)
+/// ```
+///
+/// The second term depends on the lane alone, so the whole fold needs one evaluation per group
+/// plus this vector, built once.
+fn lane_offsets() -> Packed {
+    // Lane `k` carries `domain_point(2 * k)`, the offset from its group's first domain point.
+    Packed::from_fn(|lane| domain_point(lane << 1))
+}
 
-/// The XOR step from `domain_point(2 * j)` to `domain_point(2 * (j + 1))`, indexed by
-/// `(j + 1).trailing_zeros()`.
+/// Fold the pairs one parallel task owns.
 ///
-/// `domain_point` is `F_2`-linear, and `j XOR (j + 1)` sets exactly the trailing ones of `j`
-/// together with the first zero bit above them — bits `0..=level` for `level =
-/// (j + 1).trailing_zeros()`. So `domain_point(2 * j) + domain_point(2 * (j + 1))` is
-/// `domain_point` of that same run of bits shifted up by one: the sum of `cantor_basis(1)`
-/// through `cantor_basis(level + 1)`. `steps[level]` is that sum, computed once and reused by
-/// every transition that lands at the same level.
-fn gray_chain_steps(num_pairs: usize) -> Vec<BinaryField128> {
-    let levels = num_pairs.next_power_of_two().trailing_zeros() as usize;
-    let mut steps = Vec::with_capacity(levels);
-    let mut acc = BinaryField128::ZERO;
-    for level in 0..levels {
-        acc += BinaryField128::cantor_basis(level + 1);
-        steps.push(acc);
+/// `start` is the output index the task's first pair produces.
+/// It is a multiple of the grain, hence of the packing width, which is what lets whole groups
+/// share a single domain evaluation.
+///
+/// # Panics
+///
+/// Panics unless the task holds exactly two input symbols per output slot.
+fn fold_task(
+    start: usize,
+    pairs: &[BinaryField128],
+    out: &mut [BinaryField128],
+    beta: Ghash128,
+    lane_offsets: Packed,
+) {
+    // Every output slot consumes one pair, so the task's two slices are locked together.
+    assert_eq!(
+        pairs.len(),
+        2 * out.len(),
+        "a fold task must hold one pair per output symbol"
+    );
+
+    // The challenge is the same in every lane, so it broadcasts once for the whole task.
+    let beta_packed = Packed::broadcast(beta);
+
+    // Split both sides into whole packed groups plus a shorter remainder.
+    // The two remainders match because one output slot always consumes two input symbols.
+    let (slot_groups, tail) = out.as_chunks_mut::<WIDTH>();
+    let (symbol_blocks, tail_pairs) = pairs.as_chunks::<{ 2 * WIDTH }>();
+
+    // Output index the remainder starts at, relative to the task.
+    let tail_offset = slot_groups.len() * WIDTH;
+
+    // Phase 1: whole packed groups.
+    //
+    //     block  : [ lo_0 hi_0 | lo_1 hi_1 | ... | lo_{W-1} hi_{W-1} ]   2 * WIDTH symbols
+    //     slots  : [ out_0     | out_1     | ... | out_{W-1}         ]       WIDTH symbols
+    for (group, (slots, block)) in slot_groups.iter_mut().zip(symbol_blocks).enumerate() {
+        // Output index lane 0 of this group produces, a multiple of the width.
+        let first = start + group * WIDTH;
+
+        // One domain evaluation for the group, plus the constant per-lane offsets.
+        let x = Packed::broadcast(domain_point(first << 1)) + lane_offsets;
+
+        // Cross into the polynomial basis while gathering the lanes.
+        // The change of basis is additive, so the sums formed below are the same either side.
+        let lo = Packed::from_fn(|lane| Ghash128::from(block[2 * lane]));
+        let hi = Packed::from_fn(|lane| Ghash128::from(block[2 * lane + 1]));
+
+        // The novel-basis halves of each pair.
+        let f1 = lo + hi;
+        let f0 = lo + x * f1;
+
+        // The evaluation-basis combination at the challenge.
+        let folded = f0 + beta_packed * (f0 + f1);
+
+        // Cross back so the caller sees a tower-basis codeword.
+        for (slot, &value) in slots.iter_mut().zip(folded.as_slice()) {
+            *slot = BinaryField128::from(value);
+        }
     }
-    steps
+
+    // Phase 2: fewer output slots left than one packed group holds.
+    //
+    // A task's slot count is either a whole grain or the whole codeword's pair count, and both
+    // the grain and a power-of-two pair count are multiples of the width unless the codeword has
+    // fewer pairs than the width, so this runs only for a codeword of two or four symbols.
+    // Each leftover evaluates its own domain point, so it rests on no group alignment at all.
+    //
+    // Twice as many symbols are left as slots, so the leftovers pair up exactly and the
+    // remainder discarded here is empty.
+    let (tail_blocks, _) = tail_pairs.as_chunks::<2>();
+    for (offset, (slot, pair)) in tail.iter_mut().zip(tail_blocks).enumerate() {
+        let x: Ghash128 = domain_point((start + tail_offset + offset) << 1);
+        let lo = Ghash128::from(pair[0]);
+        let hi = Ghash128::from(pair[1]);
+        let f1 = lo + hi;
+        let f0 = lo + x * f1;
+        *slot = BinaryField128::from(f0 + beta * (f0 + f1));
+    }
 }
 
 /// Fold a whole codeword, halving its length.
 ///
-/// Each parallel task opens with one `domain_point` call, then chains it across the task's own
-/// pairs by adding a precomputed per-level `F_2`-linear step at each transition: `fold_pair`'s
-/// single per-call `domain_point` is the right form for one query's verifier-side check, but
-/// here the same value would otherwise be recomputed once per output symbol of the whole
-/// codeword.
+/// Each parallel task owns a contiguous run of output symbols and the pairs feeding them, so no
+/// two tasks touch the same symbol on either side.
+/// Within a task one domain evaluation serves a whole packed group: the per-call evaluation
+/// `fold_pair` does is the right form for one query's verifier-side check, but here the same
+/// value would otherwise be recomputed once per output symbol of the whole codeword.
 ///
 /// # Panics
 ///
 /// Panics unless the codeword is empty or has a power-of-two length.
 /// That is the shape every round schedule produces.
 ///
-/// The chained step table itself covers any even length, so this is a deliberate
-/// narrowing of the contract rather than a limit of the method.
+/// The loops themselves cover any even length, so this is a deliberate narrowing of the
+/// contract rather than a limit of the method.
 #[must_use]
 pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<BinaryField128> {
     assert!(
@@ -91,27 +227,29 @@ pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<B
         "codeword length must be a power of two"
     );
 
+    // Two input symbols make one output symbol.
     let num_pairs = codeword.len() / 2;
-    let steps = gray_chain_steps(num_pairs);
 
-    codeword
-        .par_chunks(2 * FOLD_GRAIN)
+    // The challenge crosses into the polynomial basis once for the whole codeword.
+    let beta_poly = Ghash128::from(beta);
+    let offsets = lane_offsets();
+
+    // Zeroed here and fully overwritten below, so the allocation is handed out already blank
+    // rather than assembled from one vector per task.
+    let mut folded = BinaryField128::zero_vec(num_pairs);
+
+    // Task `t` owns outputs `[t * GRAIN, (t + 1) * GRAIN)` and inputs `[2 * t * GRAIN, ...)`.
+    // Output `j` reads inputs `2 * j` and `2 * j + 1`, both inside its own task's input chunk,
+    // so the two chunk streams stay index-aligned and every task is disjoint from every other.
+    folded
+        .par_chunks_mut(FOLD_GRAIN)
+        .zip(codeword.par_chunks(2 * FOLD_GRAIN))
         .enumerate()
-        .flat_map_iter(|(block, chunk)| {
-            let start = block * FOLD_GRAIN;
-            let mut x: BinaryField128 = domain_point(start << 1);
-            let steps = &steps;
-            chunk.chunks(2).enumerate().map(move |(offset, pair)| {
-                if offset != 0 {
-                    x += steps[(start + offset).trailing_zeros() as usize];
-                }
-                let (lo, hi) = (pair[0], pair[1]);
-                let f1 = lo + hi;
-                let f0 = lo + x * f1;
-                f0 + beta * (f0 + f1)
-            })
-        })
-        .collect()
+        .for_each(|(task, (out, pairs))| {
+            fold_task(task * FOLD_GRAIN, pairs, out, beta_poly, offsets);
+        });
+
+    folded
 }
 
 #[cfg(test)]
@@ -127,7 +265,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
 
-    use super::{fold_codeword, fold_pair};
+    use super::{FOLD_GRAIN, WIDTH, fold_codeword, fold_pair};
 
     /// Encode novel-basis coefficients over the additive domain, through the oracle.
     ///
@@ -138,6 +276,59 @@ mod tests {
         NaiveAdditiveNtt::<BinaryField128>::default()
             .ntt_batch(RowMajorMatrix::new(coeffs.to_vec(), 1))
             .values
+    }
+
+    /// The XOR step from `domain_point(2 * j)` to `domain_point(2 * (j + 1))`, indexed by
+    /// `(j + 1).trailing_zeros()`.
+    ///
+    /// The domain map is `F_2`-linear, and `j XOR (j + 1)` sets exactly the trailing ones of
+    /// `j` together with the first zero bit above them. So consecutive doubled domain points
+    /// differ by the sum of Cantor basis vectors `1` through `level + 1`.
+    fn gray_chain_steps(num_pairs: usize) -> Vec<BinaryField128> {
+        let levels = num_pairs.next_power_of_two().trailing_zeros() as usize;
+        let mut steps = Vec::with_capacity(levels);
+        let mut acc = BinaryField128::ZERO;
+        for level in 0..levels {
+            acc += BinaryField128::cantor_basis(level + 1);
+            steps.push(acc);
+        }
+        steps
+    }
+
+    /// The tower-basis fold, kept here as the bit-for-bit reference the packed form must match.
+    ///
+    /// It walks the domain by a chained `F_2`-linear step and multiplies in the tower basis, so
+    /// it shares neither the loop shape nor the arithmetic representation of the code under
+    /// test.
+    fn fold_codeword_tower_reference(
+        codeword: &[BinaryField128],
+        beta: BinaryField128,
+    ) -> Vec<BinaryField128> {
+        let num_pairs = codeword.len() / 2;
+        let steps = gray_chain_steps(num_pairs);
+
+        codeword
+            .chunks(2 * FOLD_GRAIN)
+            .enumerate()
+            .flat_map(|(block, chunk)| {
+                let start = block * FOLD_GRAIN;
+                let mut x: BinaryField128 = domain_point(start << 1);
+                let steps = &steps;
+                chunk
+                    .chunks(2)
+                    .enumerate()
+                    .map(move |(offset, pair)| {
+                        if offset != 0 {
+                            x += steps[(start + offset).trailing_zeros() as usize];
+                        }
+                        let (lo, hi) = (pair[0], pair[1]);
+                        let f1 = lo + hi;
+                        let f0 = lo + x * f1;
+                        f0 + beta * (f0 + f1)
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .collect()
     }
 
     #[test]
@@ -162,6 +353,86 @@ mod tests {
         }
     }
 
+    #[test]
+    fn a_lane_offset_shifts_a_group_start_to_its_own_domain_point() {
+        // Invariant: a group's first index is a multiple of the width, so its low bits are
+        // clear and adding a lane index is a disjoint exclusive-or.
+        //
+        //     group start 8, width 4:   1000
+        //     lane 3:                   0011
+        //     8 + 3 == 8 | 3 == 11:     1011   no carry crosses between the two
+        //
+        // The domain map is additive over exclusive-or, so the group's point plus the lane's
+        // point is the point of the sum.
+        for group in 0..64usize {
+            let first = group * WIDTH;
+            for lane in 0..WIDTH {
+                // Disjointness is what the identity rests on, so pin it directly.
+                assert_eq!(first & lane, 0, "group={group} lane={lane}");
+                assert_eq!(
+                    domain_point::<BinaryField128>((first + lane) << 1),
+                    domain_point::<BinaryField128>(first << 1)
+                        + domain_point::<BinaryField128>(lane << 1),
+                    "group={group} lane={lane}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_packed_fold_matches_the_tower_reference() {
+        let mut rng = SmallRng::seed_from_u64(0xF01D_0BA5_15C0_DE00);
+
+        // Shapes worth separating, all of them power-of-two lengths the assertion admits:
+        //
+        //     0                  no pairs at all
+        //     2                  one pair, fewer than one packed group
+        //     4, 8               a partial group on a four-lane build, a whole one on two lanes
+        //     16 .. 1024         several groups, still inside one parallel task
+        //     2048               pairs exactly one grain, so exactly one task
+        //     4096, 8192, 65536  several tasks, the last of them full
+        for len in [0usize, 2, 4, 8, 16, 64, 1024, 2048, 4096, 8192, 65536] {
+            let codeword: Vec<BinaryField128> = (0..len).map(|_| rng.random()).collect();
+            let beta: BinaryField128 = rng.random();
+
+            // Bit-for-bit, not merely equal up to the folded polynomial: the committed bytes
+            // of every round after this one depend on the exact output.
+            assert_eq!(
+                fold_codeword(&codeword, beta),
+                fold_codeword_tower_reference(&codeword, beta),
+                "len={len}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_whole_fold_chain_matches_the_tower_reference() {
+        let mut rng = SmallRng::seed_from_u64(0x0C0F_FEE0_DEAD_BEEF);
+
+        // 8192 symbols is 13 rounds down to a single symbol, and 4096 pairs is four grains, so
+        // the chain starts multi-task and shrinks through the single-task and sub-group shapes.
+        let start: Vec<BinaryField128> = (0..8192).map(|_| rng.random()).collect();
+
+        // One independent challenge per round, as the prover draws them.
+        let betas: Vec<BinaryField128> = (0..13).map(|_| rng.random()).collect();
+
+        let mut packed = start.clone();
+        let mut reference = start;
+
+        for (round, &beta) in betas.iter().enumerate() {
+            packed = fold_codeword(&packed, beta);
+            reference = fold_codeword_tower_reference(&reference, beta);
+
+            // Diverging at any round would silently change every later commitment, so compare
+            // the whole codeword each time rather than only the final symbol.
+            assert_eq!(packed, reference, "round={round}");
+        }
+
+        // Thirteen halvings of 8192 leave one symbol, the value the proof carries in the clear.
+        assert_eq!(packed.len(), 1);
+        assert_eq!(reference.len(), 1);
+    }
+
     proptest! {
         // Each case runs the naive oracle twice over a codeword of up to 512 symbols, so the
         // per-case cost is far above a typical property test's; 64 cases still explore every
@@ -171,8 +442,8 @@ mod tests {
         /// The crate's central identity: folding the codeword equals binding the message's
         /// lowest variable in the evaluation basis (`Poly::fix_suffix_var`).
         ///
-        /// The oracle is [`NaiveAdditiveNtt`], which evaluates the definition directly and
-        /// shares no identity with the fold, so agreement is evidence rather than restatement.
+        /// The oracle is a direct evaluation of the additive-NTT definition, which shares no
+        /// identity with the fold, so agreement is evidence rather than restatement.
         /// `log_n` and `log_inv_rate` are generated rather than swept because the identity is
         /// claimed for every message length and every blowup a prover can configure, not for a
         /// chosen list; every real prover fold runs on a blown-up codeword, so rate 0 is the
@@ -206,14 +477,12 @@ mod tests {
         }
     }
 
-    /// The chained form must agree with `fold_pair`'s independent per-call computation at
-    /// every position, including across `FOLD_GRAIN`'s block boundary: 4096 codeword symbols
-    /// is 2048 pairs, past `FOLD_GRAIN`'s 1024, so this covers two full parallel tasks and
-    /// exercises the cross-block chaining — block-start `domain_point(start << 1)` plus
-    /// `(start + offset).trailing_zeros()` indexing — that a single-block codeword leaves
-    /// silent.
     #[test]
     fn the_pair_form_agrees_with_the_vector_form() {
+        // The whole-codeword form must agree with the independent per-pair computation at every
+        // position, including across a task boundary: 4096 codeword symbols is 2048 pairs, past
+        // the 1024-symbol grain, so this covers two full parallel tasks and exercises the
+        // per-task index base that a single-task codeword leaves silent.
         let mut rng = SmallRng::seed_from_u64(0x9E37_79B9_7F4A_7C15);
         let codeword: Vec<BinaryField128> = (0..4096).map(|_| rng.random()).collect();
         let beta: BinaryField128 = rng.random();
@@ -237,7 +506,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "codeword length must be a power of two")]
     fn an_even_non_power_of_two_codeword_is_rejected() {
-        // Even is not enough: the per-level step table is sized for a power of two.
+        // Even is not enough: the contract is narrowed to the shape a round schedule produces.
         // Six symbols is three pairs, which no round schedule produces.
         let six = [BinaryField128::ONE; 6];
         let _ = fold_codeword(&six, BinaryField128::ONE);
@@ -245,15 +514,22 @@ mod tests {
 
     #[test]
     fn an_empty_codeword_folds_to_an_empty_one() {
-        // Zero pairs to fold, and zero levels to index, so the empty input is not a panic.
+        // Zero pairs to fold, so the empty input is not a panic.
         assert!(fold_codeword(&[], BinaryField128::ONE).is_empty());
     }
 
-    /// `f_0 + beta * f_1`, the novel-basis combination, is a different operation from
-    /// `fold_pair`'s evaluation-basis combination: the two differ by exactly `beta * f_0`, so
-    /// they agree only when that term vanishes.
+    #[test]
+    fn a_single_symbol_codeword_folds_to_an_empty_one() {
+        // One symbol is half a pair, so there is nothing to fold and the output is empty.
+        // A length of one is a power of two, so the length assertion admits it.
+        assert!(fold_codeword(&[BinaryField128::ONE], BinaryField128::ONE).is_empty());
+    }
+
     #[test]
     fn the_novel_basis_fold_is_a_different_operation() {
+        // `f_0 + beta * f_1`, the novel-basis combination, is a different operation from the
+        // evaluation-basis one this module folds with: the two differ by exactly `beta * f_0`,
+        // so they agree only when that term vanishes.
         let mut rng = SmallRng::seed_from_u64(0x51DE);
         let j = 5usize;
         let x: BinaryField128 = domain_point(2 * j);
@@ -291,7 +567,7 @@ mod tests {
                 (b0 + b1) * (f0 + f1)
             );
 
-            // At beta = 0 the fold is f0, pinning fold_pair's internal domain index against one
+            // At beta = 0 the fold is f0, pinning the internal domain index against one
             // computed independently here.
             prop_assert_eq!(fold_pair(j, BinaryField128::ZERO, lo, hi), f0);
         }

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -34,7 +34,7 @@
 use alloc::vec::Vec;
 
 use p3_binary_dft::domain_point;
-use p3_binary_field::{BinaryField128, Ghash128};
+use p3_binary_field::{BinaryField128, Ghash128, TowerLevel};
 use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
 use p3_maybe_rayon::prelude::*;
 
@@ -56,8 +56,9 @@ const FOLD_GRAIN: usize = 1 << 10;
 
 // A task's first output index is a multiple of the grain.
 //
-// The lane-offset identity below needs that index to be a multiple of the packing width, so the
-// grain must cover whole packed groups.
+// The lane-offset identity below needs that index to be a multiple of the packing width.
+//
+// So the grain must cover whole packed groups.
 const _: () = assert!(
     FOLD_GRAIN.is_multiple_of(WIDTH),
     "the fold grain must be a whole number of packed groups"
@@ -123,18 +124,65 @@ pub fn fold_pair(
 ///     domain_point(2 * (g + k)) = domain_point(2 * g) + domain_point(2 * k)
 /// ```
 ///
-/// The second term depends on the lane alone, so the whole fold needs one evaluation per group
-/// plus this vector, built once.
+/// The second term depends on the lane alone, so the whole fold needs one group base plus this
+/// vector, built once.
+///
 fn lane_offsets() -> Packed {
     // Lane `k` carries `domain_point(2 * k)`, the offset from its group's first domain point.
     Packed::from_fn(|lane| domain_point(lane << 1))
 }
 
+/// The exclusive-or step from one packed group's first domain point to the next.
+///
+/// # Algorithm
+///
+/// Group `G` opens at output index `G * W`, so it opens at doubled index `G << L`:
+///
+/// ```text
+///     L = log2(2 * W)
+///     base(G) = domain_point(G << L) = sum_r bit_r(G) * v_{L + r}
+/// ```
+///
+/// That map is `F_2`-linear in the bits of `G`, hence additive over exclusive-or.
+///
+/// Stepping from `G - 1` to `G` flips exactly bits `0 ..= k`, for `k = G.trailing_zeros()`:
+///
+/// ```text
+///     (G - 1) XOR G = 2^(k + 1) - 1
+/// ```
+///
+/// Consecutive group bases therefore differ by the basis vectors those bits select:
+///
+/// ```text
+///     base(G) = base(G - 1) + sum_{r <= k} v_{L + r}
+/// ```
+///
+/// Entry `k` is that sum, so a group past the first costs one exclusive-or, not a `domain_point`.
+fn group_steps<const W: usize>(num_pairs: usize) -> Vec<Ghash128> {
+    // A group strides `W` output indices, hence `2 * W` domain indices.
+    let log_stride = (2 * W).trailing_zeros() as usize;
+
+    // Group indices run below `num_pairs / W`, so one entry per bit of that count is enough.
+    let levels = (num_pairs / W).next_power_of_two().trailing_zeros() as usize;
+
+    let mut step = Ghash128::ZERO;
+    (0..levels)
+        .map(|level| {
+            step += Ghash128::cantor_basis(log_stride + level);
+            step
+        })
+        .collect()
+}
+
 /// Fold the pairs one parallel task owns.
 ///
 /// `start` is the output index the task's first pair produces.
-/// It is a multiple of the grain, hence of the packing width, which is what lets whole groups
-/// share a single domain evaluation.
+///
+/// It is a multiple of the grain, hence of the packing width.
+///
+/// That alignment is what lets a group share one domain point across its lanes.
+///
+/// `group_steps` walks the group bases, so the task evaluates the domain exactly once.
 ///
 /// # Panics
 ///
@@ -145,6 +193,7 @@ fn fold_task(
     out: &mut [BinaryField128],
     beta: Ghash128,
     lane_offsets: Packed,
+    group_steps: &[Ghash128],
 ) {
     // Every output slot consumes one pair, so the task's two slices are locked together.
     assert_eq!(
@@ -164,16 +213,24 @@ fn fold_task(
     // Output index the remainder starts at, relative to the task.
     let tail_offset = slot_groups.len() * WIDTH;
 
+    // Where the task's first group sits among all the codeword's groups.
+    let first_group = start / WIDTH;
+
+    // The task's only domain evaluation, opening the walk over its groups.
+    let mut base: Ghash128 = domain_point(start << 1);
+
     // Phase 1: whole packed groups.
     //
     //     block  : [ lo_0 hi_0 | lo_1 hi_1 | ... | lo_{W-1} hi_{W-1} ]   2 * WIDTH symbols
     //     slots  : [ out_0     | out_1     | ... | out_{W-1}         ]       WIDTH symbols
     for (group, (slots, block)) in slot_groups.iter_mut().zip(symbol_blocks).enumerate() {
-        // Output index lane 0 of this group produces, a multiple of the width.
-        let first = start + group * WIDTH;
+        // Advance the walk to this group's first domain point.
+        if group != 0 {
+            base += group_steps[(first_group + group).trailing_zeros() as usize];
+        }
 
-        // One domain evaluation for the group, plus the constant per-lane offsets.
-        let x = Packed::broadcast(domain_point(first << 1)) + lane_offsets;
+        // That base is lane 0's domain point, and the offsets carry the rest of the lanes.
+        let x = Packed::broadcast(base) + lane_offsets;
 
         // Cross into the polynomial basis while gathering the lanes.
         // The change of basis is additive, so the sums formed below are the same either side.
@@ -220,10 +277,11 @@ fn fold_task(
 /// Each parallel task owns a contiguous run of output symbols and the pairs feeding them, so no
 /// two tasks touch the same symbol on either side.
 ///
-/// Within a task one domain evaluation serves a whole packed group.
+/// A task evaluates the domain once, then advances it by one exclusive-or per packed group.
 ///
-/// Evaluating per symbol instead is the right shape for a single query, but over a whole
-/// codeword it would recompute that value once per output symbol.
+/// Evaluating per symbol instead is the right shape for a single query.
+///
+/// Over a whole codeword it would recompute that value once per output symbol.
 ///
 /// # Panics
 ///
@@ -245,6 +303,7 @@ pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<B
     // The challenge crosses into the polynomial basis once for the whole codeword.
     let beta_poly = Ghash128::from(beta);
     let offsets = lane_offsets();
+    let steps = group_steps::<WIDTH>(num_pairs);
 
     // Zeroed here and fully overwritten below, so the allocation is handed out already blank
     // rather than assembled from one vector per task.
@@ -258,7 +317,7 @@ pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<B
         .zip(codeword.par_chunks(2 * FOLD_GRAIN))
         .enumerate()
         .for_each(|(task, (out, pairs))| {
-            fold_task(task * FOLD_GRAIN, pairs, out, beta_poly, offsets);
+            fold_task(task * FOLD_GRAIN, pairs, out, beta_poly, offsets, &steps);
         });
 
     folded

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -187,6 +187,8 @@ fn group_steps<const W: usize>(num_pairs: usize) -> Vec<Ghash128> {
 /// # Panics
 ///
 /// Panics unless the task holds exactly two input symbols per output slot.
+///
+/// Panics in debug builds unless `start` is a multiple of the packing width.
 fn fold_task(
     start: usize,
     pairs: &[BinaryField128],
@@ -200,6 +202,18 @@ fn fold_task(
         pairs.len(),
         2 * out.len(),
         "a fold task must hold one pair per output symbol"
+    );
+
+    // Invariant: `start` is a multiple of the packing width.
+    //
+    // The lane-offset identity rests on `g AND k == 0` for a group start `g` and a lane `k`.
+    //
+    // A lane index only sets bits below `log2(WIDTH)`, so `g` must carry none of them.
+    //
+    // Group starts are `start + group * WIDTH`, so they inherit that from `start` alone.
+    debug_assert!(
+        start.is_multiple_of(WIDTH),
+        "a fold task must start on a packed group boundary"
     );
 
     // The challenge is the same in every lane, so it broadcasts once for the whole task.

--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -21,12 +21,14 @@
 //! are adjacent rows in memory.
 //!
 //! Each output symbol costs two field multiplications.
-//! In the tower basis one multiplication is a polynomial-basis multiplication wrapped in a
-//! change of basis on each operand and a change back on the result.
+//!
+//! In the tower basis a multiplication is a polynomial-basis multiplication between two changes
+//! of basis on the operands and one back on the result.
 //! Each change of basis is sixteen dependent byte-table lookups, so the wrapper dominates.
-//! Folding a whole codeword therefore crosses into the polynomial basis once per loaded symbol,
-//! multiplies there with the widest carryless-multiply register the target offers, and crosses
-//! back once per produced symbol.
+//!
+//! The fold therefore crosses into the polynomial basis once per loaded symbol and back once per
+//! produced symbol, multiplying in between with the widest carryless-multiply register available.
+//!
 //! Input and output stay in the tower basis, so the folded codeword is unchanged bit for bit.
 
 use alloc::vec::Vec;
@@ -47,12 +49,15 @@ const WIDTH: usize = Packed::WIDTH;
 
 /// Output symbols one parallel task owns.
 ///
-/// Large enough that the task-opening domain evaluation is amortised over many folds; small
-/// enough to leave real parallelism at every codeword length this crate exercises.
+/// Large enough that the task-opening domain evaluation is amortised over many folds.
+///
+/// Small enough to leave real parallelism at every codeword length this crate exercises.
 const FOLD_GRAIN: usize = 1 << 10;
 
-// A task's first output index is a multiple of the grain, and the lane-offset identity below
-// needs it to be a multiple of the packing width, so the grain must cover whole packed groups.
+// A task's first output index is a multiple of the grain.
+//
+// The lane-offset identity below needs that index to be a multiple of the packing width, so the
+// grain must cover whole packed groups.
 const _: () = assert!(
     FOLD_GRAIN.is_multiple_of(WIDTH),
     "the fold grain must be a whole number of packed groups"
@@ -92,6 +97,7 @@ pub fn fold_pair(
 ///
 /// It is not additive over integer addition, because a carry moves a bit to a place the sum of
 /// the two basis vectors never reaches.
+///
 /// Carries are absent exactly when the two bit patterns are disjoint, and then addition and
 /// exclusive-or agree:
 ///
@@ -101,7 +107,9 @@ pub fn fold_pair(
 ///
 /// A packed group's first output index `g` is a multiple of the width, which is a power of two,
 /// so every bit of `g` below `log2(width)` is clear.
+///
 /// A lane index `k` is below the width, so every bit it sets is below `log2(width)`.
+///
 /// The two patterns are therefore disjoint, and doubling shifts both up one place without
 /// disturbing that:
 ///
@@ -188,8 +196,10 @@ fn fold_task(
     // Phase 2: fewer output slots left than one packed group holds.
     //
     // A task's slot count is either a whole grain or the whole codeword's pair count.
+    //
     // The grain covers whole groups, and a power-of-two pair count is a multiple of the width
     // unless it is below it, so this runs only for a codeword with fewer pairs than the width.
+    //
     // Each leftover evaluates its own domain point, so it rests on no group alignment at all.
     //
     // Twice as many symbols are left as slots, so the leftovers pair up exactly and the
@@ -209,9 +219,11 @@ fn fold_task(
 ///
 /// Each parallel task owns a contiguous run of output symbols and the pairs feeding them, so no
 /// two tasks touch the same symbol on either side.
-/// Within a task one domain evaluation serves a whole packed group: the per-call evaluation
-/// `fold_pair` does is the right form for one query's verifier-side check, but here the same
-/// value would otherwise be recomputed once per output symbol of the whole codeword.
+///
+/// Within a task one domain evaluation serves a whole packed group.
+///
+/// Evaluating per symbol instead is the right shape for a single query, but over a whole
+/// codeword it would recompute that value once per output symbol.
 ///
 /// # Panics
 ///
@@ -282,8 +294,10 @@ mod tests {
     /// `(j + 1).trailing_zeros()`.
     ///
     /// The domain map is `F_2`-linear, and `j XOR (j + 1)` sets exactly the trailing ones of
-    /// `j` together with the first zero bit above them. So consecutive doubled domain points
-    /// differ by the sum of Cantor basis vectors `1` through `level + 1`.
+    /// `j` together with the first zero bit above them.
+    ///
+    /// Consecutive doubled domain points therefore differ by the sum of Cantor basis vectors
+    /// `1` through `level + 1`.
     fn gray_chain_steps(num_pairs: usize) -> Vec<BinaryField128> {
         let levels = num_pairs.next_power_of_two().trailing_zeros() as usize;
         let mut steps = Vec::with_capacity(levels);
@@ -479,10 +493,13 @@ mod tests {
 
     #[test]
     fn the_pair_form_agrees_with_the_vector_form() {
-        // The whole-codeword form must agree with the independent per-pair computation at every
-        // position, including across a task boundary: 4096 codeword symbols is 2048 pairs, past
-        // the 1024-symbol grain, so this covers two full parallel tasks and exercises the
-        // per-task index base that a single-task codeword leaves silent.
+        // Invariant: the whole-codeword form agrees with the independent per-pair computation
+        // at every position, including across a task boundary.
+        //
+        // Fixture state: 4096 symbols is 2048 pairs, past the 1024-symbol grain.
+        //
+        // So this spans two full parallel tasks and exercises the per-task index base that a
+        // single-task codeword leaves silent.
         let mut rng = SmallRng::seed_from_u64(0x9E37_79B9_7F4A_7C15);
         let codeword: Vec<BinaryField128> = (0..4096).map(|_| rng.random()).collect();
         let beta: BinaryField128 = rng.random();


### PR DESCRIPTION
## Summary

- Runs the `binary-pcs` codeword fold in the polynomial basis rather than the tower basis, multiplying with the widest carryless-multiply register the target offers.
- Signature, tower-basis input, and tower-basis output are unchanged. **The folded codeword is bit-identical, so the commitments, the transcript, and the proof bytes are unchanged.**
- Replaces the gray-code step chain with one domain evaluation per packed group plus a constant per-lane offset vector, which removes the serial scan the old form forced inside each parallel task.
- Writes into one preallocated buffer through disjoint output chunks instead of concatenating a vector per rayon task.
- ~1.9x-2.1x on the fold on AVX-512, ~1.85x on the portable width-1 build, ~1.07x on the whole `open` prove path.

Why a tower multiply is expensive: `BinaryField128` carries an element in the tower basis, where a product is not a single carryless multiply. It is a change of basis on each operand, a polynomial-basis multiply, and a change back — and each change of basis is sixteen dependent byte-table lookups, which no vector unit widens. The fold spends two multiplies per output symbol, so paying three basis changes once per symbol and then multiplying in the cheap basis is strictly less work than paying six inside two tower multiplies, even before any packing.

Why one broadcast plus a constant vector replaces a per-element twiddle: the domain point is a sum of Cantor basis vectors selected by the bits of the index, so it is additive over exclusive-or of indices but not over integer addition, because a carry moves a bit somewhere the sum of two basis vectors never reaches. A packed group's first output index is a multiple of the packing width, a power of two, so its low bits are clear; a lane index is below the width, so it sets only those bits. The two are disjoint, addition and exclusive-or therefore agree, and doubling preserves that — giving `domain_point(2 * (g + k)) = domain_point(2 * g) + domain_point(2 * k)`. The second term depends on the lane alone, so it is built once for the whole fold and added to one broadcast per group.

Scope: the drop-in form only. Carrying the polynomial basis across the whole fold chain, converting only where bytes leave for the Merkle leaves or the transcript, is worth roughly another 1.5x but reshapes the prover's round structure and the leaf-serialization boundary, so it belongs in a follow-up.

One behavioral note: a length-one codeword used to panic with an index-out-of-bounds inside the fold loop. It now returns an empty codeword, which is what the documented contract already promised for any power-of-two length. No round schedule produces that shape.

## Test plan

Host: Zen 5 (AVX-512, GFNI, VPCLMULQDQ), 32 threads, `RUSTFLAGS="-C target-cpu=native"`. The machine is shared, so before/after arms were built as standalone benchmark binaries and run strictly interleaved for three rounds; the table reports the median of the three. `commit` never folds, so it doubles as a load-calibration channel.

- [x] `cargo bench -p p3-binary-pcs --features parallel` (native, AVX-512, packing width 4):

  | shape | before | after | ratio |
  |---|---|---|---|
  | fold, 2^18-symbol codeword | 641.4 us | 319.5 us | 2.01x |
  | fold, 2^20-symbol codeword | 1.909 ms | 997.0 us | 1.91x |
  | fold, 2^22-symbol codeword | 8.266 ms | 3.929 ms | 2.10x |
  | `open/20`, whole prove path | 271.6 ms | 253.5 ms | 1.07x |
  | `commit/20`, no fold (calibration) | 238.1 ms | 244.4 ms | 0.97x |

- [x] `cargo bench -p p3-binary-pcs --features parallel`, no target features (portable, packing width 1) — the path with no wide carryless multiply does not regress, it improves, because it still drops half the basis changes:

  | shape | before | after | ratio |
  |---|---|---|---|
  | fold, 2^18-symbol codeword | 1.850 ms | 1.010 ms | 1.83x |
  | fold, 2^20-symbol codeword | 6.489 ms | 3.498 ms | 1.85x |
  | fold, 2^22-symbol codeword | 29.23 ms | 13.28 ms | 2.20x |

- [x] `cargo test -p p3-binary-pcs` and `--features parallel`, across every target-feature leg the packing is gated on — no extra features (width 1), `+pclmulqdq` (width 1), `+avx2,+vpclmulqdq` (width 2), `+avx512f,+vpclmulqdq` (width 4), `-C target-cpu=native` (width 4). All ten combinations pass with zero failures.
- [x] New test asserting the output is bit-identical to the tower-basis implementation, which is kept in the test module as the reference. Lengths 0, 2, 4, 8, 16, 64, 1024, 2048, 4096, 8192, 65536 — covering no pairs at all, a codeword shorter than one packed group, partial and whole groups, exactly one parallel task, and several tasks.
- [x] New test running the whole 13-round fold chain from 8192 symbols down to one, comparing the full codeword against the reference at every round rather than only the final symbol.
- [x] New test pinning the disjointness the lane-offset identity rests on: a group start's low bits are clear, and the domain point of the group start plus the domain point of the lane is the domain point of the sum.
- [x] Existing proptest against the naive additive-NTT oracle, the cross-check against the verifier's per-pair fold across a task boundary, and the power-of-two length rejection tests all kept and passing.
- [x] `cargo test --workspace` — 3618 passed, 0 failed, across 128 test binaries.
- [x] `cargo test -p p3-binary-pcs --doc` — ok.
- [x] `cargo +stable clippy --workspace --all-targets -- -D warnings` — clean, portable and under `+avx2,+vpclmulqdq` and `-C target-cpu=native`.
- [x] `cargo +nightly fmt --all -- --check` — clean.
- [x] `RUSTDOCFLAGS="-D rustdoc::broken_intra_doc_links" cargo +stable doc --no-deps -p p3-binary-pcs --document-private-items` — clean.
- [x] `cargo check --workspace --all-targets`, portable and native — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
