### PR TITLE
perf(stir): reduce prover work and add opt-in smaller proofs

### DIFF
--- a/stir/benches/stir.rs
+++ b/stir/benches/stir.rs
@@ -20,12 +20,13 @@ use p3_challenger::{
 use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft};
 use p3_field::extension::QuinticTrinomialExtensionField;
-use p3_field::{BasedVectorSpace, ExtensionField, Field, TwoAdicField};
+use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
+use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_stir::SecurityAssumption;
 use p3_stir::config::{StirConfig, StirParameters};
-use p3_stir::prover::prove_stir;
+use p3_stir::prover::{codeword_from_coeffs, prove_stir};
 use p3_stir::verifier::verify_stir;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use rand::distr::{Distribution, StandardUniform};
@@ -213,9 +214,43 @@ fn bench_stir_koalabear_fold3(c: &mut Criterion) {
     );
 }
 
+/// Compare degree-aware dispatch with the full padded DFT on the same build and inputs.
+fn bench_codeword(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stir_codeword");
+    group.sample_size(10);
+    let dft = Dft::default();
+    for (log_size, log_len) in [(12, 9), (18, 16), (18, 15), (18, 14), (18, 12), (18, 8)] {
+        let coeffs = random_poly::<Challenge>(log_len);
+        let shape = format!("domain{log_size}_degree{log_len}");
+        for full_dft in [false, true] {
+            let method = if full_dft { "full_dft" } else { "degree_aware" };
+            group.bench_function(BenchmarkId::new(method, &shape), |b| {
+                b.iter_batched(
+                    || coeffs.clone(),
+                    |mut coeffs| {
+                        if full_dft {
+                            coeffs.resize(1usize << log_size, Challenge::ZERO);
+                            dft.coset_dft_algebra_batch(
+                                RowMajorMatrix::new_col(coeffs),
+                                Val::GENERATOR,
+                            )
+                            .values
+                        } else {
+                            codeword_from_coeffs(&dft, coeffs, Val::GENERATOR, log_size)
+                        }
+                    },
+                    BatchSize::LargeInput,
+                );
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_stir_koalabear_fold2,
     bench_stir_koalabear_fold3,
+    bench_codeword,
 );
 criterion_main!(benches);

--- a/stir/benches/stir.rs
+++ b/stir/benches/stir.rs
@@ -25,7 +25,7 @@ use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
 use p3_stir::SecurityAssumption;
-use p3_stir::config::{StirConfig, StirParameters};
+use p3_stir::config::{StirConfig, StirOptions, StirParameters};
 use p3_stir::prover::{codeword_from_coeffs, prove_stir};
 use p3_stir::verifier::verify_stir;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
@@ -214,6 +214,52 @@ fn bench_stir_koalabear_fold3(c: &mut Criterion) {
     );
 }
 
+/// Measure optional proof-size tradeoffs at degree 2^18, including serialized bytes.
+fn bench_options(c: &mut Criterion) {
+    let (params, dft, challenger) = make_stir_env(2);
+    let poly = random_poly::<Challenge>(18);
+    let mut group = c.benchmark_group("stir_options");
+    group.sample_size(10);
+    for (name, options) in [
+        ("default", StirOptions::default()),
+        (
+            "final64",
+            StirOptions {
+                max_log_final_poly_len: Some(6),
+            },
+        ),
+    ] {
+        let config = StirConfig::<Val, Challenge, MyMmcs, Challenger>::new_with_options(
+            18,
+            params.clone(),
+            options,
+        );
+        let (proof, _) = prove_stir(&config, poly.clone(), &dft, &mut challenger.clone());
+        verify_stir(&config, &proof, &mut challenger.clone()).unwrap();
+        eprintln!(
+            "stir_options/{name}: rounds={}, final_coeffs={}, proof_bytes={}",
+            config.num_rounds(),
+            proof.final_polynomial.len(),
+            postcard::to_allocvec(&proof).unwrap().len()
+        );
+        group.bench_function(BenchmarkId::new("prove", name), |b| {
+            b.iter_batched(
+                || (challenger.clone(), poly.clone()),
+                |(mut ch, poly)| prove_stir(&config, poly, &dft, &mut ch),
+                BatchSize::LargeInput,
+            );
+        });
+        group.bench_function(BenchmarkId::new("verify", name), |b| {
+            b.iter_batched(
+                || challenger.clone(),
+                |mut ch| verify_stir(&config, &proof, &mut ch).unwrap(),
+                BatchSize::SmallInput,
+            );
+        });
+    }
+    group.finish();
+}
+
 /// Compare degree-aware dispatch with the full padded DFT on the same build and inputs.
 fn bench_codeword(c: &mut Criterion) {
     let mut group = c.benchmark_group("stir_codeword");
@@ -252,5 +298,6 @@ criterion_group!(
     bench_stir_koalabear_fold2,
     bench_stir_koalabear_fold3,
     bench_codeword,
+    bench_options,
 );
 criterion_main!(benches);

--- a/stir/benches/stir.rs
+++ b/stir/benches/stir.rs
@@ -226,6 +226,21 @@ fn bench_options(c: &mut Criterion) {
             "final64",
             StirOptions {
                 max_log_final_poly_len: Some(6),
+                ..Default::default()
+            },
+        ),
+        (
+            "compact",
+            StirOptions {
+                compact_answers: true,
+                ..Default::default()
+            },
+        ),
+        (
+            "final64_compact",
+            StirOptions {
+                max_log_final_poly_len: Some(6),
+                compact_answers: true,
             },
         ),
     ] {

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -98,6 +98,15 @@ pub struct StirParameters<M> {
     pub mmcs: M,
 }
 
+/// Optional STIR prover/proof-size tradeoffs. Both prover and verifier must use the same options.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct StirOptions {
+    /// `Some(cap)` stops folding once the coefficient bound is at most `2^cap`, after at least the
+    /// starting fold. `None` retains the legacy schedule. Larger bounds save intermediate
+    /// rounds at the cost of sending more final coefficients. An unreachable bound is rejected.
+    pub max_log_final_poly_len: Option<usize>,
+}
+
 /// Derived configuration for a single STIR round.
 ///
 /// All values are computed from [`StirParameters`] and the accumulated state
@@ -178,6 +187,7 @@ type NonOwning<F, EF, Challenger> = PhantomData<fn() -> (F, EF, Challenger)>;
 /// Contains all precomputed values needed by the prover and verifier.
 #[derive(Debug, Clone)]
 pub struct StirConfig<F, EF, M, Challenger> {
+    options: StirOptions,
     /// Log₂ of the degree of the initial polynomial.
     pub log_starting_degree: usize,
 
@@ -264,6 +274,15 @@ impl core::fmt::Display for Stage {
 /// process.
 #[derive(Clone, Copy, Debug, PartialEq, Error)]
 pub enum StirConfigError {
+    /// The folding arities cannot reach the requested final coefficient bound.
+    #[error(
+        "requested final polynomial log length {max_log_final_poly_len} is below the minimum reachable {min_log_final_poly_len}"
+    )]
+    FinalPolynomialBoundUnreachable {
+        max_log_final_poly_len: usize,
+        min_log_final_poly_len: usize,
+    },
+
     /// `log_folding_factor` was below the paper-backed schedule's minimum of 2 (k >= 4).
     #[error(
         "the paper-backed STIR parameter schedule requires log_folding_factor >= 2 (k >= 4), \
@@ -457,7 +476,7 @@ where
         log_starting_degree: usize,
         params: StirParameters<M>,
     ) -> Result<Self, StirConfigError> {
-        Self::try_new_with_optional_combine(log_starting_degree, params, None)
+        Self::try_new_with_options(log_starting_degree, params, StirOptions::default())
     }
 
     /// Derive a full STIR configuration from user-facing parameters.
@@ -470,6 +489,29 @@ where
     /// [`Self::try_new`] for the fallible form and [`StirConfigError`] for the failure modes.
     pub fn new(log_starting_degree: usize, params: StirParameters<M>) -> Self {
         Self::try_new(log_starting_degree, params).unwrap_or_else(|e| panic!("{e}"))
+    }
+
+    /// Derive the full schedule using optional prover/proof-size tradeoffs.
+    /// Both prover and verifier must agree on `options`.
+    pub fn try_new_with_options(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        options: StirOptions,
+    ) -> Result<Self, StirConfigError> {
+        Self::try_new_with_optional_combine(log_starting_degree, params, None, options)
+    }
+
+    /// Panicking form of [`Self::try_new_with_options`].
+    ///
+    /// # Panics
+    /// Panics when the parameters or requested options cannot produce a valid schedule.
+    pub fn new_with_options(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        options: StirOptions,
+    ) -> Self {
+        Self::try_new_with_options(log_starting_degree, params, options)
+            .unwrap_or_else(|e| panic!("{e}"))
     }
 
     /// Like [`Self::try_new`], but additionally inflates round 0's `eta` (and, transitively,
@@ -499,6 +541,24 @@ where
         num_classes: usize,
         ell: u64,
     ) -> Result<Self, StirConfigError> {
+        Self::try_new_with_combine_and_options(
+            log_starting_degree,
+            params,
+            num_classes,
+            ell,
+            StirOptions::default(),
+        )
+    }
+
+    /// Like [`Self::try_new_with_combine`], deriving the entire schedule with `options`.
+    /// Both prover and verifier must agree on these options.
+    pub fn try_new_with_combine_and_options(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        num_classes: usize,
+        ell: u64,
+        options: StirOptions,
+    ) -> Result<Self, StirConfigError> {
         // `ell` carries the real information, so without these a `num_classes` of 1 would
         // silently skip all Combine accounting despite the name.
         if num_classes < 2 {
@@ -511,6 +571,7 @@ where
             log_starting_degree,
             params,
             Some(CombineRequirement { num_classes, ell }),
+            options,
         )
     }
 
@@ -533,10 +594,32 @@ where
             .unwrap_or_else(|e| panic!("{e}"))
     }
 
+    /// Panicking form of [`Self::try_new_with_combine_and_options`].
+    ///
+    /// # Panics
+    /// Panics when the parameters, Combine requirements or options cannot produce a valid schedule.
+    pub fn new_with_combine_and_options(
+        log_starting_degree: usize,
+        params: StirParameters<M>,
+        num_classes: usize,
+        ell: u64,
+        options: StirOptions,
+    ) -> Self {
+        Self::try_new_with_combine_and_options(
+            log_starting_degree,
+            params,
+            num_classes,
+            ell,
+            options,
+        )
+        .unwrap_or_else(|e| panic!("{e}"))
+    }
+
     fn try_new_with_optional_combine(
         log_starting_degree: usize,
         params: StirParameters<M>,
         combine: Option<CombineRequirement>,
+        options: StirOptions,
     ) -> Result<Self, StirConfigError> {
         // Rate 1 leaves no redundancy to test proximity against: `delta = 1 - rho - eta` is
         // non-positive, so the query-count formula has no per-query failure probability
@@ -599,16 +682,24 @@ where
         let algebraic_security_level = security_level - max_pow_bits;
         let num_ood_samples = params.soundness_type.stir_num_ood_samples();
 
-        // Determine number of intermediate rounds. Round 0 folds by k0
-        // (`log_starting_folding_factor`); every fold after that, including the final
-        // direct-send stage, folds by k (`log_folding_factor`). We fold all the way down
-        // to a polynomial of size `2^log_final_degree` (where log_final_degree <
-        // log_folding_factor, whenever more than the k0 fold happens) and send it
-        // directly. When `log_starting_degree - log_starting_folding_factor` is itself
-        // already `< log_folding_factor`, the k0 fold IS the final fold and no further
-        // k-fold occurs.
+        // Every schedule performs k0 first. Optional early stopping removes only whole
+        // subsequent k folds, before deriving queries, eta, PoW and the union-bound buffer.
         let after_starting_fold = log_starting_degree - log_starting_folding_factor;
-        let extra_folds = after_starting_fold / log_folding_factor;
+        let extra_folds = match options.max_log_final_poly_len {
+            None => after_starting_fold / log_folding_factor,
+            Some(cap) => {
+                let minimum = after_starting_fold % log_folding_factor;
+                if cap < minimum {
+                    return Err(StirConfigError::FinalPolynomialBoundUnreachable {
+                        max_log_final_poly_len: cap,
+                        min_log_final_poly_len: minimum,
+                    });
+                }
+                after_starting_fold
+                    .saturating_sub(cap)
+                    .div_ceil(log_folding_factor)
+            }
+        };
         let total_folds = 1 + extra_folds;
 
         // Last fold produces the final polynomial; intermediate rounds = total_folds - 1.
@@ -887,6 +978,7 @@ where
         let final_pow_bits = derive_pow_bits("query", Stage::Final, final_query_alg)?;
 
         Ok(Self {
+            options,
             log_starting_degree,
             soundness_type: params.soundness_type,
             security_level: params.security_level,
@@ -903,6 +995,11 @@ where
             mmcs: params.mmcs,
             _phantom: PhantomData,
         })
+    }
+
+    /// Options used to derive this schedule; prover and verifier must agree on them.
+    pub const fn options(&self) -> StirOptions {
+        self.options
     }
 
     /// Log₂ of the initial evaluation domain size.
@@ -985,6 +1082,54 @@ mod tests {
             max_pow_bits: 20,
             mmcs: TestMmcs::new(val_mmcs),
         }
+    }
+
+    #[test]
+    fn early_stop_selects_the_first_fold_within_the_requested_bound() {
+        let cases = [
+            (18, 2, 2, None, 8, 0),
+            (18, 2, 2, Some(0), 8, 0),
+            (18, 2, 2, Some(6), 5, 6),
+            (18, 2, 3, None, 5, 1),
+            (18, 2, 3, Some(6), 4, 4),
+            (10, 3, 2, Some(3), 2, 3),
+            (10, 3, 2, Some(2), 3, 1),
+            (10, 3, 2, Some(usize::MAX), 0, 7),
+        ];
+        for (degree, starting_fold, fold, cap, rounds, final_log) in cases {
+            let mut params = test_params(1, fold);
+            params.log_starting_folding_factor = starting_fold;
+            params.security_level = 16;
+            params.max_pow_bits = 0;
+            let options = StirOptions {
+                max_log_final_poly_len: cap,
+            };
+            let config = StirConfig::<TestF, TestEF, TestMmcs, TestChallenger>::new_with_options(
+                degree, params, options,
+            );
+            assert_eq!(
+                (config.num_rounds(), config.log_final_degree),
+                (rounds, final_log)
+            );
+            assert_eq!(config.options(), options);
+        }
+        let mut params = test_params(1, 2);
+        params.log_starting_folding_factor = 3;
+        let err = StirConfig::<TestF, TestEF, TestMmcs, TestChallenger>::try_new_with_options(
+            10,
+            params,
+            StirOptions {
+                max_log_final_poly_len: Some(0),
+            },
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            StirConfigError::FinalPolynomialBoundUnreachable {
+                max_log_final_poly_len: 0,
+                min_log_final_poly_len: 1,
+            }
+        );
     }
 
     /// [`test_params`] with every knob the fallibility tests need to vary exposed.
