### PR TITLE
perf(merkle-tree): optimize same-height multi-matrix hashing

### DIFF
--- a/merkle-tree/Cargo.toml
+++ b/merkle-tree/Cargo.toml
@@ -30,6 +30,7 @@ tracing.workspace = true
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-blake3 = { path = "../blake3" }
+p3-goldilocks = { path = "../goldilocks" }
 p3-keccak = { path = "../keccak" }
 p3-mds = { path = "../mds" }
 p3-rescue = { path = "../rescue" }
@@ -43,6 +44,10 @@ harness = false
 
 [[bench]]
 name = "pruned_verify"
+harness = false
+
+[[bench]]
+name = "multi_matrix"
 harness = false
 
 [lints]

--- a/merkle-tree/benches/multi_matrix.rs
+++ b/merkle-tree/benches/multi_matrix.rs
@@ -1,0 +1,140 @@
+//! Compare equal-width commitments split across matrices, including injected layers.
+//! `current` uses the hasher's staging hint; `unstaged` retains the flat iterator.
+//! Input matrices are generated once and borrowed during each timed commitment.
+//!
+//! Run with a fixed worker count, for example:
+//! `RAYON_NUM_THREADS=8 cargo bench -p p3-merkle-tree --features parallel --bench multi_matrix`
+
+use std::hint::black_box;
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use p3_baby_bear::{BabyBear as F, Poseidon2BabyBear};
+use p3_commit::Mmcs;
+use p3_field::{Field, PackedValue};
+use p3_goldilocks::Goldilocks;
+use p3_keccak::{KeccakF, VECTOR_LEN};
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_merkle_tree::MerkleTreeMmcs;
+use p3_symmetric::{
+    CompressionFunctionFromHasher, CryptographicHasher, PaddingFreeSponge,
+    PseudoCompressionFunction, SerializingHasher, TruncatedPermutation,
+};
+use rand::SeedableRng;
+use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::SmallRng;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+#[derive(Clone)]
+struct Unstaged<H>(H);
+
+impl<T: Clone, Out, H: CryptographicHasher<T, Out>> CryptographicHasher<T, Out> for Unstaged<H> {
+    fn hash_iter<I: IntoIterator<Item = T>>(&self, input: I) -> Out {
+        self.0.hash_iter(input)
+    }
+}
+
+fn split<F: Field>(matrix: &RowMajorMatrix<F>, widths: &[usize]) -> Vec<RowMajorMatrix<F>> {
+    let mut start = 0;
+    widths
+        .iter()
+        .map(|&width| {
+            let mut values = Vec::with_capacity(matrix.height() * width);
+            for row in matrix.values.chunks_exact(matrix.width()) {
+                values.extend_from_slice(&row[start..start + width]);
+            }
+            start += width;
+            RowMajorMatrix::new(values, width)
+        })
+        .collect()
+}
+
+fn bench_hash<F, P, PW, H, C, const D: usize>(criterion: &mut Criterion, name: &str, h: H, c: C)
+where
+    F: Field + Serialize + DeserializeOwned,
+    StandardUniform: Distribution<F>,
+    P: PackedValue<Value = F>,
+    PW: PackedValue,
+    PW::Value: Eq,
+    [PW::Value; D]: Serialize + DeserializeOwned,
+    H: CryptographicHasher<F, [PW::Value; D]> + CryptographicHasher<P, [PW; D]> + Sync,
+    C: PseudoCompressionFunction<[PW::Value; D], 2> + PseudoCompressionFunction<[PW; D], 2> + Sync,
+{
+    let mmcs = MerkleTreeMmcs::<P, PW, _, _, 2, D>::new(h.clone(), c.clone(), 0);
+    let reference = MerkleTreeMmcs::<P, PW, _, _, 2, D>::new(Unstaged(h), c, 0);
+    let mut group = criterion.benchmark_group(format!("multi_matrix/{name}"));
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_millis(200));
+    group.measurement_time(Duration::from_secs(1));
+
+    for (rows, cols) in [(128, 2633), (4096, 32), (32768, 256)] {
+        let mut rng = SmallRng::seed_from_u64(1);
+        let matrix = RowMajorMatrix::<F>::rand(&mut rng, rows, cols);
+        let mut layouts: Vec<Vec<usize>> = [1, 2, 4, 8]
+            .into_iter()
+            .map(|n| {
+                (0..n)
+                    .map(|i| cols / n + usize::from(i < cols % n))
+                    .collect()
+            })
+            .collect();
+        layouts.push(vec![1, cols / 2, cols - cols / 2 - 1]);
+        for widths in layouts {
+            let mut matrices = split(&matrix, &widths);
+            let layout = widths
+                .iter()
+                .map(usize::to_string)
+                .collect::<Vec<_>>()
+                .join("+");
+            for layer in ["leaf", "injection"] {
+                if layer == "injection" {
+                    matrices.insert(0, RowMajorMatrix::rand(&mut rng, rows * 2, 1));
+                }
+                let params = format!("{layer}/{rows}x{layout}");
+                // Borrow the input data so cloning a potentially large trace is not timed.
+                group.bench_function(BenchmarkId::new("current", &params), |b| {
+                    b.iter(|| {
+                        black_box(mmcs.commit(matrices.iter().map(|m| m.as_view()).collect()))
+                    });
+                });
+                group.bench_function(BenchmarkId::new("unstaged", &params), |b| {
+                    b.iter(|| {
+                        black_box(reference.commit(matrices.iter().map(|m| m.as_view()).collect()))
+                    });
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+fn benches(criterion: &mut Criterion) {
+    let sponge = PaddingFreeSponge::<KeccakF, 25, 17, 4>::new(KeccakF);
+    bench_hash::<F, [F; VECTOR_LEN], [u64; VECTOR_LEN], _, _, 4>(
+        criterion,
+        "keccak_f",
+        SerializingHasher::new(sponge),
+        CompressionFunctionFromHasher::new(sponge),
+    );
+
+    bench_hash::<Goldilocks, [Goldilocks; VECTOR_LEN], [u64; VECTOR_LEN], _, _, 4>(
+        criterion,
+        "keccak_f_goldilocks",
+        SerializingHasher::new(sponge),
+        CompressionFunctionFromHasher::new(sponge),
+    );
+
+    let mut rng = SmallRng::seed_from_u64(1);
+    let perm = Poseidon2BabyBear::<16>::new_from_rng_128(&mut rng);
+    bench_hash::<F, <F as Field>::Packing, <F as Field>::Packing, _, _, 8>(
+        criterion,
+        "poseidon2",
+        PaddingFreeSponge::<_, 16, 8, 8>::new(perm.clone()),
+        TruncatedPermutation::<_, 2, 8, 16>::new(perm),
+    );
+}
+
+criterion_group!(multi_matrix, benches);
+criterion_main!(multi_matrix);

--- a/merkle-tree/benches/multi_matrix.rs
+++ b/merkle-tree/benches/multi_matrix.rs
@@ -31,8 +31,31 @@ use serde::de::DeserializeOwned;
 struct Unstaged<H>(H);
 
 impl<T: Clone, Out, H: CryptographicHasher<T, Out>> CryptographicHasher<T, Out> for Unstaged<H> {
+    const LANES: usize = H::LANES;
+    const PREFER_CONTIGUOUS_INPUT: bool = false;
+
     fn hash_iter<I: IntoIterator<Item = T>>(&self, input: I) -> Out {
         self.0.hash_iter(input)
+    }
+
+    fn hash_iter_slices<'a, I>(&self, input: I) -> Out
+    where
+        I: IntoIterator<Item = &'a [T]>,
+        T: 'a,
+    {
+        self.0.hash_iter_slices(input)
+    }
+
+    fn hash_slice(&self, input: &[T]) -> Out {
+        self.0.hash_slice(input)
+    }
+
+    fn hash_item(&self, input: T) -> Out {
+        self.0.hash_item(input)
+    }
+
+    fn hash_many(&self, input: &[T], out: &mut [Out]) {
+        self.0.hash_many(input, out);
     }
 }
 

--- a/merkle-tree/src/lib.rs
+++ b/merkle-tree/src/lib.rs
@@ -8,6 +8,9 @@ mod merkle_tree;
 mod mmcs;
 mod pruning;
 
+#[cfg(test)]
+mod packed_row_tests;
+
 pub use hiding_mmcs::*;
 pub use merkle_tree::MerkleTree;
 pub use mmcs::{MerkleTreeError, MerkleTreeMmcs, PrunedBatchOpening, PrunedProofError};

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -576,6 +576,39 @@ where
     next_digests
 }
 
+/// Hash one SIMD batch of concatenated rows, reusing scratch only when requested.
+#[inline]
+fn hash_packed_row<P, PW, H, M, const DIGEST_ELEMS: usize>(
+    h: &H,
+    matrices: &[&M],
+    first_row: usize,
+    scratch: &mut Vec<P>,
+) -> [PW; DIGEST_ELEMS]
+where
+    P: PackedValue,
+    PW: PackedValue,
+    H: CryptographicHasher<P, [PW; DIGEST_ELEMS]>,
+    M: Matrix<P::Value>,
+{
+    if let [m] = matrices {
+        h.hash_iter(m.vertically_packed_row(first_row))
+    } else if H::PREFER_CONTIGUOUS_INPUT {
+        scratch.clear();
+        for m in matrices {
+            scratch.extend(m.vertically_packed_row::<P>(first_row));
+        }
+        // Stage before serialization: a partial word or sponge block can span matrices.
+        // hash_slice's default reintroduces a compound iterator, so use hash_iter directly.
+        h.hash_iter(scratch.iter().copied())
+    } else {
+        h.hash_iter(
+            matrices
+                .iter()
+                .flat_map(|m| m.vertically_packed_row(first_row)),
+        )
+    }
+}
+
 /// Hash every row of the tallest matrices and build the first digest layer.
 ///
 /// This function is responsible for creating the first layer of Merkle digests,
@@ -635,26 +668,16 @@ where
     digests[0..max_height]
         .par_chunks_exact_mut(width)
         .enumerate()
-        .for_each(|(i, digests_chunk)| {
+        .for_each_init(Vec::new, |scratch, (i, digests_chunk)| {
             // Compute the starting row index for this chunk.
             let first_row = i * width;
 
-            // Collect all vertically packed rows from each matrix at `first_row`.
-            // These packed rows are then hashed together using `h`.
-            //
-            // The single-matrix case feeds `h` the row iterator directly: going
-            // through `flat_map` hands the hasher a compound iterator whose
-            // `next()` defeats the optimizer's vectorization of the absorb loop,
-            // which is worth ~40% of the leaf-hashing time on wide matrices.
-            let packed_digest: [PW; DIGEST_ELEMS] = if let [m] = tallest_matrices {
-                h.hash_iter(m.vertically_packed_row(first_row))
-            } else {
-                h.hash_iter(
-                    tallest_matrices
-                        .iter()
-                        .flat_map(|m| m.vertically_packed_row(first_row)),
-                )
-            };
+            let packed_digest = hash_packed_row::<P, PW, _, _, DIGEST_ELEMS>(
+                h,
+                tallest_matrices,
+                first_row,
+                scratch,
+            );
 
             // Unpack the resulting packed digest into individual scalar digests.
             PW::unpack_into(&packed_digest, digests_chunk);
@@ -736,7 +759,7 @@ where
     next_digests[0..next_len]
         .par_chunks_exact_mut(width)
         .enumerate()
-        .for_each(|(i, digests_chunk)| {
+        .for_each_init(Vec::new, |scratch, (i, digests_chunk)| {
             let first_row = i * width;
             let children: [[PW; DIGEST_ELEMS]; N] = array::from_fn(|n| {
                 if n < step {
@@ -747,18 +770,12 @@ where
             });
             let mut packed_digest = c.compress(children);
 
-            // As in `first_digest_layer`, the single-matrix case feeds `h` the
-            // row iterator directly: a `flat_map` compound iterator defeats the
-            // optimizer's vectorization of the absorb loop.
-            let tallest_digest: [PW; DIGEST_ELEMS] = if let [m] = matrices_to_inject {
-                h.hash_iter(m.vertically_packed_row(first_row))
-            } else {
-                h.hash_iter(
-                    matrices_to_inject
-                        .iter()
-                        .flat_map(|m| m.vertically_packed_row(first_row)),
-                )
-            };
+            let tallest_digest = hash_packed_row::<P, PW, _, _, DIGEST_ELEMS>(
+                h,
+                matrices_to_inject,
+                first_row,
+                scratch,
+            );
             let inject_inputs: [[PW; DIGEST_ELEMS]; N] = array::from_fn(|n| {
                 if n == 0 {
                     packed_digest

--- a/merkle-tree/src/packed_row_tests.rs
+++ b/merkle-tree/src/packed_row_tests.rs
@@ -1,0 +1,202 @@
+use alloc::vec;
+use alloc::vec::Vec;
+
+use p3_baby_bear::BabyBear;
+use p3_commit::{BatchOpeningRef, Mmcs};
+use p3_field::Field;
+use p3_goldilocks::Goldilocks;
+use p3_keccak::{KeccakF, VECTOR_LEN};
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+use p3_symmetric::{
+    CompressionFunctionFromHasher, CryptographicHasher, PaddingFreeSponge, SerializingHasher,
+};
+use rand::SeedableRng;
+use rand::distr::{Distribution, StandardUniform};
+use rand::rngs::{SmallRng, StdRng};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use crate::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
+
+// Keep the pre-staging iterator path as an independent commitment reference.
+#[derive(Clone)]
+struct Unstaged<H>(H);
+
+impl<T: Clone, Out, H: CryptographicHasher<T, Out>> CryptographicHasher<T, Out> for Unstaged<H> {
+    fn hash_iter<I: IntoIterator<Item = T>>(&self, input: I) -> Out {
+        self.0.hash_iter(input)
+    }
+}
+
+type Sponge = PaddingFreeSponge<KeccakF, 25, 17, 4>;
+type Hasher = SerializingHasher<Sponge>;
+type Compression<const N: usize> = CompressionFunctionFromHasher<Sponge, N, 4>;
+type MmcsImpl<F, H, const N: usize> =
+    MerkleTreeMmcs<[F; VECTOR_LEN], [u64; VECTOR_LEN], H, Compression<N>, N, 4>;
+
+#[test]
+fn contiguous_input_hint_targets_packed_32_bit_serialization() {
+    let hints = [
+        <Hasher as CryptographicHasher<BabyBear, [u64; 4]>>::PREFER_CONTIGUOUS_INPUT,
+        <Hasher as CryptographicHasher<[BabyBear; VECTOR_LEN], [[u64; VECTOR_LEN]; 4]>>::PREFER_CONTIGUOUS_INPUT,
+        <Hasher as CryptographicHasher<[Goldilocks; VECTOR_LEN], [[u64; VECTOR_LEN]; 4]>>::PREFER_CONTIGUOUS_INPUT,
+    ];
+    assert_eq!(hints, [false, VECTOR_LEN > 1, false]);
+}
+
+fn check_layout<F, const N: usize>(dimensions: &[(usize, usize)], cap_height: usize)
+where
+    F: Field + Serialize + DeserializeOwned,
+    StandardUniform: Distribution<F>,
+{
+    let mut rng = SmallRng::seed_from_u64(73);
+    let matrices: Vec<_> = dimensions
+        .iter()
+        .map(|&(height, width)| RowMajorMatrix::<F>::rand(&mut rng, height, width))
+        .collect();
+    let sponge = Sponge::new(KeccakF);
+    let hasher = Hasher::new(sponge);
+    let staged = MmcsImpl::<F, _, N>::new(hasher, Compression::new(sponge), cap_height);
+    let reference =
+        MmcsImpl::<F, _, N>::new(Unstaged(hasher), Compression::new(sponge), cap_height);
+    let (cap, data) = staged.commit(matrices.clone());
+    let (reference_cap, reference_data) = reference.commit(matrices);
+
+    assert_eq!(cap, reference_cap);
+    assert_eq!(data.digest_layers, reference_data.digest_layers);
+    assert_eq!(data.arity_schedule, reference_data.arity_schedule);
+
+    let dims: Vec<_> = data.leaves.iter().map(Matrix::dimensions).collect();
+    let height = dimensions.iter().map(|d| d.0).max().unwrap();
+    for index in [0, height / 2, height - 1] {
+        let opening = staged.open_batch(index, &data);
+        let reference_opening = reference.open_batch(index, &reference_data);
+        assert_eq!(opening.opened_values, reference_opening.opened_values);
+        assert_eq!(opening.opening_proof, reference_opening.opening_proof);
+        reference
+            .verify_batch(
+                &cap,
+                &dims,
+                index,
+                BatchOpeningRef::new(&opening.opened_values, &opening.opening_proof),
+            )
+            .unwrap();
+
+        let mut corrupted = opening.opened_values.clone();
+        corrupted[0][0] += F::ONE;
+        assert!(
+            reference
+                .verify_batch(
+                    &cap,
+                    &dims,
+                    index,
+                    BatchOpeningRef::new(&corrupted, &opening.opening_proof)
+                )
+                .is_err()
+        );
+    }
+}
+
+fn check_shapes<F, const N: usize>()
+where
+    F: Field + Serialize + DeserializeOwned,
+    StandardUniform: Distribution<F>,
+{
+    // Odd field counts cross u64 serialization boundaries; 34 BabyBear elements
+    // fill the sponge rate exactly. Odd heights exercise the scalar remainder.
+    for height in [1, VECTOR_LEN, VECTOR_LEN + 1, 31, 128] {
+        for widths in [
+            vec![1, 1],
+            vec![3, 5],
+            vec![17, 17],
+            vec![33, 35, 1],
+            vec![2633, 1],
+        ] {
+            let dims: Vec<_> = widths.into_iter().map(|w| (height, w)).collect();
+            check_layout::<F, N>(&dims, 0);
+        }
+    }
+    for cap_height in [0, 1, 2] {
+        // Multiple injected rows at two heights, with a binary bridge for N=4.
+        check_layout::<F, N>(
+            &[(65, 3), (33, 17), (65, 5), (17, 1), (33, 19), (17, 2)],
+            cap_height,
+        );
+    }
+    // More packed batches than the worker pool normally needs.
+    check_layout::<F, N>(&[(4097, 3), (4097, 5), (2049, 17), (2049, 19)], 0);
+}
+
+#[test]
+fn packed_babybear_rows_preserve_binary_commitments() {
+    check_shapes::<BabyBear, 2>();
+}
+
+#[test]
+fn packed_babybear_rows_preserve_quaternary_commitments() {
+    check_shapes::<BabyBear, 4>();
+}
+
+#[test]
+fn packed_goldilocks_rows_preserve_binary_commitments() {
+    check_shapes::<Goldilocks, 2>();
+}
+
+#[test]
+fn packed_goldilocks_rows_preserve_quaternary_commitments() {
+    check_shapes::<Goldilocks, 4>();
+}
+
+#[test]
+fn packed_rows_preserve_salted_commitments() {
+    type Hiding<H> = MerkleTreeHidingMmcs<
+        [BabyBear; VECTOR_LEN],
+        [u64; VECTOR_LEN],
+        H,
+        Compression<4>,
+        StdRng,
+        4,
+        4,
+        5,
+    >;
+    let mut rng = SmallRng::seed_from_u64(73);
+    let matrices: Vec<_> = [(65, 3), (33, 17), (65, 5), (33, 19)]
+        .into_iter()
+        .map(|(height, width)| RowMajorMatrix::<BabyBear>::rand(&mut rng, height, width))
+        .collect();
+    let dims: Vec<_> = matrices.iter().map(Matrix::dimensions).collect();
+    let sponge = Sponge::new(KeccakF);
+    let hasher = Hasher::new(sponge);
+    // Independently seed both MMCSs: cloning a hiding MMCS forks its salt stream.
+    let staged = Hiding::new(
+        hasher,
+        Compression::new(sponge),
+        1,
+        StdRng::seed_from_u64(91),
+    );
+    let reference = Hiding::new(
+        Unstaged(hasher),
+        Compression::new(sponge),
+        1,
+        StdRng::seed_from_u64(91),
+    );
+    let (cap, data) = staged.commit(matrices.clone());
+    let (reference_cap, reference_data) = reference.commit(matrices);
+    assert_eq!(cap, reference_cap);
+    assert_eq!(data.digest_layers, reference_data.digest_layers);
+    for index in [0, 32, 64] {
+        let opening = staged.open_batch(index, &data);
+        let reference_opening = reference.open_batch(index, &reference_data);
+        assert_eq!(opening.opened_values, reference_opening.opened_values);
+        assert_eq!(opening.opening_proof, reference_opening.opening_proof);
+        reference
+            .verify_batch(
+                &cap,
+                &dims,
+                index,
+                BatchOpeningRef::new(&opening.opened_values, &opening.opening_proof),
+            )
+            .unwrap();
+    }
+}

--- a/merkle-tree/src/packed_row_tests.rs
+++ b/merkle-tree/src/packed_row_tests.rs
@@ -1,11 +1,13 @@
+use alloc::sync::Arc;
 use alloc::vec;
 use alloc::vec::Vec;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use p3_baby_bear::BabyBear;
 use p3_commit::{BatchOpeningRef, Mmcs};
 use p3_field::Field;
 use p3_goldilocks::Goldilocks;
-use p3_keccak::{KeccakF, VECTOR_LEN};
+use p3_keccak::{Keccak256Hash, KeccakF, VECTOR_LEN};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_symmetric::{
@@ -24,9 +26,69 @@ use crate::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
 struct Unstaged<H>(H);
 
 impl<T: Clone, Out, H: CryptographicHasher<T, Out>> CryptographicHasher<T, Out> for Unstaged<H> {
+    const LANES: usize = H::LANES;
+    const PREFER_CONTIGUOUS_INPUT: bool = false;
+
     fn hash_iter<I: IntoIterator<Item = T>>(&self, input: I) -> Out {
         self.0.hash_iter(input)
     }
+
+    fn hash_iter_slices<'a, I>(&self, input: I) -> Out
+    where
+        I: IntoIterator<Item = &'a [T]>,
+        T: 'a,
+    {
+        self.0.hash_iter_slices(input)
+    }
+
+    fn hash_slice(&self, input: &[T]) -> Out {
+        self.0.hash_slice(input)
+    }
+
+    fn hash_item(&self, input: T) -> Out {
+        self.0.hash_item(input)
+    }
+
+    fn hash_many(&self, input: &[T], out: &mut [Out]) {
+        self.0.hash_many(input, out);
+    }
+}
+
+#[test]
+fn unstaged_reference_preserves_batched_leaf_hashing() {
+    #[derive(Clone)]
+    struct CountBatches(Arc<AtomicUsize>);
+
+    impl CryptographicHasher<BabyBear, [u8; 32]> for CountBatches {
+        // Exercise batching even when the native Keccak implementation is scalar.
+        const LANES: usize = 3;
+
+        fn hash_iter<I: IntoIterator<Item = BabyBear>>(&self, input: I) -> [u8; 32] {
+            SerializingHasher::new(Keccak256Hash).hash_iter(input)
+        }
+
+        fn hash_many(&self, input: &[BabyBear], out: &mut [[u8; 32]]) {
+            self.0.fetch_add(1, Ordering::Relaxed);
+            SerializingHasher::new(Keccak256Hash).hash_many(input, out);
+        }
+    }
+
+    let calls = Arc::new(AtomicUsize::new(0));
+    let hasher = CountBatches(calls.clone());
+    let compression = CompressionFunctionFromHasher::<_, 2, 32>::new(Keccak256Hash);
+    let original =
+        MerkleTreeMmcs::<BabyBear, u8, _, _, 2, 32>::new(hasher.clone(), compression.clone(), 0);
+    let reference =
+        MerkleTreeMmcs::<BabyBear, u8, _, _, 2, 32>::new(Unstaged(hasher), compression, 0);
+    let mut rng = SmallRng::seed_from_u64(73);
+    let matrices = vec![RowMajorMatrix::<BabyBear>::rand(&mut rng, 7, 5)];
+    let (cap, _) = original.commit(matrices.clone());
+    let expected_calls = calls.swap(0, Ordering::Relaxed);
+    let (reference_cap, _) = reference.commit(matrices);
+
+    assert_eq!(cap, reference_cap);
+    assert!(expected_calls > 0);
+    assert_eq!(calls.load(Ordering::Relaxed), expected_calls);
 }
 
 type Sponge = PaddingFreeSponge<KeccakF, 25, 17, 4>;

--- a/symmetric/src/hasher.rs
+++ b/symmetric/src/hasher.rs
@@ -12,6 +12,14 @@ pub trait CryptographicHasher<Item: Clone, Out>: Clone {
     /// Callers read this only to decide whether grouping messages is worth the bookkeeping.
     const LANES: usize = 1;
 
+    /// Whether materializing a compound input iterator can improve hashing throughput.
+    ///
+    /// Callers concatenating disjoint inputs may use this hint to reuse a contiguous
+    /// staging buffer and pass its simple iterator to [`Self::hash_iter`]. It is not
+    /// a request to copy inputs that already have an efficient iterator, nor does it
+    /// affect the digest: the input sequence and message boundaries must stay identical.
+    const PREFER_CONTIGUOUS_INPUT: bool = false;
+
     /// Hash an iterator of input items.
     /// # Arguments
     /// - `input`: An iterator over items to be hashed.

--- a/symmetric/src/serializing_hasher.rs
+++ b/symmetric/src/serializing_hasher.rs
@@ -191,6 +191,10 @@ where
     F: Field,
     Inner: CryptographicHasher<[u64; M], [[u64; M]; N]>,
 {
+    // Flattened iterators inhibit vectorization when pairing 32-bit elements into u64s.
+    // Staging does not help the direct u64 mapping of 64-bit fields.
+    const PREFER_CONTIGUOUS_INPUT: bool = M > 1 && F::NUM_BYTES == 4;
+
     fn hash_iter<I>(&self, input: I) -> [[u64; M]; N]
     where
         I: IntoIterator<Item = [F; M]>,


### PR DESCRIPTION
## Summary

Complements #2051 by optimizing the packed KeccakF/u64 path when several matrices share a leaf or injection layer.

The concatenated `flat_map` iterator inhibits vectorization when serializing pairs of 32-bit field elements into u64s. Staging the packed field elements first gives the hasher a simple contiguous iterator.

## Changes

- Add a default-off `CryptographicHasher::PREFER_CONTIGUOUS_INPUT` hint, enabled for packed-u64 serialization of 32-bit fields.
- Reuse scratch buffers within Rayon jobs for both leaf hashing and injected layers, retaining existing parallel granularity.
- Preserve concatenation across matrix boundaries before serialization, including partial u64s.
- Keep single-matrix hashing, scalar tails, and proof formats unchanged. Poseidon and Goldilocks remain unstaged.
- Add compatibility tests and benchmarks covering multiple matrix counts, uneven widths, and injected layers.

## Performance

Apple M4 Pro, Rust 1.98.0, eight Rayon workers. Full BabyBear MMCS commitments with 32,768 rows and two 128-column matrices:

| Path | Unstaged | Staged | Reduction |
|---|---:|---:|---:|
| Leaf | 4.659 ms | 3.034 ms | 34.9% |
| Injection | 5.858 ms | 4.259 ms | 27.3% |

Small-tree cases also improve. Separate clean-`main` comparisons detected no regression in single-matrix Keccak or Poseidon controls.

These are local commitment timings, not end-to-end prover speedup claims. Native x86 performance has not been measured.

Reproduce the representative cases with:

```sh
RAYON_NUM_THREADS=8 cargo bench -p p3-merkle-tree --features parallel --bench multi_matrix -- 'keccak_f/.*/(leaf|injection)/32768x128\+128$' --noplot
```

## Validation

- Pass the full workspace parallel test suite and doctests in the normal test profile, with debug symbols and incremental compilation disabled to limit disk usage.
- Compare complete digest layers, caps, opened rows, and authentication paths against the unstaged implementation, with verification and tamper-rejection checks.
- Cover odd widths/heights, scalar remainders, mixed-height injection, binary/quaternary trees, caps, and salted commitments.
- Pass 129 serial tests, 400 parallel tests, and six release-mode Keccak-backed proof examples.
- Pass workspace-wide Clippy, formatting, x86 default/AVX2/AVX-512 compilation, and WebAssembly library checks.
- Pass 275 tests when combined with #2051 at `851b124828b8f83358a10139e921a69eed21ba7c`; the combined benchmark retains the speedup.

The #2051 integration was checked in a separate worktree. This PR does not include its changes.

The workspace-wide `--release` run stops on two pre-existing `p3-lookup` tests, `generate_permutation_exclusive_rejects_non_boolean_flag` and `generate_permutation_exclusive_rejects_two_active_flags`. Both failures were reproduced on unmodified `main`: their expected panics come from `debug_assert!` checks disabled in release builds. No lookup changes are included here.