@@ -1483,11 +1628,11 @@ mod tests {
             (16, 1, 3, 2, 80, 20, cb),
         ];
 
-        {
+        for cap in [None, Some(2), Some(6), Some(12), Some(usize::MAX)] {
             for &(log_deg, log_blowup, log_fold, log_starting_fold, sec, max_pow, soundness_type) in
                 &cases
             {
-                let config = StirConfig::<F, EF, MyMmcs, MyChallenger>::new(
+                let config = StirConfig::<F, EF, MyMmcs, MyChallenger>::new_with_options(
                     log_deg,
                     StirParameters {
                         log_blowup,
@@ -1498,10 +1643,13 @@ mod tests {
                         max_pow_bits: max_pow,
                         mmcs: MyMmcs::new(val_mmcs.clone()),
                     },
+                    StirOptions {
+                        max_log_final_poly_len: cap,
+                    },
                 );
 
                 // Mirror `StirConfig::new`'s buffered target.
-                let total_folds = 1 + (log_deg - log_starting_fold) / log_fold;
+                let total_folds = config.num_rounds() + 1;
                 let buffer = libm::ceil(libm::log2((6 * (total_folds - 1) + 3) as f64)) as usize;
                 let buffered = (sec + buffer) as f64;
                 // Recomputed algebraic bits use the same `libm` math as the config, so
@@ -1570,7 +1718,7 @@ mod tests {
                         .round_configs
                         .last()
                         .map_or((log_deg, log_blowup), |last| {
-                            let fd = last.log_degree - log_fold;
+                            let fd = last.log_degree - last.log_folding_factor;
                             let fdom = last.log_domain_size - 1;
                             (fd, fdom - fd)
                         });

--- a/stir/src/config.rs
+++ b/stir/src/config.rs
@@ -105,6 +105,11 @@ pub struct StirOptions {
     /// starting fold. `None` retains the legacy schedule. Larger bounds save intermediate
     /// rounds at the cost of sending more final coefficients. An unreachable bound is rejected.
     pub max_log_final_poly_len: Option<usize>,
+
+    /// Omit answer-polynomial coefficients from the proof and reconstruct them in the
+    /// verifier. This saves proof bytes at the cost of verifier interpolation work and
+    /// temporary memory. The default sends coefficients; both sides must agree on this option.
+    pub compact_answers: bool,
 }
 
 /// Derived configuration for a single STIR round.
@@ -1103,6 +1108,7 @@ mod tests {
             params.max_pow_bits = 0;
             let options = StirOptions {
                 max_log_final_poly_len: cap,
+                ..Default::default()
             };
             let config = StirConfig::<TestF, TestEF, TestMmcs, TestChallenger>::new_with_options(
                 degree, params, options,
@@ -1120,6 +1126,7 @@ mod tests {
             params,
             StirOptions {
                 max_log_final_poly_len: Some(0),
+                ..Default::default()
             },
         )
         .unwrap_err();
@@ -1645,6 +1652,7 @@ mod tests {
                     },
                     StirOptions {
                         max_log_final_poly_len: cap,
+                        ..Default::default()
                     },
                 );
 

--- a/stir/src/error.rs
+++ b/stir/src/error.rs
@@ -99,6 +99,10 @@ pub enum ProofShapeError {
         got: usize,
     },
 
+    /// Compact answers require an empty transmitted coefficient vector.
+    #[error("{round}: compact answers expect no transmitted ans coefficients, got {got}")]
+    UnexpectedAnsPolynomial { round: RoundLabel, got: usize },
+
     /// A committed oracle is read through a Merkle multi-opening the proof must supply.
     #[error("{round}: missing query openings")]
     MissingQueryOpenings { round: RoundLabel },

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -20,10 +20,12 @@
 //! Several deliberate implementation choices differ from the construction stated in
 //! the paper:
 //!
-//! - **Prover-assisted Ans check.** The paper's verifier interpolates `Ans` itself. Here the
-//!   prover sends `Ans`, and the verifier checks it against the barycentric interpolant
+//! - **Prover-assisted Ans check.** The paper's verifier interpolates `Ans` itself. By default
+//!   the prover sends `Ans`, and the verifier checks it against the barycentric interpolant
 //!   through the round's points at a transcript-derived random point. Its Schwartz–Zippel
-//!   error is included explicitly in STIR's parameter validation.
+//!   error is included explicitly in STIR's parameter validation. [`StirOptions::compact_answers`]
+//!   omits the coefficients and reconstructs them in the verifier, preserving the transcript
+//!   and the existing check while trading verifier computation for fewer proof bytes.
 //! - **Fixed `s` schedule.** OOD sample count is fixed per the paper's recommended schedule
 //!   (`s = 1` for Johnson, `s = 2` for capacity); [`config::StirConfig::new`] does not search
 //!   for the smallest valid `s`.

--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -57,7 +57,9 @@ mod soundness;
 pub mod utils;
 pub mod verifier;
 
-pub use config::{Stage, StirConfig, StirConfigError, StirParameters, StirRoundConfig};
+pub use config::{
+    Stage, StirConfig, StirConfigError, StirOptions, StirParameters, StirRoundConfig,
+};
 pub use error::{ExternalSourceError, GrindStage, ProofShapeError, RoundLabel, StirError};
 pub use p3_security::whir::SecurityAssumption;
 pub use pcs::{DEFAULT_MAX_LOG_HEIGHT_SPREAD, StirCommitment, TwoAdicStirPcs};

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -1097,10 +1097,14 @@ where
                 .bit_reverse_rows();
         }
         let poly_height = 1usize << group.log_native_heights[idx_in_group];
-        let lde_mat = lde.bit_reverse_rows().to_row_major_matrix();
-        let mut coeffs = self.dft.coset_idft_batch(lde_mat, Val::GENERATOR);
-        let width = coeffs.width();
-        coeffs.values.truncate(poly_height * width);
+        let width = lde.width();
+        // In bit-reversed order the first `poly_height` rows are the polynomial's values on
+        // the native-size GENERATOR-shifted sub-coset. Interpolate only those rows instead of
+        // the whole committed LDE and discarding the high zero coefficients afterwards.
+        let native_lde = RowMajorMatrixView::new(&lde.values[..poly_height * width], width)
+            .bit_reverse_rows()
+            .to_row_major_matrix();
+        let mut coeffs = self.dft.coset_idft_batch(native_lde, Val::GENERATOR);
         coeffs.values.resize(domain.size() * width, Val::ZERO);
         let result = self
             .dft
@@ -1179,12 +1183,14 @@ where
                     // forward transform of its coefficients, zero-padded to the target size.
                     // A second `lde` would instead read those coefficients back as evaluations
                     // on a subgroup, and extend a different polynomial.
-                    let natural_lde = lde.bit_reverse_rows().to_row_major_matrix();
-                    let mut coeffs = self.dft.coset_idft_batch(natural_lde, Val::GENERATOR);
-                    let width = coeffs.width();
-                    coeffs
-                        .values
-                        .truncate((1usize << log_native_height) * width);
+                    let native_height = 1usize << log_native_height;
+                    let width = lde.width();
+                    let mut native_lde = lde;
+                    native_lde.values.truncate(native_height * width);
+                    let natural_native_lde = native_lde.bit_reverse_rows().to_row_major_matrix();
+                    let mut coeffs = self
+                        .dft
+                        .coset_idft_batch(natural_native_lde, Val::GENERATOR);
                     coeffs
                         .values
                         .resize((1usize << log_lde_height) * width, Val::ZERO);

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -2566,6 +2566,7 @@ mod tests {
         }
         let options = crate::StirOptions {
             max_log_final_poly_len: Some(4),
+            ..Default::default()
         };
         let early = original.clone().with_options(options);
         assert_eq!(original.options(), crate::StirOptions::default());
@@ -2639,6 +2640,100 @@ mod tests {
                 )];
                 <TestPcs as Pcs<EF, TestChallenger>>::verify(&pcs, claims, &proof, &mut base)
                     .expect("ordinary and Combine proofs verify under their own options");
+            }
+        }
+    }
+
+    #[test]
+    fn compact_answers_preserve_pcs_values_and_warm_clone_transcripts() {
+        for cap in [None, Some(4)] {
+            for spread in [0, 2] {
+                let (pcs, _) = test_pcs_and_params();
+                let options = StirOptions {
+                    max_log_final_poly_len: cap,
+                    ..Default::default()
+                };
+                let pcs = pcs.with_max_log_height_spread(spread).with_options(options);
+                let mut rng = rand::rngs::SmallRng::seed_from_u64(315);
+                let perm = TestPerm::new_from_rng_128(&mut rng);
+                let mut base = TestChallenger::new(perm);
+                let domains: Vec<_> = [8, 6, 4]
+                    .map(|log_h| {
+                        <TestPcs as Pcs<EF, TestChallenger>>::natural_domain_for_degree(
+                            &pcs,
+                            1 << log_h,
+                        )
+                    })
+                    .into();
+                let inputs: Vec<_> = domains
+                    .iter()
+                    .zip([8, 6, 4])
+                    .map(|(&domain, log_h)| {
+                        (
+                            domain,
+                            RowMajorMatrix::<TestVal>::rand(&mut rng, 1 << log_h, 2),
+                        )
+                    })
+                    .collect();
+                let (commit, data) = <TestPcs as Pcs<EF, TestChallenger>>::commit(&pcs, inputs);
+                base.observe(commit.clone());
+                let zeta: EF = base.sample_algebra_element();
+                let mut full_p = base.clone();
+                let (values, full_proof) = <TestPcs as Pcs<EF, TestChallenger>>::open(
+                    &pcs,
+                    vec![(&data, vec![vec![zeta]; 3])],
+                    &mut full_p,
+                );
+                // Clone only after opening has warmed both ordinary and Combine schedules.
+                let compact = pcs.clone().with_options(StirOptions {
+                    compact_answers: true,
+                    ..options
+                });
+                let mut compact_p = base.clone();
+                let (compact_values, compact_proof) = <TestPcs as Pcs<EF, TestChallenger>>::open(
+                    &compact,
+                    vec![(&data, vec![vec![zeta]; 3])],
+                    &mut compact_p,
+                );
+                assert_eq!(values, compact_values);
+                let next: EF = full_p.sample_algebra_element();
+                assert_eq!(next, compact_p.sample_algebra_element::<EF>());
+                let claims = vec![(
+                    commit,
+                    domains
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, domain)| (domain, vec![(zeta, values[0][i][0].clone())]))
+                        .collect::<Vec<_>>(),
+                )];
+                for (pcs, proof) in [(&pcs, &full_proof), (&compact, &compact_proof)] {
+                    let mut v_ch = base.clone();
+                    <TestPcs as Pcs<EF, TestChallenger>>::verify(
+                        pcs,
+                        claims.clone(),
+                        proof,
+                        &mut v_ch,
+                    )
+                    .unwrap();
+                    assert_eq!(next, v_ch.sample_algebra_element::<EF>());
+                }
+                assert!(
+                    pcs.config_cache
+                        .read()
+                        .values()
+                        .all(|c| !c.options().compact_answers)
+                );
+                assert!(
+                    compact
+                        .config_cache
+                        .read()
+                        .values()
+                        .all(|c| c.options().compact_answers)
+                );
+                assert!(
+                    postcard::to_allocvec(&compact_proof).unwrap().len()
+                        < postcard::to_allocvec(&full_proof).unwrap().len()
+                );
             }
         }
     }

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -728,11 +728,31 @@ where
 
         let inv_denoms = compute_inverse_denominators::<Val, Challenge>(&mats_and_points, &coset);
 
+        // Adjusted weights are consumed only on each matrix's native-height prefix. Track the
+        // longest such prefix separately per point; inverse denominators remain full-size for
+        // quotient construction below.
+        let mut point_max_native_height: LinearMap<Challenge, usize> = LinearMap::new();
+        for ((_, points), layout) in mats_and_points.iter().zip(&matrix_layouts) {
+            for (points_for_mat, &(log_native_h, _)) in points.iter().zip(layout) {
+                let h = 1usize << log_native_h;
+                for &point in points_for_mat {
+                    if let Some(existing) = point_max_native_height.get_mut(&point) {
+                        *existing = (*existing).max(h);
+                    } else {
+                        point_max_native_height.insert(point, h);
+                    }
+                }
+            }
+        }
+
         // Precompute adjusted barycentric weights once per opening point.
         // adjusted[i] = 1/(z - x_i) - 1/z, reused across all matrices opened at z.
         let adjusted_weights: LinearMap<Challenge, Vec<Challenge>> = inv_denoms
             .iter()
-            .map(|(point, denoms)| (*point, compute_adjusted_weights(*point, denoms)))
+            .map(|(point, denoms)| {
+                let h = *point_max_native_height.get(point).unwrap();
+                (*point, compute_adjusted_weights(*point, &denoms[..h]))
+            })
             .collect();
 
         let all_opened_values: OpenedValues<Challenge> = mats_and_points

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -86,7 +86,7 @@ use serde::{Deserialize, Serialize};
 use spin::RwLock;
 use tracing::instrument;
 
-use crate::config::{StirConfig, StirConfigError, StirParameters};
+use crate::config::{StirConfig, StirConfigError, StirOptions, StirParameters};
 use crate::error::{ProofShapeError, StirError};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_multi_from_codewords;
@@ -313,6 +313,7 @@ pub struct TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> 
     dft: Dft,
     input_mmcs: InputMmcs,
     stir: StirParameters<StirMmcs>,
+    options: StirOptions,
     /// Maximum `h_max - h_min`, in octaves, among the native heights sharing one LDE domain.
     ///
     /// `0` puts every distinct native height on its own domain, so `Combine` never runs and
@@ -337,9 +338,25 @@ impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
             dft,
             input_mmcs,
             stir,
+            options: StirOptions::default(),
             max_log_height_spread: DEFAULT_MAX_LOG_HEIGHT_SPREAD,
             config_cache: Arc::new(RwLock::new(alloc::collections::BTreeMap::new())),
         }
+    }
+
+    /// Set the STIR prover/proof-size tradeoffs. Both prover and verifier must agree on
+    /// these options; they are not carried in the proof. Cached schedules are reset so
+    /// clones configured with other options retain their own derivations.
+    #[must_use]
+    pub fn with_options(mut self, options: StirOptions) -> Self {
+        self.options = options;
+        self.config_cache = Arc::new(RwLock::new(alloc::collections::BTreeMap::new()));
+        self
+    }
+
+    /// Options used to derive this PCS instance's STIR schedules.
+    pub const fn options(&self) -> StirOptions {
+        self.options
     }
 
     /// Override how wide a native-height spread may share one LDE domain.
@@ -449,13 +466,16 @@ where
         // derivation is idempotent, so a racing duplicate is harmless: the loser's `Arc` is
         // simply dropped in favour of whichever landed first.
         let config = Arc::new(match combine {
-            Some((num_classes, ell)) => StirConfig::try_new_with_combine(
+            Some((num_classes, ell)) => StirConfig::try_new_with_combine_and_options(
                 log_stir_degree,
                 self.stir.clone(),
                 num_classes,
                 ell,
+                self.options,
             )?,
-            None => StirConfig::try_new(log_stir_degree, self.stir.clone())?,
+            None => {
+                StirConfig::try_new_with_options(log_stir_degree, self.stir.clone(), self.options)?
+            }
         });
 
         let mut cache = self.config_cache.write();
@@ -2530,6 +2550,97 @@ mod tests {
 
         // One entry per distinct shape, so nothing aliased and nothing was inserted twice.
         assert_eq!(pcs.config_cache.read().len(), shapes.len());
+    }
+
+    #[test]
+    fn early_stop_options_keep_warm_clone_caches_and_proofs_independent() {
+        let (original, params) = test_pcs_and_params();
+        let shapes = [(8, None), (8, Some((2, 194)))];
+        for (degree, combine) in shapes {
+            assert_eq!(
+                original
+                    .get_or_compute_stir_config(degree, combine)
+                    .num_rounds(),
+                3
+            );
+        }
+        let options = crate::StirOptions {
+            max_log_final_poly_len: Some(4),
+        };
+        let early = original.clone().with_options(options);
+        assert_eq!(original.options(), crate::StirOptions::default());
+        assert_eq!(early.options(), options);
+        for (degree, combine) in shapes {
+            let expected = match combine {
+                Some((classes, ell)) => TestConfig::new_with_combine_and_options(
+                    degree,
+                    params.clone(),
+                    classes,
+                    ell,
+                    options,
+                ),
+                None => TestConfig::new_with_options(degree, params.clone(), options),
+            };
+            let actual = early.get_or_compute_stir_config(degree, combine);
+            assert_eq!(actual.num_rounds(), 1);
+            assert_eq!(
+                schedule_fingerprint(&actual),
+                schedule_fingerprint(&expected)
+            );
+            assert_eq!(
+                original
+                    .get_or_compute_stir_config(degree, combine)
+                    .num_rounds(),
+                3
+            );
+        }
+
+        // Exercise ordinary buckets separately, then merge height classes through Combine.
+        for spread in [0, 2] {
+            for pcs in [original.clone(), early.clone()] {
+                let pcs = pcs.with_max_log_height_spread(spread);
+                let mut rng = rand::rngs::SmallRng::seed_from_u64(314);
+                let perm = TestPerm::new_from_rng_128(&mut rng);
+                let mut base = TestChallenger::new(perm);
+                let domains: Vec<_> = [8, 6, 4]
+                    .map(|log_h| {
+                        <TestPcs as Pcs<EF, TestChallenger>>::natural_domain_for_degree(
+                            &pcs,
+                            1 << log_h,
+                        )
+                    })
+                    .into_iter()
+                    .collect();
+                let inputs: Vec<_> = domains
+                    .iter()
+                    .zip([8, 6, 4])
+                    .map(|(&domain, log_h)| {
+                        (
+                            domain,
+                            RowMajorMatrix::<TestVal>::rand(&mut rng, 1 << log_h, 2),
+                        )
+                    })
+                    .collect();
+                let (commit, data) = <TestPcs as Pcs<EF, TestChallenger>>::commit(&pcs, inputs);
+                base.observe(commit.clone());
+                let zeta: EF = base.sample_algebra_element();
+                let (values, proof) = <TestPcs as Pcs<EF, TestChallenger>>::open(
+                    &pcs,
+                    vec![(&data, vec![vec![zeta]; 3])],
+                    &mut base.clone(),
+                );
+                let claims = vec![(
+                    commit,
+                    domains
+                        .into_iter()
+                        .enumerate()
+                        .map(|(i, domain)| (domain, vec![(zeta, values[0][i][0].clone())]))
+                        .collect(),
+                )];
+                <TestPcs as Pcs<EF, TestChallenger>>::verify(&pcs, claims, &proof, &mut base)
+                    .expect("ordinary and Combine proofs verify under their own options");
+            }
+        }
     }
 
     /// A prover that commits a perfectly low-degree codeword which is *not* the reduced

--- a/stir/src/proof.rs
+++ b/stir/src/proof.rs
@@ -69,6 +69,11 @@ pub struct StirRoundProof<EF: Field, M: Mmcs<EF>, Witness> {
     /// constant than rebuilding them by Newton's divided differences. `ans_polynomial` is
     /// observed in the transcript before `rho` is sampled, so a malicious prover cannot fit
     /// `Ans` to a known `rho`.
+    ///
+    /// With [`crate::StirOptions::compact_answers`], this vector must be empty. The verifier
+    /// reconstructs the same canonical coefficients from the OOD and verified query values
+    /// before observing them at the same transcript position. The option is agreed outside
+    /// the proof; an empty vector alone does not select compact mode.
     pub ans_polynomial: Vec<EF>,
 
     /// Merkle openings for the STIR queries, sharing one pruned multi-opening proof.

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -252,7 +252,16 @@ where
                 let folded = tracing::debug_span!("fold_codeword").in_scope(|| {
                     fold_codeword::<F, EF>(codeword, fold_beta, self.log_arity, current_log_domain)
                 });
-                let coeffs = coeffs_from_codeword(self.dft, &folded, self.fold_shift);
+                // The folded polynomial has only `folded_degree_bound` coefficients. Gather
+                // that size sub-coset for interpolation while retaining the full fold codeword
+                // below, since round queries still read it at the original domain size.
+                let rc = &self.config.round_configs[self.round];
+                let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);
+                let stride = folded.len() / folded_degree_bound;
+                let folded_subcoset: Vec<EF> = (0..folded_degree_bound)
+                    .map(|i| folded[i * stride])
+                    .collect();
+                let coeffs = coeffs_from_codeword(self.dft, &folded_subcoset, self.fold_shift);
                 self.folded_codeword = Some(folded);
                 coeffs
             }
@@ -295,10 +304,10 @@ where
 
     /// The prefix of `fold_coeffs` that can be non-zero.
     ///
-    /// `fold_coeffs` runs to whatever length the fold's source implied — the fold domain when
-    /// the round folded a committed codeword, the folded sub-coset when it folded a virtual
-    /// witness — and either can reach past the folded polynomial's true degree, which the
-    /// round's degree schedule bounds. Evaluating only that prefix skips the trailing zeros.
+    /// `fold_coeffs` has exactly the scheduled degree-bound length when the round folded a
+    /// committed codeword. When it folded a virtual witness, its sub-coset can reach past the
+    /// folded polynomial's true degree. Evaluating only this prefix skips that trailing zero
+    /// tail while remaining valid for both representations.
     fn truncated_fold_coeffs(&self) -> &[EF] {
         let rc = &self.config.round_configs[self.round];
         let folded_degree_bound = 1usize << (rc.log_degree - self.log_arity);

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -613,7 +613,11 @@ where
             folding_pow_witness,
             ood_answers,
             pow_witness,
-            ans_polynomial: finish.ans_poly,
+            ans_polynomial: if config.options().compact_answers {
+                Vec::new()
+            } else {
+                finish.ans_poly
+            },
             query_openings,
         },
         next_oracle: finish.next_oracle,
@@ -1179,7 +1183,11 @@ where
                 folding_pow_witness,
                 ood_answers: p.ood_answers,
                 pow_witness,
-                ans_polynomial: finish.ans_poly,
+                ans_polynomial: if configs[i].options().compact_answers {
+                    Vec::new()
+                } else {
+                    finish.ans_poly
+                },
                 query_openings: p.query_openings,
             });
             if r == offset(i) {

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -56,10 +56,8 @@ where
 {
     let initial_shift = F::GENERATOR;
     let log_initial_domain = config.log_starting_domain_size();
-    let initial_domain_size = 1 << log_initial_domain;
-    let mut coeffs = poly_coeffs;
-    coeffs.resize(initial_domain_size, EF::ZERO);
-    let initial_codeword = codeword_from_coeffs(dft, coeffs, initial_shift, log_initial_domain);
+    let initial_codeword =
+        codeword_from_coeffs(dft, poly_coeffs, initial_shift, log_initial_domain);
 
     prove_stir_from_codeword(config, initial_codeword, dft, challenger)
 }
@@ -270,7 +268,7 @@ where
 
         self.next_commit_codeword = codeword_from_coeffs(
             self.dft,
-            self.fold_coeffs.clone(),
+            self.truncated_fold_coeffs().to_vec(),
             self.next_shift,
             self.next_log_domain,
         );
@@ -1295,8 +1293,6 @@ where
         .zip(poly_coeffs)
         .map(|(config, coeffs)| {
             let log_initial_domain = config.log_starting_domain_size();
-            let mut coeffs = coeffs;
-            coeffs.resize(1 << log_initial_domain, EF::ZERO);
             codeword_from_coeffs(dft, coeffs, F::GENERATOR, log_initial_domain)
         })
         .collect();
@@ -1359,8 +1355,8 @@ where
     prove_stir_multi_inner(configs, initial_codewords, dft, challenger, false)
 }
 
-/// Evaluate two polynomials of at most `2^log_len` coefficients on the coset `shift * <g>` of
-/// size `2^log_size`, returning both codewords in **natural order**.
+/// Evaluate polynomials of at most `2^log_len` coefficients on the coset `shift * <g>` of
+/// size `2^log_size`, interleaving their codewords in **natural order**.
 ///
 /// A full-size DFT would spend all `log_size` butterfly layers on an input that is zero past
 /// its first `2^log_len` coefficients. Instead, split the coset into
@@ -1377,6 +1373,46 @@ where
 /// batched call, and each output row lands on a contiguous natural-order block.
 ///
 /// Coefficients past index `2^log_size` are ignored, matching evaluation of the truncation.
+fn eval_low_degree_on_coset<F, EF, Dft, const WIDTH: usize>(
+    dft: &Dft,
+    polys: [&[EF]; WIDTH],
+    shift: F,
+    log_size: usize,
+    log_len: usize,
+) -> Vec<EF>
+where
+    F: TwoAdicField,
+    EF: ExtensionField<F> + BasedVectorSpace<F>,
+    Dft: TwoAdicSubgroupDft<F>,
+{
+    debug_assert!(log_len <= log_size);
+    let size = 1usize << log_size;
+    let num_cosets = size >> log_len;
+    let generator = F::two_adic_generator(log_size);
+
+    // Row `c` holds the degree-`c` coefficients scaled by `(shift * g^a)^c`, which as
+    // `a` varies is the geometric sequence starting at `shift^c` with ratio `g^c`.
+    let mut scaled = EF::zero_vec(size * WIDTH);
+    scaled
+        .par_chunks_mut(WIDTH * num_cosets)
+        .enumerate()
+        .for_each(|(c, row)| {
+            let coeffs = polys.map(|poly| poly.get(c).copied().unwrap_or(EF::ZERO));
+            let ratio = generator.exp_u64(c as u64);
+            let mut scale = shift.exp_u64(c as u64);
+            for values in row.as_chunks_mut::<WIDTH>().0 {
+                for (value, &coeff) in values.iter_mut().zip(&coeffs) {
+                    *value = coeff * scale;
+                }
+                scale *= ratio;
+            }
+        });
+
+    dft.dft_algebra_batch(RowMajorMatrix::new(scaled, WIDTH * num_cosets))
+        .values
+}
+
+/// Evaluate a pair using the shared low-degree transform, then deinterleave the codewords.
 fn eval_low_degree_pair_on_coset<F, EF, Dft>(
     dft: &Dft,
     first: &[EF],
@@ -1390,32 +1426,9 @@ where
     EF: ExtensionField<F> + BasedVectorSpace<F>,
     Dft: TwoAdicSubgroupDft<F>,
 {
-    debug_assert!(log_len <= log_size);
     let size = 1usize << log_size;
     let num_cosets = size >> log_len;
-    let generator = F::two_adic_generator(log_size);
-
-    // Row `c` holds the pair of degree-`c` coefficients scaled by `(shift * g^a)^c`, which as
-    // `a` varies is the geometric sequence starting at `shift^c` with ratio `g^c`.
-    let mut scaled = EF::zero_vec((1usize << log_len) * 2 * num_cosets);
-    scaled
-        .par_chunks_mut(2 * num_cosets)
-        .enumerate()
-        .for_each(|(c, row)| {
-            let first_c = first.get(c).copied().unwrap_or(EF::ZERO);
-            let second_c = second.get(c).copied().unwrap_or(EF::ZERO);
-            let ratio = generator.exp_u64(c as u64);
-            let mut scale = shift.exp_u64(c as u64);
-            for pair in row.as_chunks_mut::<2>().0 {
-                pair[0] = first_c * scale;
-                pair[1] = second_c * scale;
-                scale *= ratio;
-            }
-        });
-
-    let transformed = dft
-        .dft_algebra_batch(RowMajorMatrix::new(scaled, 2 * num_cosets))
-        .values;
+    let transformed = eval_low_degree_on_coset(dft, [first, second], shift, log_size, log_len);
 
     // Transform row `b` holds the evaluations at `i = a + num_cosets * b` for every `a`, i.e.
     // the natural-order block `[num_cosets * b, num_cosets * (b + 1))`.
@@ -1440,7 +1453,8 @@ where
 }
 
 /// Evaluate a polynomial (coefficients in `EF`) on a coset `shift * <g>` of size
-/// `2^log_size`, returning the codeword in **natural order**.
+/// `2^log_size`, returning the codeword in **natural order**. Coefficients beyond the domain
+/// size are truncated; shorter inputs are implicitly padded with zeros.
 pub fn codeword_from_coeffs<F, EF, Dft>(
     dft: &Dft,
     coeffs: Vec<EF>,
@@ -1452,7 +1466,12 @@ where
     EF: ExtensionField<F> + BasedVectorSpace<F>,
     Dft: TwoAdicSubgroupDft<F>,
 {
-    let size = 1 << log_size;
+    let size = 1usize << log_size;
+    let log_len = log2_ceil_usize(coeffs.len().min(size).max(1));
+    // At low expansion ratios the full DFT avoids the cost of scaling a wide batch.
+    if log_size - log_len >= 3 {
+        return eval_low_degree_on_coset(dft, [&coeffs], shift, log_size, log_len);
+    }
     let mut padded = coeffs;
     padded.resize(size, EF::ZERO);
 

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -1,5 +1,6 @@
 //! STIR verifier implementation (Construction 5.2).
 
+use alloc::borrow::Cow;
 use alloc::vec::Vec;
 
 use itertools::izip;
@@ -14,7 +15,7 @@ use crate::config::{StirConfig, StirRoundConfig};
 use crate::error::{ExternalSourceError, GrindStage, ProofShapeError, RoundLabel, StirError};
 use crate::proof::{StirProof, StirQueryOpenings, StirRoundProof};
 use crate::utils::{
-    check_ans_interpolates, eval_poly, eval_poly_at_base, fold_domain_params,
+    check_ans_interpolates, eval_poly, eval_poly_at_base, fold_domain_params, interpolate_poly,
     lagrange_interpolate_at, next_domain_shift, reduce_mod_x_pow_minus_c, sample_ood_points,
     vanishing_poly_from_roots,
 };
@@ -147,6 +148,86 @@ fn check_ans_length<EF, MmcsError, InputError>(
         .into());
     }
     Ok(())
+}
+
+/// Resolve the explicitly configured encoding before the original transcript observation.
+/// Reconstruction uses the prover's canonical representation, including `[ZERO]` for a
+/// zero interpolant through a nonempty set of points.
+fn resolve_ans_polynomial<'a, EF: Field, MmcsError, InputError>(
+    round: RoundLabel,
+    compact: bool,
+    transmitted: &'a [EF],
+    points: &[EF],
+    values: &[EF],
+) -> Result<Cow<'a, [EF]>, StirError<MmcsError, InputError>> {
+    if !compact {
+        check_ans_length(round, transmitted, points.len())?;
+        return Ok(Cow::Borrowed(transmitted));
+    }
+    if !transmitted.is_empty() {
+        return Err(ProofShapeError::UnexpectedAnsPolynomial {
+            round,
+            got: transmitted.len(),
+        }
+        .into());
+    }
+    // interpolate_poly asserts these preconditions. Keep malformed inputs fallible here.
+    if points.len() != values.len()
+        || points
+            .iter()
+            .enumerate()
+            .any(|(i, point)| points[..i].contains(point))
+    {
+        return Err(StirError::InvalidAnsConsistency { round });
+    }
+    Ok(Cow::Owned(interpolate_poly(points, values)))
+}
+
+#[cfg(test)]
+mod compact_answer_tests {
+    use p3_baby_bear::BabyBear as F;
+    use p3_field::PrimeCharacteristicRing;
+
+    use super::*;
+
+    #[test]
+    fn compact_answers_reconstruct_canonical_zero_and_reject_invalid_nodes() {
+        let round = RoundLabel::Round(2);
+        assert!(
+            resolve_ans_polynomial::<F, (), ()>(round, true, &[], &[], &[])
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(
+            resolve_ans_polynomial::<F, (), ()>(round, true, &[], &[F::ONE], &[F::ZERO])
+                .unwrap()
+                .as_ref(),
+            &[F::ZERO]
+        );
+        for (points, values) in [
+            (&[F::ONE][..], &[][..]),
+            (&[F::ONE, F::ONE][..], &[F::ZERO, F::ZERO][..]),
+        ] {
+            assert!(matches!(
+                resolve_ans_polynomial::<F, (), ()>(round, true, &[], points, values),
+                Err(StirError::InvalidAnsConsistency {
+                    round: RoundLabel::Round(2)
+                })
+            ));
+        }
+        // The default representation still borrows the provided coefficients verbatim.
+        assert!(matches!(
+            resolve_ans_polynomial::<F, (), ()>(
+                round,
+                false,
+                &[F::ZERO, F::ZERO],
+                &[F::ZERO, F::ONE],
+                &[F::ZERO, F::ZERO]
+            )
+            .unwrap(),
+            Cow::Borrowed([F::ZERO, F::ZERO])
+        ));
+    }
 }
 
 /// Fetch an external initial oracle's queried fibers and lay them out in draw order.
@@ -613,24 +694,27 @@ where
     // Step 4: ans polynomial observation and consistency check.
     let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
-    // Ans interpolates |all_points| values, bounding its length. That bound is what makes the
-    // one-point check below bind.
-    let max_ans_len = all_points.len();
-    check_ans_length(RoundLabel::Round(round), &rp.ans_polynomial, max_ans_len)?;
+    let ans = resolve_ans_polynomial(
+        RoundLabel::Round(round),
+        config.options().compact_answers,
+        &rp.ans_polynomial,
+        &all_points,
+        &all_values,
+    )?;
 
     // Bind ans_poly into the transcript BEFORE rho. The interpolation identity is a one-point
     // check; observing Ans first means the prover commits to it before learning rho.
-    challenger.observe_algebra_slice(&rp.ans_polynomial);
+    challenger.observe_algebra_slice(&ans);
 
     let rho: EF = challenger.sample_algebra_element();
 
-    if !check_ans_interpolates(&rp.ans_polynomial, &all_points, &all_values, rho) {
+    if !check_ans_interpolates(&ans, &all_points, &all_values, rho) {
         return Err(StirError::InvalidAnsConsistency {
             round: RoundLabel::Round(round),
         });
     }
 
-    Ok(rv.finish(rp.ans_polynomial.clone(), &all_points))
+    Ok(rv.finish(ans.into_owned(), &all_points))
 }
 
 /// One instance's in-flight final round, advanced in the order the transcript demands.
@@ -1306,19 +1390,24 @@ where
             let rp = &proofs[i].round_proofs[local_r];
             let (all_points, all_values) = rv.all_points_and_values(&rp.ood_answers);
 
-            let max_ans_len = all_points.len();
-            check_ans_length(RoundLabel::Round(local_r), &rp.ans_polynomial, max_ans_len)?;
+            let ans = resolve_ans_polynomial(
+                RoundLabel::Round(local_r),
+                configs[i].options().compact_answers,
+                &rp.ans_polynomial,
+                &all_points,
+                &all_values,
+            )?;
 
-            challenger.observe_algebra_slice(&rp.ans_polynomial);
+            challenger.observe_algebra_slice(&ans);
             let rho: EF = challenger.sample_algebra_element();
 
-            if !check_ans_interpolates(&rp.ans_polynomial, &all_points, &all_values, rho) {
+            if !check_ans_interpolates(&ans, &all_points, &all_values, rho) {
                 return Err(StirError::InvalidAnsConsistency {
                     round: RoundLabel::Round(local_r),
                 });
             }
 
-            finishes.push((i, rv.finish(rp.ans_polynomial.clone(), &all_points)));
+            finishes.push((i, rv.finish(ans.into_owned(), &all_points)));
         }
 
         // Phase 5: touches no transcript state, so instance order no longer matters.

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -183,6 +183,7 @@ mod babybear_stir {
                 params,
                 StirOptions {
                     max_log_final_poly_len: Some(cap),
+                    ..Default::default()
                 },
             );
             let mut rng = seeded_rng();
@@ -212,6 +213,7 @@ mod babybear_stir {
             params,
             StirOptions {
                 max_log_final_poly_len: Some(6),
+                ..Default::default()
             },
         );
         let mut rng = seeded_rng();
@@ -224,6 +226,106 @@ mod babybear_stir {
             postcard::to_allocvec(&early_proof).unwrap().len()
                 < postcard::to_allocvec(&full_proof).unwrap().len()
         );
+    }
+
+    #[test]
+    fn compact_answers_preserve_proofs_and_transcripts() {
+        for (degree, kind, cap) in [
+            (8, 0, None),
+            (8, 1, None),
+            (8, 2, None),
+            (3, 0, None),
+            (10, 0, Some(6)),
+        ] {
+            let (params, dft, challenger) = make_params(1, 2);
+            let options = StirOptions {
+                max_log_final_poly_len: cap,
+                ..Default::default()
+            };
+            let full = StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+                degree,
+                params.clone(),
+                options,
+            );
+            let compact = StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+                degree,
+                params,
+                StirOptions {
+                    compact_answers: true,
+                    ..options
+                },
+            );
+            let mut rng = seeded_rng();
+            let mut poly: Vec<EF> = (0..1 << degree).map(|_| rng.random()).collect();
+            if kind != 0 {
+                poly.fill(EF::ZERO);
+                if kind == 2 {
+                    poly[0] = EF::from_u64(7);
+                }
+            }
+            let mut full_p = challenger.clone();
+            let mut compact_p = challenger.clone();
+            let (full_proof, full_queries) = prove_stir(&full, poly.clone(), &dft, &mut full_p);
+            let (compact_proof, compact_queries) = prove_stir(&compact, poly, &dft, &mut compact_p);
+            assert_eq!(full_queries, compact_queries);
+            let mut full_v = challenger.clone();
+            let mut compact_v = challenger.clone();
+            verify_stir(&full, &full_proof, &mut full_v).unwrap();
+            verify_stir(&compact, &compact_proof, &mut compact_v).unwrap();
+            let next: EF = full_p.sample_algebra_element();
+            assert_eq!(next, compact_p.sample_algebra_element::<EF>());
+            assert_eq!(next, full_v.sample_algebra_element::<EF>());
+            assert_eq!(next, compact_v.sample_algebra_element::<EF>());
+
+            if kind == 1 {
+                assert!(
+                    full_proof
+                        .round_proofs
+                        .iter()
+                        .all(|r| r.ans_polynomial == [EF::ZERO])
+                );
+            }
+            let mut omitted = full_proof.clone();
+            for round in &mut omitted.round_proofs {
+                round.ans_polynomial.clear();
+            }
+            let full_bytes = postcard::to_allocvec(&full_proof).unwrap();
+            let compact_bytes = postcard::to_allocvec(&compact_proof).unwrap();
+            assert_eq!(compact_bytes, postcard::to_allocvec(&omitted).unwrap());
+            if compact.num_rounds() == 0 {
+                assert_eq!(compact_bytes, full_bytes);
+                continue;
+            }
+            assert!(compact_bytes.len() < full_bytes.len());
+            for coefficients in [
+                full_proof.round_proofs[0].ans_polynomial.clone(),
+                vec![EF::ONE],
+            ] {
+                let mut bad = compact_proof.clone();
+                let got = coefficients.len();
+                bad.round_proofs[0].ans_polynomial = coefficients;
+                let err = verify_stir(&compact, &bad, &mut challenger.clone()).unwrap_err();
+                assert_eq!(
+                    shape_of(err),
+                    ProofShapeError::UnexpectedAnsPolynomial {
+                        round: RoundLabel::Round(0),
+                        got
+                    }
+                );
+            }
+            if degree == 8 && kind == 0 {
+                let mut bad = compact_proof.clone();
+                bad.round_proofs[0].ood_answers[0] += EF::ONE;
+                assert!(verify_stir(&compact, &bad, &mut challenger.clone()).is_err());
+                let mut bad = compact_proof;
+                bad.round_proofs[0]
+                    .query_openings
+                    .as_mut()
+                    .unwrap()
+                    .row_evals[0][0] += EF::ONE;
+                assert!(verify_stir(&compact, &bad, &mut challenger.clone()).is_err());
+            }
+        }
     }
 
     #[test]
@@ -3470,6 +3572,7 @@ mod babybear_stir_multi {
                     params.clone(),
                     StirOptions {
                         max_log_final_poly_len: cap,
+                        ..Default::default()
                     },
                 )
             })
@@ -3535,6 +3638,148 @@ mod babybear_stir_multi {
         for ((_, first), output) in results.iter().zip(outputs) {
             assert_eq!(first.draws, output.first_round_draws);
             assert_eq!(first.unique_sorted, output.first_round_indices);
+        }
+    }
+
+    #[test]
+    fn compact_answers_support_mixed_configs_and_external_oracles() {
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        let full_configs: Vec<_> = [(10, None), (8, Some(4)), (6, Some(usize::MAX))]
+            .into_iter()
+            .map(|(degree, cap)| {
+                StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+                    degree,
+                    params.clone(),
+                    StirOptions {
+                        max_log_final_poly_len: cap,
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect();
+        let configs: Vec<_> = full_configs
+            .iter()
+            .zip([true, false, true])
+            .map(|(full, compact_answers)| {
+                StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+                    full.log_starting_degree,
+                    params.clone(),
+                    StirOptions {
+                        compact_answers,
+                        ..full.options()
+                    },
+                )
+            })
+            .collect();
+        let full_refs: Vec<_> = full_configs.iter().collect();
+        let config_refs: Vec<_> = configs.iter().collect();
+        let mut rng = seeded_rng();
+        let polys: Vec<Vec<EF>> = configs
+            .iter()
+            .map(|config| {
+                (0..1 << config.log_starting_degree)
+                    .map(|_| rng.random())
+                    .collect()
+            })
+            .collect();
+        let codewords: Vec<_> = configs
+            .iter()
+            .zip(&polys)
+            .map(|(config, poly)| {
+                codeword_from_coeffs(
+                    &dft,
+                    poly.clone(),
+                    F::GENERATOR,
+                    config.log_starting_domain_size(),
+                )
+            })
+            .collect();
+
+        for external in [false, true] {
+            let mut base = challenger.clone();
+            if external {
+                for codeword in &codewords {
+                    base.observe_algebra_slice(codeword);
+                }
+            }
+            let prove = |refs: &[&StirConfig<F, EF, MyMmcs, Challenger>], ch: &mut Challenger| {
+                if external {
+                    prove_stir_multi_from_external_codewords(refs, codewords.clone(), &dft, ch)
+                } else {
+                    prove_stir_multi(refs, polys.clone(), &dft, ch)
+                }
+            };
+            let verify = |refs: &[&StirConfig<F, EF, MyMmcs, Challenger>],
+                          proofs: &[&StirProof<EF, MyMmcs, F>],
+                          ch: &mut Challenger| {
+                if external {
+                    let sources: Vec<_> = configs
+                        .iter()
+                        .zip(&codewords)
+                        .map(|(config, codeword)| {
+                            let arity = 1 << config.log_starting_folding_factor;
+                            external_fiber_source(codeword.clone(), arity, codeword.len() / arity)
+                        })
+                        .collect();
+                    verify_stir_multi_with_external_initial::<F, EF, MyMmcs, Challenger, (), _>(
+                        refs, proofs, ch, sources,
+                    )
+                } else {
+                    verify_stir_multi(refs, proofs, ch)
+                }
+            };
+            let mut full_p = base.clone();
+            let mut compact_p = base.clone();
+            let full = prove(&full_refs, &mut full_p);
+            let mixed = prove(&config_refs, &mut compact_p);
+            let mut full_v = base.clone();
+            let mut compact_v = base.clone();
+            let full_outputs = verify(
+                &full_refs,
+                &full.iter().map(|(p, _)| p).collect::<Vec<_>>(),
+                &mut full_v,
+            )
+            .unwrap();
+            let mixed_outputs = verify(
+                &config_refs,
+                &mixed.iter().map(|(p, _)| p).collect::<Vec<_>>(),
+                &mut compact_v,
+            )
+            .unwrap();
+            let next: EF = full_p.sample_algebra_element();
+            assert_eq!(next, compact_p.sample_algebra_element::<EF>());
+            assert_eq!(next, full_v.sample_algebra_element::<EF>());
+            assert_eq!(next, compact_v.sample_algebra_element::<EF>());
+            for (i, ((full_proof, full_queries), (mixed_proof, mixed_queries))) in
+                full.iter().zip(&mixed).enumerate()
+            {
+                assert_eq!(full_queries, mixed_queries);
+                assert_eq!(
+                    full_outputs[i].first_round_draws,
+                    mixed_outputs[i].first_round_draws
+                );
+                assert_eq!(mixed_queries.draws, mixed_outputs[i].first_round_draws);
+                let mut expected = full_proof.clone();
+                if configs[i].options().compact_answers {
+                    for round in &mut expected.round_proofs {
+                        round.ans_polynomial.clear();
+                    }
+                }
+                assert_eq!(
+                    postcard::to_allocvec(&expected).unwrap(),
+                    postcard::to_allocvec(mixed_proof).unwrap()
+                );
+            }
+            let mut bad: Vec<_> = mixed.into_iter().map(|(proof, _)| proof).collect();
+            bad[0].round_proofs[1].ans_polynomial = vec![EF::ONE];
+            let err = verify(&config_refs, &bad.iter().collect::<Vec<_>>(), &mut base).unwrap_err();
+            assert_eq!(
+                shape_of(err),
+                ProofShapeError::UnexpectedAnsPolynomial {
+                    round: RoundLabel::Round(1),
+                    got: 1
+                }
+            );
         }
     }
 

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -15,7 +15,7 @@ use p3_field::extension::BinomialExtensionField;
 use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_stir::config::{StirConfig, StirParameters};
+use p3_stir::config::{StirConfig, StirOptions, StirParameters};
 use p3_stir::proof::StirProof;
 use p3_stir::prover::{codeword_from_coeffs, prove_stir, prove_stir_from_external_codeword};
 use p3_stir::verifier::{verify_stir, verify_stir_with_external_initial};
@@ -166,6 +166,64 @@ mod babybear_stir {
     fn test_prove_verify_blowup1_fold2_degree8() {
         let (params, dft, challenger) = make_params(1, 2);
         do_test_stir_prove_verify::<F, EF, _, _, _>(&params, &dft, &challenger, 8);
+    }
+
+    #[test]
+    fn early_stop_roundtrips_and_checks_final_coefficients() {
+        for (degree, starting_fold, cap, rounds, final_log) in [
+            (12, 2, 6, 2, 6),
+            (10, 3, 3, 2, 3),
+            (10, 3, 5, 1, 5),
+            (10, 3, usize::MAX, 0, 7),
+        ] {
+            let (mut params, dft, challenger) = make_params(1, 2);
+            params.log_starting_folding_factor = starting_fold;
+            let config = StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+                degree,
+                params,
+                StirOptions {
+                    max_log_final_poly_len: Some(cap),
+                },
+            );
+            let mut rng = seeded_rng();
+            let poly: Vec<EF> = (0..1usize << degree).map(|_| rng.random()).collect();
+            let mut p_ch = challenger.clone();
+            let (mut proof, _) = prove_stir(&config, poly, &dft, &mut p_ch);
+            assert_eq!(proof.round_proofs.len(), rounds);
+            assert_eq!(proof.final_polynomial.len(), 1 << final_log);
+            let mut v_ch = challenger.clone();
+            verify_stir(&config, &proof, &mut v_ch).unwrap();
+            assert_eq!(
+                p_ch.sample_algebra_element::<EF>(),
+                v_ch.sample_algebra_element::<EF>()
+            );
+
+            *proof.final_polynomial.last_mut().unwrap() += EF::ONE;
+            assert!(verify_stir(&config, &proof, &mut challenger.clone()).is_err());
+        }
+    }
+
+    #[test]
+    fn early_stop_reduces_serialized_proof_size() {
+        let (params, dft, mut challenger) = make_params_full(1, 2, 80, 0);
+        let full = StirConfig::<F, EF, MyMmcs, Challenger>::new(14, params.clone());
+        let early = StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+            14,
+            params,
+            StirOptions {
+                max_log_final_poly_len: Some(6),
+            },
+        );
+        let mut rng = seeded_rng();
+        let poly: Vec<EF> = (0..1 << 14).map(|_| rng.random()).collect();
+        let (full_proof, _) = prove_stir(&full, poly.clone(), &dft, &mut challenger.clone());
+        let (early_proof, _) = prove_stir(&early, poly, &dft, &mut challenger.clone());
+        verify_stir(&full, &full_proof, &mut challenger.clone()).unwrap();
+        verify_stir(&early, &early_proof, &mut challenger).unwrap();
+        assert!(
+            postcard::to_allocvec(&early_proof).unwrap().len()
+                < postcard::to_allocvec(&full_proof).unwrap().len()
+        );
     }
 
     #[test]
@@ -3397,6 +3455,86 @@ mod babybear_stir_multi {
                 .iter()
                 .map(|&j| (0..arity).map(|l| codeword[j + l * fold_height]).collect())
                 .collect())
+        }
+    }
+
+    #[test]
+    fn early_stop_mixed_schedules_verify_with_committed_and_external_oracles() {
+        let (mut params, dft, challenger) = make_params(1, 2, 16, 0);
+        params.log_starting_folding_factor = 3;
+        let configs: Vec<_> = [(8, Some(4)), (6, Some(usize::MAX))]
+            .into_iter()
+            .map(|(degree, cap)| {
+                StirConfig::<F, EF, MyMmcs, Challenger>::new_with_options(
+                    degree,
+                    params.clone(),
+                    StirOptions {
+                        max_log_final_poly_len: cap,
+                    },
+                )
+            })
+            .collect();
+        let config_refs: Vec<_> = configs.iter().collect();
+        assert_eq!(
+            configs.iter().map(|c| c.num_rounds()).collect::<Vec<_>>(),
+            vec![1, 0]
+        );
+        let mut rng = seeded_rng();
+        let polys: Vec<Vec<EF>> = [8, 6]
+            .map(|degree| (0..1 << degree).map(|_| rng.random()).collect())
+            .into();
+        let mut p_ch = challenger.clone();
+        let results = prove_stir_multi(&config_refs, polys.clone(), &dft, &mut p_ch);
+        let proofs: Vec<_> = results.iter().map(|(proof, _)| proof).collect();
+        let mut v_ch = challenger.clone();
+        verify_stir_multi(&config_refs, &proofs, &mut v_ch).unwrap();
+        assert_eq!(
+            p_ch.sample_algebra_element::<EF>(),
+            v_ch.sample_algebra_element::<EF>()
+        );
+
+        let codewords: Vec<_> = configs
+            .iter()
+            .zip(polys)
+            .map(|(config, poly)| {
+                codeword_from_coeffs(&dft, poly, F::GENERATOR, config.log_starting_domain_size())
+            })
+            .collect();
+        let mut base = challenger;
+        for codeword in &codewords {
+            base.observe_algebra_slice(codeword);
+        }
+        let mut p_ch = base.clone();
+        let results = prove_stir_multi_from_external_codewords(
+            &config_refs,
+            codewords.clone(),
+            &dft,
+            &mut p_ch,
+        );
+        let proofs: Vec<_> = results.iter().map(|(proof, _)| proof).collect();
+        let sources: Vec<_> = configs
+            .iter()
+            .zip(codewords)
+            .map(|(config, codeword)| {
+                let arity = 1 << config.log_starting_folding_factor;
+                let height = codeword.len() / arity;
+                external_fiber_source(codeword, arity, height)
+            })
+            .collect();
+        let outputs = verify_stir_multi_with_external_initial::<F, EF, MyMmcs, Challenger, (), _>(
+            &config_refs,
+            &proofs,
+            &mut base,
+            sources,
+        )
+        .unwrap();
+        assert_eq!(
+            p_ch.sample_algebra_element::<EF>(),
+            base.sample_algebra_element::<EF>()
+        );
+        for ((_, first), output) in results.iter().zip(outputs) {
+            assert_eq!(first.draws, output.first_round_draws);
+            assert_eq!(first.unique_sorted, output.first_round_indices);
         }
     }
 

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -1352,6 +1352,49 @@ mod babybear_pcs {
         assert_eq!(evals, expected);
     }
 
+    /// The general `get_evaluations_on_domain` path must interpolate the committed polynomial
+    /// before changing cosets. Exercise both a native-size target and a target taller than the
+    /// committed LDE so neither can use the borrowed `GENERATOR`-shift prefix.
+    #[test]
+    fn get_evaluations_on_changed_shift_matches_direct_evaluation() {
+        use p3_field::coset::TwoAdicMultiplicativeCoset;
+        use p3_matrix::Matrix;
+
+        let (pcs, _) = get_pcs();
+        let mut rng = seeded_rng();
+
+        let log_d = 4;
+        let d = 1usize << log_d;
+        let width = 3;
+        let trace = RowMajorMatrix::<Val>::rand(&mut rng, d, width);
+        let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d);
+        let (_, data) =
+            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(domain, trace.clone())]);
+
+        let dft = Dft::default();
+        let native_coeffs = dft.idft_batch(trace);
+        for log_target in [log_d, log_d + 2] {
+            let target = TwoAdicMultiplicativeCoset::new(Val::from_u64(7), log_target).unwrap();
+            let actual = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
+                &pcs, &data, 0, target,
+            )
+            .to_row_major_matrix();
+
+            let mut padded_coeffs = native_coeffs.clone();
+            padded_coeffs
+                .values
+                .resize(target.size() * width, Val::ZERO);
+            let expected = dft
+                .coset_dft_batch(padded_coeffs, target.shift())
+                .to_row_major_matrix();
+
+            assert_eq!(
+                actual, expected,
+                "changed-shift evaluation disagrees at log_target={log_target}"
+            );
+        }
+    }
+
     /// Commit `log_degrees`, with `widths[i]` columns in matrix `i`, open every matrix at one
     /// shared point, and verify.
     ///

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -24,6 +24,46 @@ fn ef(n: u64) -> EF {
     EF::from(f(n))
 }
 
+#[test]
+fn test_codeword_from_coeffs_matches_horner_across_shapes() {
+    use p3_field::TwoAdicField;
+
+    let dft = Radix2DitParallel::<F>::default();
+    let mut rng = SmallRng::seed_from_u64(0xdecaf);
+    for log_size in [0usize, 1, 4, 8] {
+        let size = 1usize << log_size;
+        // Cover empty/constant inputs, ragged lengths, both sides of the degree-aware
+        // crossover, a full domain, and truncation of coefficients beyond the domain.
+        for len in [
+            0,
+            1,
+            2,
+            3,
+            size / 16,
+            size / 8,
+            size / 8 + 1,
+            size,
+            size + 3,
+        ] {
+            let coeffs: Vec<EF> = (0..len).map(|_| rng.random()).collect();
+            for shift in [F::ZERO, F::ONE, F::GENERATOR, f(7)] {
+                let actual = codeword_from_coeffs(&dft, coeffs.clone(), shift, log_size);
+                assert_eq!(actual.len(), size);
+                let mut point = shift;
+                let generator = F::two_adic_generator(log_size);
+                for (i, value) in actual.into_iter().enumerate() {
+                    let expected = coeffs[..len.min(size)]
+                        .iter()
+                        .rev()
+                        .fold(EF::ZERO, |acc, &coeff| acc * point + coeff);
+                    assert_eq!(value, expected, "log_size={log_size}, len={len}, i={i}");
+                    point *= generator;
+                }
+            }
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // eval_poly
 // ---------------------------------------------------------------------------

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -397,6 +397,43 @@ fn test_fold_poly_coeffs_agrees_with_the_evaluation_form_fold() {
     }
 }
 
+#[test]
+fn test_folded_coeffs_recover_from_degree_sized_subcosets() {
+    let log_degree = 6;
+    let degree = 1usize << log_degree;
+    let dft = Radix2DitParallel::<F>::default();
+    let shift = f(7);
+    let gamma = ef(31);
+    let native_coeffs: Vec<EF> = (1..=degree).map(|i| ef(i as u64)).collect();
+
+    // Vary both the LDE blowup and fold arity, including distinct k0/k-style arities. The
+    // expected coefficients come from the independent coefficient-form fold.
+    for log_blowup in [0usize, 1, 2] {
+        let log_domain = log_degree + log_blowup;
+        let mut domain_coeffs = native_coeffs.clone();
+        domain_coeffs.resize(1usize << log_domain, EF::ZERO);
+        let codeword = codeword_from_coeffs(&dft, domain_coeffs, shift, log_domain);
+
+        for log_arity in [1usize, 2, 3] {
+            let beta = gamma * EF::from(shift.inverse());
+            let folded = fold_codeword::<F, EF>(&codeword, beta, log_arity, log_domain);
+            let folded_degree_bound = degree >> log_arity;
+            let stride = folded.len() / folded_degree_bound;
+            let subcoset: Vec<EF> = (0..folded_degree_bound)
+                .map(|i| folded[i * stride])
+                .collect();
+            let fold_shift = shift.exp_power_of_2(log_arity);
+
+            assert_eq!(
+                coeffs_from_codeword(&dft, &subcoset, fold_shift),
+                fold_poly_coeffs(&native_coeffs, gamma, log_arity),
+                "subcoset recovery disagrees at log_blowup={log_blowup}, \
+                 log_arity={log_arity}"
+            );
+        }
+    }
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(64))]
 


### PR DESCRIPTION
STIR currently interpolates some polynomials on oversized domains and evaluates known-zero coefficient tails. This reduces that work and adds two opt-in proof-size tradeoffs. Default options preserve the existing schedule and serialized proof bytes in the measured cases.

## Changes

Each optimization is a separate commit:

1. Size adjusted interpolation weights to the largest native matrix height needed at each opening point.
2. Recover coefficients with native-size inverse DFTs in folded rounds and PCS evaluation/LDE-extension paths.
3. Use degree-aware codeword transforms at expansion ratios of at least 8x, sharing the existing batched transform implementation.
4. Add optional early stopping via `StirOptions::max_log_final_poly_len`; derive the complete schedule for the selected final coefficient bound.
5. Add optional compact answers via `StirOptions::compact_answers`; omit answer coefficients from the proof and reconstruct them in the verifier at the same transcript position.

The options are exposed through `StirConfig` constructors and `TwoAdicStirPcs::with_options`. Prover and verifier must agree on them. Changing PCS options resets the configuration cache without changing previously configured clones.

## Measured against main

Baseline: `7230fc572870436e6651762f35c6c3f3f48960d2` (`origin/main`, freshly verified before opening this PR). Branch: `50e198d44316553df43fcd92f779e2e03751565e`.

Apple M4 Pro (14 cores, 48 GiB), macOS 26.6, Rust 1.98.0. Both revisions used the identical measurement harness and lockfile, `--profile optimized`, `RUSTFLAGS="-C target-cpu=native"`, thin LTO, one codegen unit and incremental compilation disabled. Serial and `parallel` builds were separate; parallel runs used `RAYON_NUM_THREADS=4`.

KoalaBear quintic extension, CapacityBound, 100-bit configuration, 2x starting blowup, PoW disabled and fixed seed `0xdeadbeef`. Standalone proving includes initial codeword evaluation/commitment and the full STIR proof. Setup/input cloning, output destruction, serialization and correctness checks are outside the timers; configuration and transform caches are warm.

Six paired process blocks alternate main/branch and branch/main. Each API has two warmups and five measurements per block (50 for verification). Times below are geometric means of block medians; changes use paired ratios. Intervals are descriptive 95% bootstraps over blocks, not individual calls. Negative means faster.

| Workload | Threads | main ms | Branch ms | Time change [95% interval] |
|---|---:|---:|---:|---:|
| STIR 2^18, arity 4 | Serial | 219.49 | 207.23 | -5.6% [-6.7%, -4.7%] |
| STIR 2^18, arity 8 | Serial | 188.11 | 178.59 | -5.1% [-7.5%, -1.5%] |
| STIR 2^20, arity 4 | Serial | 909.59 | 895.72 | -1.5% [-7.3%, +7.4%] — inconclusive |
| STIR 2^18, arity 4 | 4 | 77.07 | 77.50 | +0.6% [-3.0%, +4.2%] — inconclusive |
| STIR 2^18, arity 8 | 4 | 61.84 | 59.43 | -3.9% [-4.9%, -2.9%] |
| STIR 2^20, arity 4 | 4 | 316.49 | 301.54 | -4.7% [-6.8%, -2.7%] |

### Proof size

`final64` sets `max_log_final_poly_len=Some(6)`; `compact` sets `compact_answers=true`. Sizes are serialized Postcard bytes and agree between serial and parallel builds.

| Workload | main / branch default | final64 | compact | Both | Both vs main |
|---|---:|---:|---:|---:|---:|
| STIR 2^18, arity 4 | 114,015 | 103,851 | 108,155 | 98,731 | -13.41% |
| STIR 2^18, arity 8 | 91,556 | 83,313 | 87,616 | 79,913 | -12.72% |
| Merged PCS | 159,233 | 148,813 | 153,373 | 143,693 | -9.76% |

Compact answers alone increase verifier time by 11.5% (arity 4) and 11.8% (arity 8) in the four-thread builds, relative to branch/default. Early stopping alone reduces verifier time by about 9% in those builds. Optional-mode timings use four separate paired blocks with refreshed branch/default controls; they are not comparisons against main.

<details>
<summary>PCS opening timings and targeted entry points</summary>

All PCS matrices have width four. Uniform uses log2 height [18]; merged uses [18,17,16] with spread cap 2; separate domains uses [18,15,12] with spread cap 0. Ordinary cases share one opening point; distinct-points uses the merged layout with a separate point per matrix. Opening starts from an existing commitment.

| Workload | Threads | main ms | Branch ms | Time change [95% interval] |
|---|---:|---:|---:|---:|
| PCS distinct points | 4 | 91.08 | 91.02 | -0.1% [-3.2%, +2.9%] — inconclusive |
| PCS merged | 4 | 93.55 | 90.45 | -3.3% [-7.1%, -0.1%] |
| PCS separate domains | 4 | 95.26 | 104.21 | +9.4% [-0.6%, +19.0%] — inconclusive |
| PCS uniform | 4 | 81.40 | 79.78 | -2.0% [-4.8%, +2.4%] — inconclusive |
| PCS distinct points | Serial | 310.74 | 282.12 | -9.2% [-21.6%, -1.1%] |
| PCS merged | Serial | 275.87 | 247.74 | -10.2% [-18.1%, -3.1%] |
| PCS separate domains | Serial | 244.66 | 234.46 | -4.2% [-4.8%, -3.7%] |
| PCS uniform | Serial | 267.78 | 247.65 | -7.5% [-13.2%, -3.3%] |

Codeword cases evaluate on a size-2^18 domain with 2^15 or 2^12 coefficients. `commit_ldes` extends precomputed native 2x LDEs for heights [18,17,16] onto the tallest merged domain; preparation is untimed. Changed-shift evaluation recovers the height-2^16 matrix from that merged domain and evaluates it on a size-2^16 coset shifted by `GENERATOR^2`.

| Workload | Threads | main ms | Branch ms | Time change [95% interval] |
|---|---:|---:|---:|---:|
| Codeword, 64x expansion | 4 | 2.91 | 1.13 | -61.4% [-64.1%, -58.0%] |
| Codeword, 8x expansion | 4 | 2.59 | 1.70 | -34.3% [-35.6%, -33.1%] |
| PCS changed-shift evaluation | 4 | 6.56 | 1.20 | -81.7% [-82.7%, -80.0%] |
| PCS commit_ldes | 4 | 70.12 | 70.85 | +1.0% [-4.4%, +11.3%] — inconclusive |
| Codeword, 64x expansion | Serial | 8.51 | 3.14 | -63.1% [-65.9%, -59.3%] |
| Codeword, 8x expansion | Serial | 8.77 | 5.24 | -40.2% [-41.7%, -38.8%] |
| PCS changed-shift evaluation | Serial | 22.91 | 3.12 | -86.4% [-86.8%, -86.0%] |
| PCS commit_ldes | Serial | 270.24 | 265.60 | -1.7% [-6.6%, +7.3%] — inconclusive |

</details>

<details>
<summary>Optional-mode prover and verifier timings versus branch/default</summary>

Each option has four paired blocks, with a refreshed default in every block and rotated/reversed option order. PCS options were measured for verified proof bytes only.

| Workload | Threads | Option | Branch/default ms | Branch ms | Time change [95% interval] |
|---|---:|---|---:|---:|---:|
| STIR 2^18, arity 4 / prove | 4 | both | 76.66 | 81.74 | +6.6% [-4.4%, +30.0%] — inconclusive |
| STIR 2^18, arity 4 / verify | 4 | both | 2.70 | 2.93 | +8.7% [-0.3%, +26.7%] — inconclusive |
| STIR 2^18, arity 4 / prove | 4 | compact | 76.66 | 74.33 | -3.0% [-6.0%, -0.0%] |
| STIR 2^18, arity 4 / verify | 4 | compact | 2.70 | 3.01 | +11.5% [+10.7%, +13.0%] |
| STIR 2^18, arity 4 / prove | 4 | final64 | 76.66 | 72.64 | -5.3% [-9.5%, -2.9%] |
| STIR 2^18, arity 4 / verify | 4 | final64 | 2.70 | 2.46 | -9.0% [-10.1%, -8.0%] |
| STIR 2^18, arity 8 / prove | 4 | both | 55.70 | 53.41 | -4.1% [-6.5%, -1.7%] |
| STIR 2^18, arity 8 / verify | 4 | both | 2.03 | 2.03 | -0.0% [-2.0%, +2.0%] — inconclusive |
| STIR 2^18, arity 8 / prove | 4 | compact | 55.70 | 55.86 | +0.3% [-1.1%, +1.6%] — inconclusive |
| STIR 2^18, arity 8 / verify | 4 | compact | 2.03 | 2.27 | +11.8% [+9.4%, +15.3%] |
| STIR 2^18, arity 8 / prove | 4 | final64 | 55.70 | 53.78 | -3.4% [-9.4%, +3.1%] — inconclusive |
| STIR 2^18, arity 8 / verify | 4 | final64 | 2.03 | 1.85 | -9.1% [-10.2%, -8.4%] |
| STIR 2^18, arity 4 / prove | Serial | both | 276.12 | 280.34 | +1.5% [-0.9%, +5.3%] — inconclusive |
| STIR 2^18, arity 4 / verify | Serial | both | 2.88 | 3.09 | +7.3% [-0.9%, +24.1%] — inconclusive |
| STIR 2^18, arity 4 / prove | Serial | compact | 276.12 | 294.03 | +6.5% [-3.5%, +23.2%] — inconclusive |
| STIR 2^18, arity 4 / verify | Serial | compact | 2.88 | 3.32 | +15.5% [+6.9%, +29.5%] |
| STIR 2^18, arity 4 / prove | Serial | final64 | 276.12 | 256.45 | -7.1% [-19.3%, +0.3%] — inconclusive |
| STIR 2^18, arity 4 / verify | Serial | final64 | 2.88 | 2.49 | -13.4% [-16.9%, -10.1%] |
| STIR 2^18, arity 8 / prove | Serial | both | 218.75 | 209.41 | -4.3% [-18.1%, +12.9%] — inconclusive |
| STIR 2^18, arity 8 / verify | Serial | both | 2.30 | 2.61 | +13.6% [+0.3%, +42.7%] |
| STIR 2^18, arity 8 / prove | Serial | compact | 218.75 | 213.18 | -2.5% [-12.8%, +7.5%] — inconclusive |
| STIR 2^18, arity 8 / verify | Serial | compact | 2.30 | 2.27 | -1.3% [-18.4%, +9.1%] — inconclusive |
| STIR 2^18, arity 8 / prove | Serial | final64 | 218.75 | 186.10 | -14.9% [-27.7%, -5.7%] |
| STIR 2^18, arity 8 / verify | Serial | final64 | 2.30 | 1.89 | -17.7% [-33.4%, -6.1%] |

</details>

The machine was OS-scheduled without CPU affinity or frequency locking; one-minute load varied from 4.08 to 33.30. All samples were retained. With only six default blocks or four option blocks, intervals are approximate and not adjusted for multiple comparisons. In particular, identical serial commitment controls measured -23.3% under the distinct-points case versus -0.2% under the merged case, so the larger serial PCS deltas should not be treated as precise optimization gains. `commit_ldes` shows no clear gain in this run.

Every generated proof was verified with matching prover/verifier next challenges. All 40 default main/branch artifact comparisons matched byte-for-byte (proofs, opened values, commitments and arithmetic outputs), plus 55 serial/parallel artifact comparisons.

## Validation

- `cargo test -p p3-stir --locked --offline`: 202 tests passed.
- `cargo test -p p3-stir --features parallel --locked --offline`: 202 tests passed.
- `cargo clippy -p p3-stir --all-targets --locked --offline -- -D warnings`: passed.
- `cargo clippy -p p3-stir --all-targets --features parallel --locked --offline -- -D warnings`: passed.
- `cargo +nightly fmt -p p3-stir -- --check`: passed.
- `git diff --check origin/main...HEAD`: passed.
