### PR TITLE
refactor(commit): separate core PCS and STARK capabilities

### DIFF
--- a/batch-stark/src/common.rs
+++ b/batch-stark/src/common.rs
@@ -12,7 +12,7 @@ use alloc::vec::Vec;
 
 use p3_air::Air;
 use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_field::{Algebra, BasedVectorSpace};
 use p3_lookup::{InteractionSymbolicBuilder, LogUpGadget, Lookups};
 use p3_matrix::Matrix;

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -9,7 +9,7 @@ use p3_air::DebugConstraintBuilder;
 use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
 use p3_air::{Air, RowWindow};
 use p3_challenger::GrindingChallenger;
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_field::{
     Algebra, BasedVectorSpace, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
     PrimeField,
@@ -500,6 +500,7 @@ where
         transcript.grind_and_sample_zeta(config.ood_proof_of_work_bits());
 
     // Build the opening rounds and produce the FRI opening proof.
+    let opening_layout = p3_uni_stark::StarkOpeningLayout::new(SC::Pcs::ZK);
     let (opened_values, opening_proof) = {
         let mut rounds = Vec::new();
 
@@ -583,9 +584,12 @@ where
         }
 
         pcs.open_with_preprocessing(
-            rounds,
+            rounds.into_iter().map(Into::into).collect(),
             &mut transcript.challenger,
-            common.preprocessed.is_some(),
+            common
+                .preprocessed
+                .as_ref()
+                .map(|_| opening_layout.preprocessed),
         )
     };
 
@@ -593,13 +597,13 @@ where
 
     // Permutation round follows preprocessed (if present), else takes its slot.
     let permutation_idx = if common.preprocessed.is_some() {
-        SC::Pcs::PREPROCESSED_TRACE_IDX + 1
+        opening_layout.preprocessed + 1
     } else {
-        SC::Pcs::PREPROCESSED_TRACE_IDX
+        opening_layout.preprocessed
     };
 
     // Main trace opened values: one entry per instance.
-    let trace_values_for_mats = &opened_values[SC::Pcs::TRACE_IDX];
+    let trace_values_for_mats = &opened_values[opening_layout.trace];
     assert_eq!(trace_values_for_mats.len(), n_instances);
 
     let mut per_instance = Vec::with_capacity(n_instances);
@@ -608,7 +612,7 @@ where
     let preprocessed_openings = common
         .preprocessed
         .as_ref()
-        .map(|_| &opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX]);
+        .map(|_| &opened_values[opening_layout.preprocessed]);
 
     // Iterator over permutation opened values (one per instance with lookups).
     let is_lookup = permutation_commit_and_data.is_some();
@@ -620,7 +624,7 @@ where
     let mut permutation_values_for_mats = permutation_values_for_mats.iter();
 
     // Iterate over quotient chunk ranges to assemble per-instance opened values.
-    let mut quotient_openings_iter = opened_values[SC::Pcs::QUOTIENT_IDX].iter();
+    let mut quotient_openings_iter = opened_values[opening_layout.quotient].iter();
     for (i, (s, e)) in quotient_chunk_ranges.iter().copied().enumerate() {
         // Optional randomization polynomial opening.
         let random = if opt_r_data.is_some() {

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -7,7 +7,7 @@ pub use data::VerifierData;
 use p3_air::symbolic::{AirLayout, SymbolicExpressionExt};
 use p3_air::{Air, BaseAir};
 use p3_challenger::GrindingChallenger;
-use p3_commit::{CommitmentWithOpeningPoints, Pcs, PolynomialSpace};
+use p3_commit::{CommitmentWithOpeningPoints, Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_field::{Algebra, BasedVectorSpace, ExtensionField, PrimeCharacteristicRing, PrimeField};
 use p3_lookup::logup::LogUpGadget;
 use p3_lookup::{
@@ -75,7 +75,7 @@ pub type OpeningArgumentWithQuotientDomains<SC> = (
 /// - per-instance counts agreeing across `airs`, opened values, public values, degree bits,
 ///   lookup terminals and lookups ([`InvalidProofShapeError::InstanceCountMismatch`]);
 /// - presence of the ZK randomization commitment and its per-instance opened values matching
-///   [`Pcs::ZK`], and each random opening's dimension;
+///   [`UnivariateStarkPcs::ZK`], and each random opening's dimension;
 /// - public-value counts, trace-width agreement (local and next) and the
 ///   `main_next_row_columns` presence rule;
 /// - quotient-chunk counts and per-chunk dimensions;
@@ -332,7 +332,10 @@ where
         coms_to_verify.push((permutation_commit, permutation_round));
     }
 
-    Ok((coms_to_verify, quotient_domains))
+    Ok((
+        coms_to_verify.into_iter().map(Into::into).collect(),
+        quotient_domains,
+    ))
 }
 
 #[instrument(skip_all)]

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -5,7 +5,10 @@ use core::marker::PhantomData;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, OpenedValues, Pcs, PeriodicLdeTable, PolynomialSpace};
+use p3_commit::{
+    CommitmentOpening, MatrixOpening, Mmcs, OpenedValues, OpeningRequest, Pcs, PeriodicLdeTable,
+    PointOpening, PolynomialSpace, UnivariateStarkPcs,
+};
 use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, Field, batch_multiplicative_inverse, dot_product};
 use p3_fri::verifier::FriError;
@@ -143,17 +146,11 @@ where
     type Domain = CircleDomain<Val>;
     type Commitment = InputMmcs::Commitment;
     type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
-    type EvaluationsOnDomain<'a> = RowIndexMappedView<CfftPerm, RowMajorMatrixCow<'a, Val>>;
     type Proof = CirclePcsProof<Val, Challenge, InputMmcs, FriMmcs, Challenger::Witness>;
     type Error = FriError<FriMmcs::Error, InputError<InputMmcs::Error, FriMmcs::Error>>;
-    const ZK: bool = false;
 
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
         CircleDomain::standard(log2_strict_usize(degree))
-    }
-
-    fn log_max_lde_height(&self) -> usize {
-        Val::CIRCLE_TWO_ADICITY - 1
     }
 
     fn commit(
@@ -179,74 +176,10 @@ where
         (comm, mmcs_data)
     }
 
-    fn get_quotient_ldes(
-        &self,
-        evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
-        _num_chunks: usize,
-    ) -> Vec<RowMajorMatrix<Val>> {
-        evaluations
-            .into_iter()
-            .map(|(domain, evals)| {
-                assert!(
-                    domain.log_n >= 2,
-                    "CirclePcs cannot commit to a matrix with fewer than 4 rows.",
-                    // (because we bivariate fold one bit, and fri needs one more bit)
-                );
-                CircleEvaluations::from_natural_order(domain, evals)
-                    .extrapolate(CircleDomain::standard(
-                        domain.log_n + self.fri_params.log_blowup,
-                    ))
-                    .to_cfft_order()
-            })
-            .collect_vec()
-    }
-
-    fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
-        self.mmcs.commit(ldes)
-    }
-
-    fn get_evaluations_on_domain<'a>(
-        &self,
-        data: &'a Self::ProverData,
-        idx: usize,
-        domain: Self::Domain,
-    ) -> Self::EvaluationsOnDomain<'a> {
-        let mat = self.mmcs.get_matrices(data)[idx].as_view();
-        let committed_domain = CircleDomain::standard(log2_strict_usize(mat.height()));
-        if domain == committed_domain {
-            mat.as_cow().cfft_perm_rows()
-        } else {
-            // The committed matrix is the LDE of a polynomial of `committed_domain.log_n -
-            // log_blowup` coefficients. The first `2^log_sub` CFFT-ordered rows of the LDE
-            // are exactly the CFFT-ordered evaluations over the smaller `sub_domain` of that
-            // size (see `eval_at_point_on_subdomain_prefix_matches_full`), so interpolating
-            // that prefix instead of the full committed matrix recovers the same coefficients
-            // at `1 / blowup` of the CFFT work. This also lets `domain` be smaller than the
-            // committed LDE (e.g. a quotient domain when `log_blowup` exceeds the quotient
-            // degree), which `extrapolate` would reject.
-            let log_sub = committed_domain.log_n - self.fri_params.log_blowup;
-            let sub_domain = CircleDomain::new(log_sub, committed_domain.shift);
-            let coeffs =
-                CircleEvaluations::from_cfft_order(sub_domain, mat.split_rows(1 << log_sub).0)
-                    .interpolate();
-            CircleEvaluations::evaluate(domain, coeffs)
-                .to_cfft_order()
-                .as_cow()
-                .cfft_perm_rows()
-        }
-    }
-
     fn open(
         &self,
         // For each round,
-        rounds: Vec<(
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // points to open
-                Vec<Challenge>,
-            >,
-        )>,
+        rounds: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
         challenger: &mut Challenger,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         assert!(
@@ -259,7 +192,10 @@ where
         // turn shared by every matrix opened at the same point on the same domain.
         let mut permuted_points: BTreeMap<usize, Vec<Point<Val>>> = BTreeMap::new();
         debug_span!("materialize domain points").in_scope(|| {
-            for (data, _) in &rounds {
+            for OpeningRequest {
+                prover_data: data, ..
+            } in &rounds
+            {
                 for mat in self.mmcs.get_matrices(data) {
                     let log_height = log2_strict_usize(mat.height());
                     permuted_points.entry(log_height).or_insert_with(|| {
@@ -275,88 +211,93 @@ where
         // Open matrices at points
         let values: OpenedValues<Challenge> = rounds
             .iter()
-            .map(|(data, points_for_mats)| {
-                let mats = self.mmcs.get_matrices(data);
-                debug_assert_eq!(
-                    mats.len(),
-                    points_for_mats.len(),
-                    "Mismatched number of matrices and points"
-                );
-                izip!(mats, points_for_mats)
-                    .map(|(mat, points_for_mat)| {
-                        let log_height = log2_strict_usize(mat.height());
-                        // The committed polynomial has degree below the pre-blow-up domain
-                        // size, so its values on a sub-twin-coset of that size determine it.
-                        // The first `2^log_sub` rows of the CFFT-ordered LDE are exactly the
-                        // CFFT-ordered evaluations over `CircleDomain::new(log_sub, shift)`
-                        // (see `eval_at_point_on_subdomain_prefix_matches_full`), so the
-                        // out-of-domain evaluation only traverses `1 / blowup` of the matrix.
-                        let log_sub = log_height - self.fri_params.log_blowup;
-                        let sub_height = 1 << log_sub;
-                        let sub_domain = CircleDomain::new(
-                            log_sub,
-                            CircleDomain::<Val>::standard(log_height).shift,
-                        );
-                        // It was committed in cfft order.
-                        let evals = CircleEvaluations::from_cfft_order(
-                            sub_domain,
-                            mat.split_rows(sub_height).0,
-                        );
+            .map(
+                |OpeningRequest {
+                     prover_data: data,
+                     points: points_for_mats,
+                 }| {
+                    let mats = self.mmcs.get_matrices(data);
+                    debug_assert_eq!(
+                        mats.len(),
+                        points_for_mats.len(),
+                        "Mismatched number of matrices and points"
+                    );
+                    izip!(mats, points_for_mats)
+                        .map(|(mat, points_for_mat)| {
+                            let log_height = log2_strict_usize(mat.height());
+                            // The committed polynomial has degree below the pre-blow-up domain
+                            // size, so its values on a sub-twin-coset of that size determine it.
+                            // The first `2^log_sub` rows of the CFFT-ordered LDE are exactly the
+                            // CFFT-ordered evaluations over `CircleDomain::new(log_sub, shift)`
+                            // (see `eval_at_point_on_subdomain_prefix_matches_full`), so the
+                            // out-of-domain evaluation only traverses `1 / blowup` of the matrix.
+                            let log_sub = log_height - self.fri_params.log_blowup;
+                            let sub_height = 1 << log_sub;
+                            let sub_domain = CircleDomain::new(
+                                log_sub,
+                                CircleDomain::<Val>::standard(log_height).shift,
+                            );
+                            // It was committed in cfft order.
+                            let evals = CircleEvaluations::from_cfft_order(
+                                sub_domain,
+                                mat.split_rows(sub_height).0,
+                            );
 
-                        // Resolve the Lagrange denominators for every point up front.
-                        let den_idxs = points_for_mat
-                            .iter()
-                            .map(|&zeta_uni| {
-                                let key = (log_height, zeta_uni);
-                                lagrange_dens
-                                    .iter()
-                                    .position(|(k, _)| *k == key)
-                                    .unwrap_or_else(|| {
-                                        let den = info_span!("compute Lagrange denominators")
-                                            .in_scope(|| {
-                                                compute_lagrange_den_batched(
-                                                    &permuted_points[&log_height][..sub_height],
-                                                    Point::from_projective_line(zeta_uni),
-                                                    log_sub,
-                                                )
-                                            });
-                                        lagrange_dens.push((key, den));
-                                        lagrange_dens.len() - 1
-                                    })
-                            })
-                            .collect_vec();
-
-                        let ps_for_points: Vec<Vec<Challenge>> =
-                            debug_span!("compute opened values with Lagrange interpolation")
-                                .in_scope(|| match (&points_for_mat[..], &den_idxs[..]) {
-                                    // A matrix opened at two points (e.g. zeta and zeta_next)
-                                    // is traversed once for both.
-                                    (&[zeta_0, zeta_1], &[idx_0, idx_1]) => evals
-                                        .evaluate_at_two_points_with_dens(
-                                            [
-                                                Point::from_projective_line(zeta_0),
-                                                Point::from_projective_line(zeta_1),
-                                            ],
-                                            [&lagrange_dens[idx_0].1, &lagrange_dens[idx_1].1],
-                                        )
-                                        .into(),
-                                    _ => izip!(points_for_mat, &den_idxs)
-                                        .map(|(&zeta_uni, &den_idx)| {
-                                            evals.evaluate_at_point_with_den(
-                                                Point::from_projective_line(zeta_uni),
-                                                &lagrange_dens[den_idx].1,
-                                            )
+                            // Resolve the Lagrange denominators for every point up front.
+                            let den_idxs = points_for_mat
+                                .iter()
+                                .map(|&zeta_uni| {
+                                    let key = (log_height, zeta_uni);
+                                    lagrange_dens
+                                        .iter()
+                                        .position(|(k, _)| *k == key)
+                                        .unwrap_or_else(|| {
+                                            let den = info_span!("compute Lagrange denominators")
+                                                .in_scope(|| {
+                                                    compute_lagrange_den_batched(
+                                                        &permuted_points[&log_height][..sub_height],
+                                                        Point::from_projective_line(zeta_uni),
+                                                        log_sub,
+                                                    )
+                                                });
+                                            lagrange_dens.push((key, den));
+                                            lagrange_dens.len() - 1
                                         })
-                                        .collect(),
-                                });
+                                })
+                                .collect_vec();
 
-                        for ps_at_zeta in &ps_for_points {
-                            challenger.observe_algebra_slice(ps_at_zeta);
-                        }
-                        ps_for_points
-                    })
-                    .collect()
-            })
+                            let ps_for_points: Vec<Vec<Challenge>> =
+                                debug_span!("compute opened values with Lagrange interpolation")
+                                    .in_scope(|| match (&points_for_mat[..], &den_idxs[..]) {
+                                        // A matrix opened at two points (e.g. zeta and zeta_next)
+                                        // is traversed once for both.
+                                        (&[zeta_0, zeta_1], &[idx_0, idx_1]) => evals
+                                            .evaluate_at_two_points_with_dens(
+                                                [
+                                                    Point::from_projective_line(zeta_0),
+                                                    Point::from_projective_line(zeta_1),
+                                                ],
+                                                [&lagrange_dens[idx_0].1, &lagrange_dens[idx_1].1],
+                                            )
+                                            .into(),
+                                        _ => izip!(points_for_mat, &den_idxs)
+                                            .map(|(&zeta_uni, &den_idx)| {
+                                                evals.evaluate_at_point_with_den(
+                                                    Point::from_projective_line(zeta_uni),
+                                                    &lagrange_dens[den_idx].1,
+                                                )
+                                            })
+                                            .collect(),
+                                    });
+
+                            for ps_at_zeta in &ps_for_points {
+                                challenger.observe_algebra_slice(ps_at_zeta);
+                            }
+                            ps_for_points
+                        })
+                        .collect()
+                },
+            )
             .collect();
         drop(lagrange_dens);
 
@@ -379,10 +320,14 @@ where
         // (log_height, point) -> DEEP-quotient vanishing parts.
         let mut vanishing_parts: Vec<((usize, Challenge), VanishingParts<Challenge>)> = vec![];
 
-        rounds
-            .iter()
-            .zip(values.iter())
-            .for_each(|((data, points_for_mats), values)| {
+        rounds.iter().zip(values.iter()).for_each(
+            |(
+                OpeningRequest {
+                    prover_data: data,
+                    points: points_for_mats,
+                },
+                values,
+            )| {
                 let mats = self.mmcs.get_matrices(data);
                 izip!(mats, points_for_mats, values).for_each(|(mat, points_for_mat, values)| {
                     let log_height = log2_strict_usize(mat.height());
@@ -459,7 +404,8 @@ where
                             *alpha_offset *= alpha_pow_width.square();
                         });
                 });
-            });
+            },
+        );
         drop(vanishing_parts);
 
         // Iterate over our reduced columns and extract lambda - the multiple of the vanishing polynomial
@@ -518,19 +464,23 @@ where
                 // one committed tree share a single proof, so overlapping paths ship once.
                 let input_openings = rounds
                     .iter()
-                    .map(|(data, _)| {
-                        let log_max_batch_height =
-                            log2_strict_usize(self.mmcs.get_max_height(data));
-                        let bits_reduced = log_max_height - log_max_batch_height;
-                        let reduced_indices: Vec<usize> =
-                            indices.iter().map(|&index| index >> bits_reduced).collect();
-                        let (opened_values, opening_proof) =
-                            self.mmcs.open_multi_batch(&reduced_indices, data);
-                        BatchMultiOpening {
-                            opened_values,
-                            opening_proof,
-                        }
-                    })
+                    .map(
+                        |OpeningRequest {
+                             prover_data: data, ..
+                         }| {
+                            let log_max_batch_height =
+                                log2_strict_usize(self.mmcs.get_max_height(data));
+                            let bits_reduced = log_max_height - log_max_batch_height;
+                            let reduced_indices: Vec<usize> =
+                                indices.iter().map(|&index| index >> bits_reduced).collect();
+                            let (opened_values, opening_proof) =
+                                self.mmcs.open_multi_batch(&reduced_indices, data);
+                            BatchMultiOpening {
+                                opened_values,
+                                opening_proof,
+                            }
+                        },
+                    )
                     .collect();
 
                 // We committed to first_layer in pairs, so open the reduced index and include the sibling
@@ -572,21 +522,7 @@ where
     fn verify(
         &self,
         // For each round:
-        rounds: Vec<(
-            Self::Commitment,
-            // for each matrix:
-            Vec<(
-                // its domain,
-                Self::Domain,
-                // for each point:
-                Vec<(
-                    // the point,
-                    Challenge,
-                    // values at the point
-                    Vec<Challenge>,
-                )>,
-            )>,
-        )>,
+        rounds: Vec<CommitmentOpening<Challenge, Self::Commitment, Self::Domain>>,
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
@@ -596,9 +532,12 @@ where
             }));
         }
         // Write evaluations to challenger
-        for (_, round) in &rounds {
-            for (_, mat) in round {
-                for (_, point) in mat {
+        for CommitmentOpening {
+            matrices: round, ..
+        } in &rounds
+        {
+            for MatrixOpening { points: mat, .. } in round {
+                for PointOpening { values: point, .. } in mat {
                     challenger.observe_algebra_slice(point);
                 }
             }
@@ -614,20 +553,36 @@ where
         // or (query, matrix, point) inside the per-query closure below.
         let matrix_alpha_pows: Vec<Vec<(Challenge, Challenge)>> = rounds
             .iter()
-            .map(|(_, mats)| {
+            .map(|CommitmentOpening { matrices: mats, .. }| {
                 mats.iter()
-                    .map(|(_, points_and_values)| {
-                        let width = points_and_values.first().map_or(0, |(_, v)| v.len());
-                        let alpha_pow_width = alpha.exp_u64(width as u64);
-                        (alpha_pow_width, alpha_pow_width.square())
-                    })
+                    .map(
+                        |MatrixOpening {
+                             points: points_and_values,
+                             ..
+                         }| {
+                            let width = points_and_values
+                                .first()
+                                .map_or(0, |PointOpening { values: v, .. }| v.len());
+                            let alpha_pow_width = alpha.exp_u64(width as u64);
+                            (alpha_pow_width, alpha_pow_width.square())
+                        },
+                    )
                     .collect()
             })
             .collect();
         let max_width = rounds
             .iter()
-            .flat_map(|(_, mats)| mats.iter())
-            .flat_map(|(_, points_and_values)| points_and_values.iter().map(|(_, v)| v.len()))
+            .flat_map(|CommitmentOpening { matrices: mats, .. }| mats.iter())
+            .flat_map(
+                |MatrixOpening {
+                     points: points_and_values,
+                     ..
+                 }| {
+                    points_and_values
+                        .iter()
+                        .map(|PointOpening { values: v, .. }| v.len())
+                },
+            )
             .max()
             .unwrap_or(0);
         let alpha_powers: Vec<Challenge> = alpha.powers().collect_n(max_width);
@@ -653,9 +608,9 @@ where
         // under-report is the only case to reject here.
         let expected_log_global_max_height = rounds
             .iter()
-            .flat_map(|(_, mats)| {
+            .flat_map(|CommitmentOpening { matrices: mats, .. }| {
                 mats.iter()
-                    .map(|(domain, _)| domain.log_n + self.fri_params.log_blowup)
+                    .map(|MatrixOpening { domain, .. }| domain.log_n + self.fri_params.log_blowup)
             })
             .max();
         if let Some(expected) = expected_log_global_max_height
@@ -694,12 +649,22 @@ where
 
                 // Check every input commitment's shared multi-opening once, before the
                 // per-query arithmetic reads any opened value.
-                for (batch, (batch_opening, (batch_commit, mats))) in
-                    zip_eq(input_openings, &rounds, InputError::InputShapeError)?.enumerate()
+                for (
+                    batch,
+                    (
+                        batch_opening,
+                        CommitmentOpening {
+                            commitment: batch_commit,
+                            matrices: mats,
+                        },
+                    ),
+                ) in zip_eq(input_openings, &rounds, InputError::InputShapeError)?.enumerate()
                 {
                     let batch_heights: Vec<usize> = mats
                         .iter()
-                        .map(|(domain, _)| domain.size() << self.fri_params.log_blowup)
+                        .map(|MatrixOpening { domain, .. }| {
+                            domain.size() << self.fri_params.log_blowup
+                        })
                         .collect_vec();
                     // The opened rows must pair one-to-one with the committed matrices.
                     for opened_values in &batch_opening.opened_values {
@@ -711,24 +676,35 @@ where
                         .iter()
                         .zip(mats)
                         .enumerate()
-                        .map(|(matrix, (&height, (_, points_and_values)))| {
-                            // Invariant: a matrix's width is fixed by its first opening point.
-                            //
-                            //     >= 1 point  ->  width = number of claimed evaluations
-                            //     no points   ->  reject
-                            //
-                            // Why reject the no-points case:
-                            //   - row boundaries in the flattened leaf hash are authenticated only from claimed widths
-                            //   - a matrix opened at no points claims no width
-                            //   - its width could then come only from the unverified proof
-                            let (_, values) = points_and_values
-                                .first()
-                                .ok_or(InputError::MatrixWithoutOpeningPoints { batch, matrix })?;
-                            Ok(Dimensions {
-                                width: values.len(),
-                                height,
-                            })
-                        })
+                        .map(
+                            |(
+                                matrix,
+                                (
+                                    &height,
+                                    MatrixOpening {
+                                        points: points_and_values,
+                                        ..
+                                    },
+                                ),
+                            )| {
+                                // Invariant: a matrix's width is fixed by its first opening point.
+                                //
+                                //     >= 1 point  ->  width = number of claimed evaluations
+                                //     no points   ->  reject
+                                //
+                                // Why reject the no-points case:
+                                //   - row boundaries in the flattened leaf hash are authenticated only from claimed widths
+                                //   - a matrix opened at no points claims no width
+                                //   - its width could then come only from the unverified proof
+                                let PointOpening { values, .. } = points_and_values.first().ok_or(
+                                    InputError::MatrixWithoutOpeningPoints { batch, matrix },
+                                )?;
+                                Ok(Dimensions {
+                                    width: values.len(),
+                                    height,
+                                })
+                            },
+                        )
                         .collect::<Result<Vec<_>, _>>()?;
 
                     let (dims, reduced_indices) = batch_heights
@@ -769,10 +745,19 @@ where
                     // log_height -> (alpha_offset, ro)
                     let mut reduced_openings = BTreeMap::new();
 
-                    for (batch, (batch_opening, (_, mats))) in
+                    for (batch, (batch_opening, CommitmentOpening { matrices: mats, .. })) in
                         zip_eq(input_openings, &rounds, InputError::InputShapeError)?.enumerate()
                     {
-                        for (matrix, (ps_at_x, (mat_domain, mat_points_and_values))) in zip_eq(
+                        for (
+                            matrix,
+                            (
+                                ps_at_x,
+                                MatrixOpening {
+                                    domain: mat_domain,
+                                    points: mat_points_and_values,
+                                },
+                            ),
+                        ) in zip_eq(
                             &batch_opening.opened_values[query],
                             mats,
                             InputError::InputShapeError,
@@ -792,7 +777,11 @@ where
                             let (alpha_pow_width, alpha_pow_width_2) =
                                 matrix_alpha_pows[batch][matrix];
 
-                            for (zeta_uni, ps_at_zeta) in mat_points_and_values {
+                            for PointOpening {
+                                point: zeta_uni,
+                                values: ps_at_zeta,
+                            } in mat_points_and_values
+                            {
                                 // The claimed opening must have exactly as many
                                 // values as the committed row has columns.
                                 if ps_at_zeta.len() != ps_at_x.len() {
@@ -915,6 +904,81 @@ where
             },
         )
     }
+}
+
+impl<Val, InputMmcs, FriMmcs, Challenge, Challenger> UnivariateStarkPcs<Challenge, Challenger>
+    for CirclePcs<Val, InputMmcs, FriMmcs>
+where
+    Val: ComplexExtendable,
+    Challenge: ExtensionField<Val>,
+    InputMmcs: Mmcs<Val>,
+    FriMmcs: Mmcs<Challenge>,
+    Challenger: FieldChallenger<Val> + GrindingChallenger + CanObserve<FriMmcs::Commitment>,
+{
+    type EvaluationsOnDomain<'a> = RowIndexMappedView<CfftPerm, RowMajorMatrixCow<'a, Val>>;
+
+    const ZK: bool = false;
+
+    fn log_max_lde_height(&self) -> usize {
+        Val::CIRCLE_TWO_ADICITY - 1
+    }
+
+    fn get_quotient_ldes(
+        &self,
+        evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
+        _num_chunks: usize,
+    ) -> Vec<RowMajorMatrix<Val>> {
+        evaluations
+            .into_iter()
+            .map(|(domain, evals)| {
+                assert!(
+                    domain.log_n >= 2,
+                    "CirclePcs cannot commit to a matrix with fewer than 4 rows.",
+                    // (because we bivariate fold one bit, and fri needs one more bit)
+                );
+                CircleEvaluations::from_natural_order(domain, evals)
+                    .extrapolate(CircleDomain::standard(
+                        domain.log_n + self.fri_params.log_blowup,
+                    ))
+                    .to_cfft_order()
+            })
+            .collect_vec()
+    }
+
+    fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
+        self.mmcs.commit(ldes)
+    }
+
+    fn get_evaluations_on_domain<'a>(
+        &self,
+        data: &'a Self::ProverData,
+        idx: usize,
+        domain: Self::Domain,
+    ) -> Self::EvaluationsOnDomain<'a> {
+        let mat = self.mmcs.get_matrices(data)[idx].as_view();
+        let committed_domain = CircleDomain::standard(log2_strict_usize(mat.height()));
+        if domain == committed_domain {
+            mat.as_cow().cfft_perm_rows()
+        } else {
+            // The committed matrix is the LDE of a polynomial of `committed_domain.log_n -
+            // log_blowup` coefficients. The first `2^log_sub` CFFT-ordered rows of the LDE
+            // are exactly the CFFT-ordered evaluations over the smaller `sub_domain` of that
+            // size (see `eval_at_point_on_subdomain_prefix_matches_full`), so interpolating
+            // that prefix instead of the full committed matrix recovers the same coefficients
+            // at `1 / blowup` of the CFFT work. This also lets `domain` be smaller than the
+            // committed LDE (e.g. a quotient domain when `log_blowup` exceeds the quotient
+            // degree), which `extrapolate` would reject.
+            let log_sub = committed_domain.log_n - self.fri_params.log_blowup;
+            let sub_domain = CircleDomain::new(log_sub, committed_domain.shift);
+            let coeffs =
+                CircleEvaluations::from_cfft_order(sub_domain, mat.split_rows(1 << log_sub).0)
+                    .interpolate();
+            CircleEvaluations::evaluate(domain, coeffs)
+                .to_cfft_order()
+                .as_cow()
+                .cfft_perm_rows()
+        }
+    }
 
     fn build_periodic_lde_table(
         &self,
@@ -1032,7 +1096,13 @@ mod tests {
 
         // Generate the opening proof at the chosen evaluation point.
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
-        let (values, proof) = pcs.open(vec![(&data, vec![vec![zeta]])], &mut chal);
+        let (values, proof) = pcs.open(
+            vec![OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut chal,
+        );
 
         (pcs, byte_hash, comm, d, zeta, values, proof)
     }
@@ -1055,10 +1125,13 @@ mod tests {
         // replays identically to what the prover produced.
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         pcs.verify(
-            vec![(
-                comm.clone(),
-                vec![(d, vec![(zeta, values[0][0][0].clone())])],
-            )],
+            vec![
+                (
+                    comm.clone(),
+                    vec![(d, vec![(zeta, values[0][0][0].clone())])],
+                )
+                    .into(),
+            ],
             proof,
             &mut chal,
         )
@@ -1094,7 +1167,10 @@ mod tests {
         pcs.fri_params.batch_proof_of_work_bits = 20;
 
         pcs.open(
-            vec![(&data, vec![vec![zeta]])],
+            vec![OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut Challenger::from_hasher(vec![], byte_hash),
         );
     }
@@ -1141,16 +1217,25 @@ mod tests {
         // Prove: open matrix 0 at one point, matrix 1 at no points.
         let zeta: Challenge = rng.random();
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
-        let (values, proof) = pcs.open(vec![(&data, vec![vec![zeta], vec![]])], &mut chal);
+        let (values, proof) = pcs.open(
+            vec![OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta], vec![]],
+            }],
+            &mut chal,
+        );
 
         // Verify with the same shape: matrix 1 carries no opening points.
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
         let err = pcs
             .verify(
-                vec![(
-                    comm,
-                    vec![(d, vec![(zeta, values[0][0][0].clone())]), (d, vec![])],
-                )],
+                vec![
+                    (
+                        comm,
+                        vec![(d, vec![(zeta, values[0][0][0].clone())]), (d, vec![])],
+                    )
+                        .into(),
+                ],
                 &proof,
                 &mut chal,
             )
@@ -1203,10 +1288,11 @@ mod tests {
         // `log_n + 2` hits the equal fast path, and `log_n + 3` is the larger-than case.
         for target_log_n in [log_n, log_n + 1, log_n + 2, log_n + 3] {
             let target = CircleDomain::standard(target_log_n);
-            let got = <TestPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
-                &pcs, &data, 0, target,
-            )
-            .to_row_major_matrix();
+            let got =
+                <TestPcs as UnivariateStarkPcs<Challenge, Challenger>>::get_evaluations_on_domain(
+                    &pcs, &data, 0, target,
+                )
+                .to_row_major_matrix();
 
             // Ground truth: extrapolate the original trace straight onto `target`.
             let expected = CircleEvaluations::from_natural_order(d, evals.clone())
@@ -1326,7 +1412,13 @@ mod tests {
         // Commit succeeds; the assert fires inside the opening (FRI prover).
         let zeta: Challenge = rng.random();
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
-        let _ = pcs.open(vec![(&data, vec![vec![zeta]])], &mut chal);
+        let _ = pcs.open(
+            vec![OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut chal,
+        );
     }
 
     #[test]
@@ -1386,7 +1478,13 @@ mod tests {
         // Commit succeeds; the assert fires inside the opening (FRI prover).
         let zeta: Challenge = rng.random();
         let mut chal = Challenger::from_hasher(vec![], byte_hash);
-        let _ = pcs.open(vec![(&data, vec![vec![zeta]])], &mut chal);
+        let _ = pcs.open(
+            vec![OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut chal,
+        );
     }
 
     #[test]

--- a/commit/README.md
+++ b/commit/README.md
@@ -16,3 +16,47 @@ Implementations live in `p3-merkle-tree` (Mmcs), `p3-fri`, `p3-circle` and
 `p3-whir` (Pcs).
 
 Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.
+
+## Univariate PCS API migration
+
+`Pcs` covers domains, commitments, prover data, and opening/verification. Implementers
+that serve univariate STARKs also implement `UnivariateStarkPcs`: move
+`EvaluationsOnDomain`, `ZK`, LDE/evaluation/quotient/periodic helpers and preprocessing
+adaptation to that implementation. Generic commitment clients can continue to bound
+only `Pcs`; STARK configurations require `UnivariateStarkPcs`. Import both traits when
+calling both sets of methods, and change qualified references to moved members to
+`UnivariateStarkPcs`. `MultilinearPcs` is unchanged.
+
+Opening batches now use named requests and claims:
+
+```rust,ignore
+let requests = vec![OpeningRequest {
+    prover_data: &data,
+    points: vec![vec![zeta]], // one point vector per committed matrix
+}];
+let claims = vec![CommitmentOpening {
+    commitment,
+    matrices: vec![MatrixOpening {
+        domain,
+        points: vec![PointOpening { point: zeta, values }],
+    }],
+}];
+```
+
+Requests borrow prover data and own their point vectors. Claims own commitments,
+matrices and column values, as before. All ordering remains significant: requests,
+matrices, points and columns are used in caller order. The existing
+`CommitmentWithOpeningPoints` name aliases `CommitmentOpening`. Explicit `From`
+conversions accept the former tuples, including nested matrix/point claims, so a
+caller can migrate a batch with `old_batch.into_iter().map(Into::into).collect()`.
+The FRI `ProverDataWithOpeningPoints` alias likewise names `OpeningRequest`.
+
+PCS traits no longer define trace, quotient or preprocessing commitment indices.
+Univariate STARK owns these positions in `p3_uni_stark::StarkOpeningLayout`.
+`open_with_preprocessing` now takes `Option<usize>` identifying the preprocessing
+**commitment request**, replacing the old boolean. Use `None` for no preprocessing;
+STARK callers pass `Some(layout.preprocessed)` when it is present. Other clients may
+place preprocessing at any commitment index.
+
+This is a Rust API change only; commitment/proof serialization, transcript absorption
+order and evaluation-view ownership remain unchanged. No version bump is included.

--- a/commit/src/pcs/univariate.rs
+++ b/commit/src/pcs/univariate.rs
@@ -31,36 +31,18 @@ where
     /// Data that the prover stores for committed polynomials, to help the prover with opening.
     type ProverData;
 
-    /// Type of the output of `get_evaluations_on_domain`.
-    type EvaluationsOnDomain<'a>: Matrix<Val<Self::Domain>> + 'a;
-
     /// The opening argument.
     type Proof: Clone + Serialize + DeserializeOwned;
 
     /// The type of a proof verification error.
     type Error: Debug;
 
-    /// Set to true to activate randomization and achieve zero-knowledge.
-    const ZK: bool;
-
-    /// Index of the trace commitment in the computed opened values.
-    const TRACE_IDX: usize = Self::ZK as usize;
-
-    /// Index of the quotient commitments in the computed opened values.
-    const QUOTIENT_IDX: usize = Self::TRACE_IDX + 1;
-
-    /// Index of the preprocessed trace commitment in the computed opened values.
-    const PREPROCESSED_TRACE_IDX: usize = Self::QUOTIENT_IDX + 1; // Note: not always present
-
     /// This should return a domain such that `Domain::next_point` returns `Some`.
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain;
 
-    /// The base-2 logarithm of the largest evaluation domain this PCS can construct.
-    fn log_max_lde_height(&self) -> usize;
-
     /// Given a collection of evaluation matrices, produce a binding commitment to
-    /// the polynomials defined by those evaluations. If `zk` is enabled, the evaluations are
-    /// first randomized as explained in Section 3 of <https://eprint.iacr.org/2024/1037.pdf>.
+    /// the polynomials defined by those evaluations. Hiding implementations may randomize
+    /// their encoding before committing.
     ///
     /// Returns both the commitment which should be sent to the verifier
     /// and the prover data which can be used to produce opening proofs.
@@ -69,6 +51,51 @@ where
         &self,
         evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val<Self::Domain>>)>,
     ) -> (Self::Commitment, Self::ProverData);
+
+    /// Open each requested commitment, matrix and point in caller order.
+    ///
+    /// Each request must supply one point vector per committed matrix. Columns are
+    /// interpreted as polynomials evaluated over the domain supplied to [`Self::commit`].
+    /// The returned values retain request, matrix, point and column order.
+    fn open(
+        &self,
+        // For each multi-matrix commitment,
+        commitment_data_with_opening_points: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
+        fiat_shamir_challenger: &mut Challenger,
+    ) -> (OpenedValues<Challenge>, Self::Proof);
+
+    /// Verify the claimed column evaluations for each commitment, matrix and point.
+    ///
+    /// Claims supply the original evaluation domains and must retain the ordering used
+    /// to construct the opening proof. The proof and transcript formats are backend-specific.
+    fn verify(
+        &self,
+        // For each commitment:
+        commitments_with_opening_points: Vec<
+            CommitmentOpening<Challenge, Self::Commitment, Self::Domain>,
+        >,
+        // The opening proof for all claimed evaluations.
+        proof: &Self::Proof,
+        fiat_shamir_challenger: &mut Challenger,
+    ) -> Result<(), Self::Error>;
+}
+
+/// Capabilities used by univariate STARK provers and verifiers.
+///
+/// Generic commitment clients only need [`Pcs`]. Evaluation views remain backend-specific
+/// through the GAT, so implementations can borrow committed LDEs without copying.
+pub trait UnivariateStarkPcs<Challenge, Challenger>: Pcs<Challenge, Challenger>
+where
+    Challenge: ExtensionField<Val<Self::Domain>>,
+{
+    /// Type of the output of `get_evaluations_on_domain`.
+    type EvaluationsOnDomain<'a>: Matrix<Val<Self::Domain>> + 'a;
+
+    /// Set to true to activate randomization and achieve zero-knowledge.
+    const ZK: bool;
+
+    /// The base-2 logarithm of the largest evaluation domain this PCS can construct.
+    fn log_max_lde_height(&self) -> usize;
 
     /// Same as `commit` but without randomization. This is used for preprocessed columns
     /// which do not have to be randomized even when ZK is enabled. Note that the preprocessed columns still
@@ -158,73 +185,18 @@ where
         self.get_evaluations_on_domain(prover_data, idx, domain)
     }
 
-    /// Open a collection of polynomial commitments at a set of points. Produce the values at those points along with a proof
-    /// of correctness.
+    /// Open commitments with an optional commitment to unrandomized preprocessing.
     ///
-    /// Arguments:
-    /// - `commitment_data_with_opening_points`: A vector whose elements are a pair:
-    ///     - `data`: The prover data corresponding to a multi-matrix commitment.
-    ///     - `opening_points`: A vector containing, for each matrix committed to, a vector of opening points.
-    /// - `fiat_shamir_challenger`: The challenger that will be used to generate the proof.
-    ///
-    /// Unwrapping the arguments further, each `data` contains a vector of the committed matrices (`matrices = Vec<M>`).
-    /// If the length of `matrices` is not equal to the length of `opening_points` the function will error. Otherwise, for
-    /// each index `i`, the matrix `M = matrices[i]` will be opened at the points `opening_points[i]`.
-    ///
-    /// This means that each column of `M` will be interpreted as the evaluation vector of some polynomial
-    /// and we will compute the value of all of those polynomials at `opening_points[i]`.
-    ///
-    /// The domains on which the evaluation vectors are defined is not part of the arguments here
-    /// but should be public information known to both the prover and verifier.
-    fn open(
-        &self,
-        // For each multi-matrix commitment,
-        commitment_data_with_opening_points: Vec<(
-            // The matrices and auxiliary prover data
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // the points to open
-                Vec<Challenge>,
-            >,
-        )>,
-        fiat_shamir_challenger: &mut Challenger,
-    ) -> (OpenedValues<Challenge>, Self::Proof);
-
-    /// Open a collection of polynomial commitments at a set of points, when there is preprocessing data.
-    /// It is the same as `open` when `ZK` is disabled.
-    /// Produce the values at those points along with a proof of correctness.
-    ///
-    /// Arguments:
-    /// - `commitment_data_with_opening_points`: A vector whose elements are a pair:
-    ///     - `data`: The prover data corresponding to a multi-matrix commitment.
-    ///     - `opening_points`: A vector containing, for each matrix committed to, a vector of opening points.
-    /// - `fiat_shamir_challenger`: The challenger that will be used to generate the proof.
-    /// - `is_preprocessing`: If one of the committed matrices corresponds to preprocessed columns, this is the index of that matrix.
-    ///
-    /// Unwrapping the arguments further, each `data` contains a vector of the committed matrices (`matrices = Vec<M>`).
-    /// If the length of `matrices` is not equal to the length of `opening_points` the function will error. Otherwise, for
-    /// each index `i`, the matrix `M = matrices[i]` will be opened at the points `opening_points[i]`.
-    ///
-    /// This means that each column of `M` will be interpreted as the evaluation vector of some polynomial
-    /// and we will compute the value of all of those polynomials at `opening_points[i]`.
-    ///
-    /// The domains on which the evaluation vectors are defined is not part of the arguments here
-    /// but should be public information known to both the prover and verifier.
+    /// `preprocessed_commitment` identifies a request in the batch, not a matrix within
+    /// a commitment. Hiding implementations omit random codewords for that request.
+    /// The caller owns the commitment ordering; PCS implementations impose no STARK layout.
+    /// Non-hiding implementations behave exactly like [`Pcs::open`].
     fn open_with_preprocessing(
         &self,
         // For each multi-matrix commitment,
-        commitment_data_with_opening_points: Vec<(
-            // The matrices and auxiliary prover data
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // the points to open
-                Vec<Challenge>,
-            >,
-        )>,
+        commitment_data_with_opening_points: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
         fiat_shamir_challenger: &mut Challenger,
-        _is_preprocessing: bool,
+        _preprocessed_commitment: Option<usize>,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         assert!(
             !Self::ZK,
@@ -232,39 +204,6 @@ where
         );
         self.open(commitment_data_with_opening_points, fiat_shamir_challenger)
     }
-
-    /// Verify that a collection of opened values is correct.
-    ///
-    /// Arguments:
-    /// - `commitments_with_opening_points`: A vector whose elements are a pair:
-    ///     - `commitment`: A multi matrix commitment.
-    ///     - `opening_points`: A vector containing, for each matrix committed to, a vector of opening points and claimed evaluations.
-    /// - `proof`: A claimed proof of correctness for the opened values.
-    /// - `fiat_shamir_challenger`: The challenger that will be used to generate the proof.
-    #[allow(clippy::type_complexity)]
-    fn verify(
-        &self,
-        // For each commitment:
-        commitments_with_opening_points: Vec<(
-            // The commitment
-            Self::Commitment,
-            // for each matrix in the commitment:
-            Vec<(
-                // its domain,
-                Self::Domain,
-                // A vector of (point, claimed_evaluation) pairs
-                Vec<(
-                    // the point the matrix was opened at,
-                    Challenge,
-                    // the claimed evaluations at that point
-                    Vec<Challenge>,
-                )>,
-            )>,
-        )>,
-        // The opening proof for all claimed evaluations.
-        proof: &Self::Proof,
-        fiat_shamir_challenger: &mut Challenger,
-    ) -> Result<(), Self::Error>;
 
     fn get_opt_randomization_poly_commitment(
         &self,
@@ -355,17 +294,92 @@ where
 ///
 /// This is the shape [`Pcs::verify`] checks an opening argument against, so it is also what
 /// any code building that argument produces.
-pub type CommitmentWithOpeningPoints<Challenge, Commitment, Domain> = (
-    Commitment,
-    // For each matrix in the commitment:
-    Vec<(
-        // The domain of the matrix
-        Domain,
-        // A vector of (point, claimed_evaluation) pairs.
-        // The claimed evaluation count per point is also the matrix width used by verification.
-        Vec<(Challenge, Vec<Challenge>)>,
-    )>,
-);
+#[derive(Clone, Debug)]
+pub struct CommitmentOpening<Challenge, Commitment, Domain> {
+    /// Commitment whose matrices are opened, in commitment order.
+    pub commitment: Commitment,
+    /// Claims for each matrix, in the order supplied to `commit`.
+    pub matrices: Vec<MatrixOpening<Challenge, Domain>>,
+}
+
+/// Opening points and claimed column evaluations for one matrix.
+#[derive(Clone, Debug)]
+pub struct MatrixOpening<Challenge, Domain> {
+    pub domain: Domain,
+    pub points: Vec<PointOpening<Challenge>>,
+}
+
+/// Claimed evaluations of every column at one point, in column order.
+#[derive(Clone, Debug)]
+pub struct PointOpening<Challenge> {
+    pub point: Challenge,
+    pub values: Vec<Challenge>,
+}
+
+/// Points to open for each matrix in one commitment.
+///
+/// Requests, matrices and points retain caller order in [`OpenedValues`].
+/// The prover data is borrowed; point vectors are moved without copying.
+#[derive(Debug)]
+pub struct OpeningRequest<'a, ProverData, Challenge> {
+    pub prover_data: &'a ProverData,
+    pub points: Vec<Vec<Challenge>>,
+}
+
+impl<ProverData, Challenge: Clone> Clone for OpeningRequest<'_, ProverData, Challenge> {
+    fn clone(&self) -> Self {
+        Self {
+            prover_data: self.prover_data,
+            points: self.points.clone(),
+        }
+    }
+}
+
+impl<'a, ProverData, Challenge> From<(&'a ProverData, Vec<Vec<Challenge>>)>
+    for OpeningRequest<'a, ProverData, Challenge>
+{
+    fn from((prover_data, points): (&'a ProverData, Vec<Vec<Challenge>>)) -> Self {
+        Self {
+            prover_data,
+            points,
+        }
+    }
+}
+
+impl<Challenge> From<(Challenge, Vec<Challenge>)> for PointOpening<Challenge> {
+    fn from((point, values): (Challenge, Vec<Challenge>)) -> Self {
+        Self { point, values }
+    }
+}
+
+impl<Challenge, Domain> From<(Domain, Vec<(Challenge, Vec<Challenge>)>)>
+    for MatrixOpening<Challenge, Domain>
+{
+    fn from((domain, points): (Domain, Vec<(Challenge, Vec<Challenge>)>)) -> Self {
+        Self {
+            domain,
+            points: points.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl<Challenge, Commitment, Domain>
+    From<(Commitment, Vec<(Domain, Vec<(Challenge, Vec<Challenge>)>)>)>
+    for CommitmentOpening<Challenge, Commitment, Domain>
+{
+    fn from(
+        (commitment, matrices): (Commitment, Vec<(Domain, Vec<(Challenge, Vec<Challenge>)>)>),
+    ) -> Self {
+        Self {
+            commitment,
+            matrices: matrices.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+/// Compatibility name for the named verification claim.
+pub type CommitmentWithOpeningPoints<Challenge, Commitment, Domain> =
+    CommitmentOpening<Challenge, Commitment, Domain>;
 
 pub type OpenedValues<F> = Vec<OpenedValuesForRound<F>>;
 pub type OpenedValuesForRound<F> = Vec<OpenedValuesForMatrix<F>>;

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -11,7 +11,10 @@ use p3_util::log2_strict_usize;
 use p3_util::zip_eq::zip_eq;
 use serde::{Deserialize, Serialize};
 
-use crate::{OpenedValues, Pcs, PolynomialSpace};
+use crate::{
+    CommitmentOpening, MatrixOpening, OpenedValues, OpeningRequest, Pcs, PointOpening,
+    PolynomialSpace, UnivariateStarkPcs,
+};
 
 /// A trivial PCS: its commitment is simply the coefficients of each poly.
 #[derive(Clone, Debug)]
@@ -48,19 +51,13 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = Vec<Vec<Val>>;
     type ProverData = Vec<RowMajorMatrix<Val>>;
-    type EvaluationsOnDomain<'a> = Dft::Evaluations;
     type Proof = ();
     type Error = ();
-    const ZK: bool = false;
 
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
         // This panics if (and only if) `degree` is not a power of 2 or `degree`
         // > `1 << Val::TWO_ADICITY`.
         TwoAdicMultiplicativeCoset::new(Val::ONE, log2_strict_usize(degree)).unwrap()
-    }
-
-    fn log_max_lde_height(&self) -> usize {
-        Val::TWO_ADICITY
     }
 
     fn commit(
@@ -91,6 +88,90 @@ where
             coeffs.clone().into_iter().map(|m| m.values).collect(),
             coeffs,
         )
+    }
+
+    fn open(
+        &self,
+        // For each round,
+        rounds: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
+        _challenger: &mut Challenger,
+    ) -> (OpenedValues<Challenge>, Self::Proof) {
+        (
+            rounds
+                .into_iter()
+                .map(
+                    |OpeningRequest {
+                         prover_data: coeffs_for_round,
+                         points: points_for_round,
+                     }| {
+                        // ensure that each matrix corresponds to a set of opening points
+                        debug_assert_eq!(coeffs_for_round.len(), points_for_round.len());
+                        coeffs_for_round
+                            .iter()
+                            .zip(points_for_round)
+                            .map(|(coeffs_for_mat, points_for_mat)| {
+                                points_for_mat
+                                    .into_iter()
+                                    .map(|pt| eval_coeffs_at_pt(coeffs_for_mat, pt))
+                                    .collect()
+                            })
+                            .collect()
+                    },
+                )
+                .collect(),
+            (),
+        )
+    }
+
+    // This is a testing function, so we allow panics for convenience.
+    #[allow(clippy::panic_in_result_fn)]
+    fn verify(
+        &self,
+        // For each round:
+        rounds: Vec<CommitmentOpening<Challenge, Self::Commitment, Self::Domain>>,
+        _proof: &Self::Proof,
+        _challenger: &mut Challenger,
+    ) -> Result<(), Self::Error> {
+        for CommitmentOpening {
+            commitment: comm,
+            matrices: round_opening,
+        } in rounds
+        {
+            for (
+                coeff_vec,
+                MatrixOpening {
+                    domain,
+                    points: points_and_values,
+                },
+            ) in zip_eq(comm, round_opening, ())?
+            {
+                let width = coeff_vec.len() / domain.size();
+                assert_eq!(width * domain.size(), coeff_vec.len());
+                let coeffs = RowMajorMatrix::new(coeff_vec, width);
+                for PointOpening { point: pt, values } in points_and_values {
+                    assert_eq!(eval_coeffs_at_pt(&coeffs, pt), values);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<Val, Dft, Challenge, Challenger> UnivariateStarkPcs<Challenge, Challenger>
+    for TrivialPcs<Val, Dft>
+where
+    Val: TwoAdicField,
+    Challenge: ExtensionField<Val>,
+    Challenger: CanSample<Challenge>,
+    Dft: TwoAdicSubgroupDft<Val>,
+    Vec<Vec<Val>>: Serialize + for<'de> Deserialize<'de>,
+{
+    type EvaluationsOnDomain<'a> = Dft::Evaluations;
+
+    const ZK: bool = false;
+
+    fn log_max_lde_height(&self) -> usize {
+        Val::TWO_ADICITY
     }
 
     fn commit_quotient(
@@ -136,75 +217,5 @@ where
             Val::ZERO,
         );
         self.dft.coset_dft_batch(coeffs, domain.shift())
-    }
-
-    fn open(
-        &self,
-        // For each round,
-        rounds: Vec<(
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // points to open
-                Vec<Challenge>,
-            >,
-        )>,
-        _challenger: &mut Challenger,
-    ) -> (OpenedValues<Challenge>, Self::Proof) {
-        (
-            rounds
-                .into_iter()
-                .map(|(coeffs_for_round, points_for_round)| {
-                    // ensure that each matrix corresponds to a set of opening points
-                    debug_assert_eq!(coeffs_for_round.len(), points_for_round.len());
-                    coeffs_for_round
-                        .iter()
-                        .zip(points_for_round)
-                        .map(|(coeffs_for_mat, points_for_mat)| {
-                            points_for_mat
-                                .into_iter()
-                                .map(|pt| eval_coeffs_at_pt(coeffs_for_mat, pt))
-                                .collect()
-                        })
-                        .collect()
-                })
-                .collect(),
-            (),
-        )
-    }
-
-    // This is a testing function, so we allow panics for convenience.
-    #[allow(clippy::panic_in_result_fn)]
-    fn verify(
-        &self,
-        // For each round:
-        rounds: Vec<(
-            Self::Commitment,
-            // for each matrix:
-            Vec<(
-                // its domain,
-                Self::Domain,
-                // for each point:
-                Vec<(
-                    Challenge,
-                    // values at this point
-                    Vec<Challenge>,
-                )>,
-            )>,
-        )>,
-        _proof: &Self::Proof,
-        _challenger: &mut Challenger,
-    ) -> Result<(), Self::Error> {
-        for (comm, round_opening) in rounds {
-            for (coeff_vec, (domain, points_and_values)) in zip_eq(comm, round_opening, ())? {
-                let width = coeff_vec.len() / domain.size();
-                assert_eq!(width * domain.size(), coeff_vec.len());
-                let coeffs = RowMajorMatrix::new(coeff_vec, width);
-                for (pt, values) in points_and_values {
-                    assert_eq!(eval_coeffs_at_pt(&coeffs, pt), values);
-                }
-            }
-        }
-        Ok(())
     }
 }

--- a/commit/tests/core_pcs.rs
+++ b/commit/tests/core_pcs.rs
@@ -1,0 +1,156 @@
+//! A PCS can serve generic opening clients without implementing STARK capabilities.
+use p3_baby_bear::BabyBear as F;
+use p3_commit::{
+    CommitmentOpening, MatrixOpening, OpenedValues, OpeningRequest, Pcs, PointOpening,
+};
+use p3_field::coset::TwoAdicMultiplicativeCoset;
+use p3_field::{Field, PrimeCharacteristicRing};
+use p3_matrix::dense::RowMajorMatrix;
+
+struct LinearPcs;
+type Domain = TwoAdicMultiplicativeCoset<F>;
+
+// Deliberately no UnivariateStarkPcs implementation, LDE support or hiding policy.
+impl Pcs<F, ()> for LinearPcs {
+    type Domain = Domain;
+    type Commitment = Vec<Vec<F>>;
+    type ProverData = Vec<Vec<F>>;
+    type Proof = ();
+    type Error = ();
+
+    fn natural_domain_for_degree(&self, degree: usize) -> Domain {
+        assert_eq!(degree, 2);
+        Domain::new(F::ONE, 1).unwrap()
+    }
+
+    fn commit(
+        &self,
+        evaluations: impl IntoIterator<Item = (Domain, RowMajorMatrix<F>)>,
+    ) -> (Self::Commitment, Self::ProverData) {
+        let data: Vec<_> = evaluations
+            .into_iter()
+            .map(|(_, matrix)| matrix.values)
+            .collect();
+        (data.clone(), data)
+    }
+
+    fn open(
+        &self,
+        requests: Vec<OpeningRequest<'_, Self::ProverData, F>>,
+        _: &mut (),
+    ) -> (OpenedValues<F>, ()) {
+        (
+            requests
+                .into_iter()
+                .map(|request| {
+                    request
+                        .prover_data
+                        .iter()
+                        .zip(request.points)
+                        .map(|(evals, points)| {
+                            points
+                                .into_iter()
+                                .map(|point| evaluate(evals, point))
+                                .collect()
+                        })
+                        .collect()
+                })
+                .collect(),
+            (),
+        )
+    }
+
+    fn verify(
+        &self,
+        claims: Vec<CommitmentOpening<F, Self::Commitment, Domain>>,
+        _: &(),
+        _: &mut (),
+    ) -> Result<(), ()> {
+        for claim in claims {
+            if claim.commitment.len() != claim.matrices.len() {
+                return Err(());
+            }
+            for (evals, matrix) in claim.commitment.iter().zip(claim.matrices) {
+                for opening in matrix.points {
+                    if evaluate(evals, opening.point) != opening.values {
+                        return Err(());
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn evaluate(evals: &[F], point: F) -> Vec<F> {
+    let half = F::TWO.inverse();
+    vec![(evals[0] + evals[1]) * half + point * (evals[0] - evals[1]) * half]
+}
+
+#[test]
+fn core_only_pcs_preserves_round_matrix_and_point_order() {
+    let pcs = LinearPcs;
+    let domain = pcs.natural_domain_for_degree(2);
+    // p(x) = 3 + 2x, q(x) = 7 - x, r(x) = 11 + 4x.
+    let matrix = |a: u8, b: F| RowMajorMatrix::new(vec![F::from_u8(a) + b, F::from_u8(a) - b], 1);
+    let (first, first_data) =
+        pcs.commit([(domain, matrix(3, F::TWO)), (domain, matrix(7, -F::ONE))]);
+    let (second, second_data) = pcs.commit([(domain, matrix(11, F::from_u8(4)))]);
+    let x = F::from_u8(5);
+    let y = F::from_u8(9);
+    let (values, proof) = pcs.open(
+        vec![
+            OpeningRequest {
+                prover_data: &first_data,
+                points: vec![vec![y, x], vec![x]],
+            },
+            OpeningRequest {
+                prover_data: &second_data,
+                points: vec![vec![x, y]],
+            },
+        ],
+        &mut (),
+    );
+    assert_eq!(
+        values,
+        vec![
+            vec![
+                vec![vec![F::from_u8(21)], vec![F::from_u8(13)]],
+                vec![vec![F::TWO]]
+            ],
+            vec![vec![vec![F::from_u8(31)], vec![F::from_u8(47)]]]
+        ]
+    );
+    let point = |point, value| PointOpening {
+        point,
+        values: vec![F::from_u8(value)],
+    };
+    let mut claims = vec![
+        CommitmentOpening {
+            commitment: first,
+            matrices: vec![
+                MatrixOpening {
+                    domain,
+                    points: vec![point(y, 21), point(x, 13)],
+                },
+                MatrixOpening {
+                    domain,
+                    points: vec![point(x, 2)],
+                },
+            ],
+        },
+        CommitmentOpening {
+            commitment: second,
+            matrices: vec![MatrixOpening {
+                domain,
+                points: vec![point(x, 31), point(y, 47)],
+            }],
+        },
+    ];
+    assert_eq!(pcs.verify(claims.clone(), &proof, &mut ()), Ok(()));
+    claims[0].matrices.swap(0, 1);
+    assert_eq!(pcs.verify(claims.clone(), &proof, &mut ()), Err(()));
+    claims[0].matrices.swap(0, 1);
+    claims[0].matrices[0].points[0].values[0] = F::from_u8(13);
+    assert_eq!(pcs.verify(claims, &proof, &mut ()), Err(()));
+}

--- a/examples/examples/pcs_comparison.rs
+++ b/examples/examples/pcs_comparison.rs
@@ -242,7 +242,13 @@ where
 
     let t = Instant::now();
     let opening_points = domains.iter().map(|_| vec![zeta]).collect();
-    let (openings, proof) = pcs.open(vec![(&prover_data, opening_points)], &mut prover_challenger);
+    let (openings, proof) = pcs.open(
+        vec![p3_commit::OpeningRequest {
+            prover_data: &prover_data,
+            points: opening_points,
+        }],
+        &mut prover_challenger,
+    );
     let open_ms = t.elapsed().as_millis();
     let values: Vec<_> = openings[0]
         .iter()
@@ -264,7 +270,7 @@ where
     let verify_us = median_verify_us(|| {
         let mut challenger = verifier_challenger.clone();
         pcs.verify(
-            vec![(commit.clone(), matrices_with_openings.clone())],
+            vec![(commit.clone(), matrices_with_openings.clone()).into()],
             &proof,
             &mut challenger,
         )

--- a/fri/src/hiding_pcs.rs
+++ b/fri/src/hiding_pcs.rs
@@ -2,7 +2,9 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, OpenedValues, Pcs, PolynomialSpace};
+use p3_commit::{
+    CommitmentOpening, Mmcs, OpenedValues, OpeningRequest, Pcs, PolynomialSpace, UnivariateStarkPcs,
+};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{ExtensionField, PrimeField64, TwoAdicField, batch_multiplicative_inverse};
@@ -104,26 +106,19 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
     type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
-    type EvaluationsOnDomain<'a> =
-        HorizontallyTruncated<Val, RowIndexMappedView<BitReversalPerm, RowMajorMatrixCow<'a, Val>>>;
+
     /// The first item contains the openings of the random polynomials added by this wrapper.
     /// The second item is the usual FRI proof.
     type Proof = (
         OpenedValues<Challenge>,
         FriProof<Challenge, FriMmcs, Val, Vec<BatchMultiOpening<Val, InputMmcs>>>,
     );
-    type Error = FriError<FriMmcs::Error, InputMmcs::Error>;
 
-    const ZK: bool = true;
+    type Error = FriError<FriMmcs::Error, InputMmcs::Error>;
 
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
         <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
             &self.inner, degree)
-    }
-
-    fn log_max_lde_height(&self) -> usize {
-        <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<Challenge, Challenger>>::log_max_lde_height(
-            &self.inner)
     }
 
     fn commit(
@@ -152,6 +147,103 @@ where
             });
 
         Pcs::<Challenge, Challenger>::commit(&self.inner, randomized_evaluations)
+    }
+
+    fn open(
+        &self,
+        // For each round,
+        rounds: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
+        challenger: &mut Challenger,
+    ) -> (OpenedValues<Challenge>, Self::Proof) {
+        self.open_with_preprocessing(rounds, challenger, None)
+    }
+
+    fn verify(
+        &self,
+        // For each round:
+        mut rounds: Vec<CommitmentOpening<Challenge, Self::Commitment, Self::Domain>>,
+        proof: &Self::Proof,
+        challenger: &mut Challenger,
+    ) -> Result<(), Self::Error> {
+        let (opened_values_for_rand_cws, inner_proof) = proof;
+
+        // Proving split each opening into a public half and a hidden half.
+        // - The public half lives here.
+        // - The hidden half travels beside the proof as random codewords.
+        //
+        // Re-joining them gives the inner verifier the full openings it committed to.
+        //
+        //     public (per point):  [v_0, .., v_k]
+        //     hidden (per point):                [r_0, .., r_m]
+        //     merged:              [v_0, .., v_k,  r_0, .., r_m]
+        //
+        // Invariant: the halves nest identically by round, then matrix, then point.
+        // Each level's length is checked before merging.
+        // A mismatch returns a precise error instead of being truncated silently.
+
+        // Level 1: one set of random openings per round.
+        if opened_values_for_rand_cws.len() != rounds.len() {
+            return Err(FriError::HidingRandomOpeningRoundCountMismatch {
+                expected: rounds.len(),
+                got: opened_values_for_rand_cws.len(),
+            });
+        }
+        for (round_idx, (round, rand_round)) in rounds
+            .iter_mut()
+            .zip(opened_values_for_rand_cws.iter())
+            .enumerate()
+        {
+            // Level 2: one set per matrix in this round.
+            if rand_round.len() != round.matrices.len() {
+                return Err(FriError::HidingRandomOpeningMatrixCountMismatch {
+                    round: round_idx,
+                    expected: round.matrices.len(),
+                    got: rand_round.len(),
+                });
+            }
+            for (matrix_idx, (mat, rand_mat)) in
+                round.matrices.iter_mut().zip(rand_round.iter()).enumerate()
+            {
+                // Level 3: one set per opening point of this matrix.
+                if rand_mat.len() != mat.points.len() {
+                    return Err(FriError::HidingRandomOpeningPointCountMismatch {
+                        round: round_idx,
+                        matrix: matrix_idx,
+                        expected: mat.points.len(),
+                        got: rand_mat.len(),
+                    });
+                }
+                // Shapes agree: append the hidden values onto the public ones.
+                for (point, rand_point) in mat.points.iter_mut().zip(rand_mat.iter()) {
+                    point.values.extend(rand_point);
+                }
+            }
+        }
+        self.inner.verify(rounds, inner_proof, challenger)
+    }
+}
+
+impl<Val, Dft, InputMmcs, FriMmcs, Challenge, Challenger, R>
+    UnivariateStarkPcs<Challenge, Challenger> for HidingFriPcs<Val, Dft, InputMmcs, FriMmcs, R>
+where
+    Val: TwoAdicField + PrimeField64,
+    StandardUniform: Distribution<Val>,
+    Dft: TwoAdicSubgroupDft<Val>,
+    InputMmcs: Mmcs<Val, MultiProof: Sync, Error: Sync>,
+    FriMmcs: Mmcs<Challenge>,
+    Challenge: TwoAdicField + ExtensionField<Val>,
+    Challenger:
+        FieldChallenger<Val> + CanObserve<FriMmcs::Commitment> + GrindingChallenger<Witness = Val>,
+    R: CryptoRng + Send + Sync,
+{
+    type EvaluationsOnDomain<'a> =
+        HorizontallyTruncated<Val, RowIndexMappedView<BitReversalPerm, RowMajorMatrixCow<'a, Val>>>;
+
+    const ZK: bool = true;
+
+    fn log_max_lde_height(&self) -> usize {
+        <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as UnivariateStarkPcs<Challenge, Challenger>>::log_max_lde_height(
+            &self.inner)
     }
 
     fn commit_preprocessing(
@@ -284,7 +376,7 @@ where
     }
 
     fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
-        Pcs::<Challenge, Challenger>::commit_ldes(&self.inner, ldes)
+        UnivariateStarkPcs::<Challenge, Challenger>::commit_ldes(&self.inner, ldes)
     }
 
     fn get_evaluations_on_domain<'a>(
@@ -293,12 +385,11 @@ where
         idx: usize,
         domain: Self::Domain,
     ) -> Self::EvaluationsOnDomain<'a> {
-        let inner_evals = <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<
-            Challenge,
-            Challenger,
-        >>::get_evaluations_on_domain(
-            &self.inner, prover_data, idx, domain
-        );
+        let inner_evals =
+            <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as UnivariateStarkPcs<
+                Challenge,
+                Challenger,
+            >>::get_evaluations_on_domain(&self.inner, prover_data, idx, domain);
         let inner_width = inner_evals.width();
         // Truncate off the columns representing random codewords we added in `commit` above.
         // The unwrap is safe as inner_width - self.num_random_codewords <= inner_width.
@@ -311,50 +402,26 @@ where
         idx: usize,
         domain: Self::Domain,
     ) -> Self::EvaluationsOnDomain<'a> {
-        let inner_evals = <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as Pcs<
-            Challenge,
-            Challenger,
-        >>::get_evaluations_on_domain(
-            &self.inner, prover_data, idx, domain
-        );
+        let inner_evals =
+            <TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> as UnivariateStarkPcs<
+                Challenge,
+                Challenger,
+            >>::get_evaluations_on_domain(&self.inner, prover_data, idx, domain);
         let inner_width = inner_evals.width();
 
         HorizontallyTruncated::new(inner_evals, inner_width).unwrap()
     }
 
-    fn open(
-        &self,
-        // For each round,
-        rounds: Vec<(
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // points to open
-                Vec<Challenge>,
-            >,
-        )>,
-        challenger: &mut Challenger,
-    ) -> (OpenedValues<Challenge>, Self::Proof) {
-        self.open_with_preprocessing(rounds, challenger, false)
-    }
-
     fn open_with_preprocessing(
         &self,
         // For each round,
-        rounds: Vec<(
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // points to open
-                Vec<Challenge>,
-            >,
-        )>,
+        rounds: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
         challenger: &mut Challenger,
-        is_preprocessing: bool,
+        preprocessed_commitment: Option<usize>,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         let (mut inner_opened_values, inner_proof) =
             self.inner
-                .open_with_preprocessing(rounds, challenger, is_preprocessing);
+                .open_with_preprocessing(rounds, challenger, preprocessed_commitment);
         // inner_opened_values includes opened values for the random codewords. Those should be
         // hidden from our caller, so we split them off and store them in the proof.
         let opened_values_rand = inner_opened_values
@@ -367,12 +434,11 @@ where
                         opened_values_for_mat
                             .iter_mut()
                             .map(|opened_values_for_point| {
-                                let num_random_codewords =
-                                    if is_preprocessing && idx == <Self as Pcs<Challenge, Challenger>>::PREPROCESSED_TRACE_IDX {
-                                        0
-                                    } else {
-                                        self.num_random_codewords
-                                    };
+                                let num_random_codewords = if preprocessed_commitment == Some(idx) {
+                                    0
+                                } else {
+                                    self.num_random_codewords
+                                };
                                 let split = opened_values_for_point.len() - num_random_codewords;
                                 opened_values_for_point.drain(split..).collect()
                             })
@@ -383,84 +449,6 @@ where
             .collect();
 
         (inner_opened_values, (opened_values_rand, inner_proof))
-    }
-
-    fn verify(
-        &self,
-        // For each round:
-        mut rounds: Vec<(
-            Self::Commitment,
-            // for each matrix:
-            Vec<(
-                // its domain,
-                Self::Domain,
-                // for each point:
-                Vec<(
-                    // the point,
-                    Challenge,
-                    // values at the point
-                    Vec<Challenge>,
-                )>,
-            )>,
-        )>,
-        proof: &Self::Proof,
-        challenger: &mut Challenger,
-    ) -> Result<(), Self::Error> {
-        let (opened_values_for_rand_cws, inner_proof) = proof;
-
-        // Proving split each opening into a public half and a hidden half.
-        // - The public half lives here.
-        // - The hidden half travels beside the proof as random codewords.
-        //
-        // Re-joining them gives the inner verifier the full openings it committed to.
-        //
-        //     public (per point):  [v_0, .., v_k]
-        //     hidden (per point):                [r_0, .., r_m]
-        //     merged:              [v_0, .., v_k,  r_0, .., r_m]
-        //
-        // Invariant: the halves nest identically by round, then matrix, then point.
-        // Each level's length is checked before merging.
-        // A mismatch returns a precise error instead of being truncated silently.
-
-        // Level 1: one set of random openings per round.
-        if opened_values_for_rand_cws.len() != rounds.len() {
-            return Err(FriError::HidingRandomOpeningRoundCountMismatch {
-                expected: rounds.len(),
-                got: opened_values_for_rand_cws.len(),
-            });
-        }
-        for (round_idx, (round, rand_round)) in rounds
-            .iter_mut()
-            .zip(opened_values_for_rand_cws.iter())
-            .enumerate()
-        {
-            // Level 2: one set per matrix in this round.
-            if rand_round.len() != round.1.len() {
-                return Err(FriError::HidingRandomOpeningMatrixCountMismatch {
-                    round: round_idx,
-                    expected: round.1.len(),
-                    got: rand_round.len(),
-                });
-            }
-            for (matrix_idx, (mat, rand_mat)) in
-                round.1.iter_mut().zip(rand_round.iter()).enumerate()
-            {
-                // Level 3: one set per opening point of this matrix.
-                if rand_mat.len() != mat.1.len() {
-                    return Err(FriError::HidingRandomOpeningPointCountMismatch {
-                        round: round_idx,
-                        matrix: matrix_idx,
-                        expected: mat.1.len(),
-                        got: rand_mat.len(),
-                    });
-                }
-                // Shapes agree: append the hidden values onto the public ones.
-                for (point, rand_point) in mat.1.iter_mut().zip(rand_mat.iter()) {
-                    point.1.extend(rand_point);
-                }
-            }
-        }
-        self.inner.verify(rounds, inner_proof, challenger)
     }
 
     fn get_opt_randomization_poly_commitment(
@@ -491,7 +479,7 @@ where
         trace_domain: Self::Domain,
         quotient_domain: Self::Domain,
     ) -> p3_commit::PeriodicLdeTable<Val> {
-        Pcs::<Challenge, Challenger>::build_periodic_lde_table(
+        UnivariateStarkPcs::<Challenge, Challenger>::build_periodic_lde_table(
             &self.inner,
             periodic_cols,
             trace_domain,
@@ -551,7 +539,6 @@ mod tests {
     type MyPcs = HidingFriPcs<Val, Dft, ValMmcs, ChallengeMmcs, StdRng>;
     /// Same wrapper, left generic over the DFT backend.
     type HidingPcs<D> = HidingFriPcs<Val, D, ValMmcs, ChallengeMmcs, StdRng>;
-
     type Commitment = <ValMmcs as Mmcs<Val>>::Commitment;
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     /// Public opening claims (the `rounds` argument): per matrix, its domain and
@@ -627,8 +614,13 @@ mod tests {
         let mut p_challenger = Challenger::new(perm.clone());
         p_challenger.observe(&commitment);
         let zeta: Challenge = p_challenger.sample_algebra_element();
-        let (opened_values, proof) =
-            pcs.open(vec![(&prover_data, vec![vec![zeta]])], &mut p_challenger);
+        let (opened_values, proof) = pcs.open(
+            vec![OpeningRequest {
+                prover_data: &prover_data,
+                points: vec![vec![zeta]],
+            }],
+            &mut p_challenger,
+        );
 
         // Verifier: replay up to the point sample so a valid proof must pass.
         let mut v_challenger = Challenger::new(perm);
@@ -655,7 +647,70 @@ mod tests {
         proof: &Proof,
         challenger: &mut Challenger,
     ) -> Result<(), TestError> {
-        <MyPcs as Pcs<Challenge, Challenger>>::verify(pcs, claims, proof, challenger)
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            pcs,
+            claims.into_iter().map(Into::into).collect(),
+            proof,
+            challenger,
+        )
+    }
+
+    #[test]
+    fn preprocessing_request_can_precede_hidden_requests() {
+        let (pcs, _, _, mut prover_challenger) = make_fixture();
+        let mut verifier_challenger = prover_challenger.clone();
+        let mut rng = SmallRng::seed_from_u64(17);
+        let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 16);
+        let (pre_commit, pre_data) =
+            <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::commit_preprocessing(
+                &pcs,
+                [(domain, RowMajorMatrix::<Val>::rand(&mut rng, 8, 3))],
+            );
+        let (trace_commit, trace_data) = <MyPcs as Pcs<Challenge, Challenger>>::commit(
+            &pcs,
+            [(domain, RowMajorMatrix::<Val>::rand(&mut rng, 8, 4))],
+        );
+        for challenger in [&mut prover_challenger, &mut verifier_challenger] {
+            challenger.observe(&pre_commit);
+            challenger.observe(&trace_commit);
+        }
+        let zeta: Challenge = prover_challenger.sample_algebra_element();
+        assert_eq!(zeta, verifier_challenger.sample_algebra_element());
+        let (values, proof) = pcs.open_with_preprocessing(
+            vec![
+                OpeningRequest {
+                    prover_data: &pre_data,
+                    points: vec![vec![zeta]],
+                },
+                OpeningRequest {
+                    prover_data: &trace_data,
+                    points: vec![vec![zeta]],
+                },
+            ],
+            &mut prover_challenger,
+            Some(0),
+        );
+        assert_eq!(values[0][0][0].len(), 3);
+        assert_eq!(values[1][0][0].len(), 4);
+        assert!(proof.0[0][0][0].is_empty());
+        assert_eq!(proof.0[1][0][0].len(), NUM_RANDOM_CODEWORDS);
+        pcs.verify(
+            vec![
+                (
+                    pre_commit,
+                    vec![(domain, vec![(zeta, values[0][0][0].clone())])],
+                )
+                    .into(),
+                (
+                    trace_commit,
+                    vec![(domain, vec![(zeta, values[1][0][0].clone())])],
+                )
+                    .into(),
+            ],
+            &proof,
+            &mut verifier_challenger,
+        )
+        .unwrap();
     }
 
     #[test]
@@ -882,7 +937,7 @@ mod tests {
                 .collect_vec();
 
             let expected = expected_quotient_ldes(dft, &domains, &mats);
-            let fused = Pcs::<Challenge, Challenger>::get_quotient_ldes(
+            let fused = UnivariateStarkPcs::<Challenge, Challenger>::get_quotient_ldes(
                 &pcs,
                 domains.iter().copied().zip(mats).collect_vec(),
                 num_chunks,

--- a/fri/src/prover.rs
+++ b/fri/src/prover.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::Mmcs;
+use p3_commit::{Mmcs, OpeningRequest};
 use p3_dft::{Radix2DFTSmallBatch, TwoAdicSubgroupDft};
 use p3_field::{ExtensionField, Field, PrimeField64, TwoAdicField};
 use p3_matrix::dense::RowMajorMatrix;
@@ -453,18 +453,22 @@ where
     // as appropriate.
     prover_data_with_opening_points
         .iter()
-        .map(|(data, _)| {
-            let log_max_height = log2_strict_usize(mmcs.get_max_height(data));
-            let bits_reduced = log_global_max_height - log_max_height;
-            // If a matrix is smaller than global max height, we roll it into
-            // fri in a later round.
-            let reduced_indices: Vec<usize> =
-                indices.iter().map(|&index| index >> bits_reduced).collect();
-            let (opened_values, opening_proof) = mmcs.open_multi_batch(&reduced_indices, data);
-            BatchMultiOpening {
-                opened_values,
-                opening_proof,
-            }
-        })
+        .map(
+            |OpeningRequest {
+                 prover_data: data, ..
+             }| {
+                let log_max_height = log2_strict_usize(mmcs.get_max_height(data));
+                let bits_reduced = log_global_max_height - log_max_height;
+                // If a matrix is smaller than global max height, we roll it into
+                // fri in a later round.
+                let reduced_indices: Vec<usize> =
+                    indices.iter().map(|&index| index >> bits_reduced).collect();
+                let (opened_values, opening_proof) = mmcs.open_multi_batch(&reduced_indices, data);
+                BatchMultiOpening {
+                    opened_values,
+                    opening_proof,
+                }
+            },
+        )
         .collect()
 }

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -20,7 +20,10 @@ use core::marker::PhantomData;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Mmcs, OpenedValues, Pcs, PeriodicLdeTable};
+use p3_commit::{
+    CommitmentOpening, MatrixOpening, Mmcs, OpenedValues, OpeningRequest, Pcs, PeriodicLdeTable,
+    PointOpening, UnivariateStarkPcs,
+};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
@@ -76,15 +79,7 @@ impl<Val, Dft, InputMmcs, FriMmcs> TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
 
 /// The Prover Data associated to a commitment to a collection of matrices
 /// and a list of points to open each matrix at.
-pub type ProverDataWithOpeningPoints<'a, EF, ProverData> = (
-    // The matrices and auxiliary prover data
-    &'a ProverData,
-    // for each matrix,
-    Vec<
-        // points to open
-        Vec<EF>,
-    >,
-);
+pub type ProverDataWithOpeningPoints<'a, EF, ProverData> = OpeningRequest<'a, ProverData, EF>;
 
 // Re-exported so `p3_fri::CommitmentWithOpeningPoints` keeps naming the shape this PCS
 // verifies against; it is defined in `p3-commit` alongside `Pcs` so crates that build an
@@ -298,10 +293,8 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = InputMmcs::Commitment;
     type ProverData = InputMmcs::ProverData<RowMajorMatrix<Val>>;
-    type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
     type Proof = FriProof<Challenge, FriMmcs, Val, Vec<BatchMultiOpening<Val, InputMmcs>>>;
     type Error = FriError<FriMmcs::Error, InputMmcs::Error>;
-    const ZK: bool = false;
 
     /// Get the unique subgroup `H` of size `|H| = degree`.
     ///
@@ -309,10 +302,6 @@ where
     /// This function will panic if `degree` is not a power of 2 or `degree > (1 << Val::TWO_ADICITY)`.
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
         TwoAdicMultiplicativeCoset::new(Val::ONE, log2_strict_usize(degree)).unwrap()
-    }
-
-    fn log_max_lde_height(&self) -> usize {
-        Val::TWO_ADICITY
     }
 
     /// Commit to a collection of evaluation matrices.
@@ -349,86 +338,6 @@ where
         self.mmcs.commit(ldes)
     }
 
-    fn get_quotient_ldes(
-        &self,
-        evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
-        _num_chunks: usize,
-    ) -> Vec<RowMajorMatrix<Val>> {
-        evaluations
-            .into_iter()
-            .map(|(domain, evals)| {
-                assert_eq!(domain.size(), evals.height());
-                // coset_lde_batch converts from evaluations over `xH` to evaluations over `shift * x * K`.
-                // Hence, letting `shift = g/x` the output will be evaluations over `gK` as desired.
-                // When `x = g`, we could just use the standard LDE but currently this doesn't seem
-                // to give a meaningful performance boost.
-                let shift = Val::GENERATOR / domain.shift();
-                // Compute the LDE with blowup factor fri.log_blowup.
-                // We bit reverse as this is required by our implementation of the FRI protocol.
-                self.dft
-                    .coset_lde_batch(evals, self.fri.log_blowup, shift)
-                    .bit_reverse_rows()
-                    .to_row_major_matrix()
-            })
-            .collect()
-    }
-
-    fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
-        // Opening assumes every committed matrix is an LDE at `self.fri.log_blowup` and recovers the
-        // underlying polynomial degree as `height >> log_blowup`. A matrix shorter than the blowup
-        // factor would silently yield a zero-height degree and a malformed proof, so reject it here.
-        let min_height = 1 << self.fri.log_blowup;
-        for lde in &ldes {
-            assert!(
-                lde.height() >= min_height,
-                "committed LDE height {} is smaller than the blowup factor {min_height}",
-                lde.height()
-            );
-        }
-        self.mmcs.commit(ldes)
-    }
-
-    /// Given the evaluations on a domain `gH`, return the evaluations on a different domain `g'K`.
-    ///
-    /// Arguments:
-    /// - `prover_data`: The prover data containing all committed evaluation matrices.
-    /// - `idx`: The index of the matrix containing the evaluations we want. These evaluations
-    ///   are assumed to be over the coset `gH` where `g = Val::GENERATOR`.
-    /// - `domain`: The domain `g'K` on which to get evaluations on.
-    ///
-    /// When `g' = g` (i.e. `Val::GENERATOR`) and `K` is a subgroup of `H`, this is a simple
-    /// truncation of the bit-reversed LDE. Otherwise, we recover the polynomial coefficients
-    /// from the committed LDE and re-evaluate on the requested domain.
-    fn get_evaluations_on_domain<'a>(
-        &self,
-        prover_data: &'a Self::ProverData,
-        idx: usize,
-        domain: Self::Domain,
-    ) -> Self::EvaluationsOnDomain<'a> {
-        let lde = self.mmcs.get_matrices(prover_data)[idx];
-        if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
-            return lde.split_rows(domain.size()).0.as_cow().bit_reverse_rows();
-        }
-
-        // The committed LDE contains bit-reversed evaluations over `gH`.
-        // Un-bit-reverse, coset iDFT to recover coefficients, truncate to
-        // the original polynomial degree, then coset DFT onto the target domain.
-        let poly_height = lde.height() >> self.fri.log_blowup;
-        let lde_mat = lde.as_view().bit_reverse_rows().to_row_major_matrix();
-        let mut coeffs = self.dft.coset_idft_batch(lde_mat, Val::GENERATOR);
-        let width = coeffs.width();
-        coeffs.values.truncate(poly_height * width);
-        coeffs.values.resize(domain.size() * width, Val::ZERO);
-        let result = self
-            .dft
-            .coset_dft_batch(coeffs, domain.shift())
-            .bit_reverse_rows()
-            .to_row_major_matrix();
-        let result_width = result.width();
-
-        RowMajorMatrixCow::new(Cow::Owned(result.values), result_width).bit_reverse_rows()
-    }
-
     /// Open a batch of matrices at a collection of points.
     ///
     /// Returns the opened values along with a proof.
@@ -439,15 +348,7 @@ where
     fn open(
         &self,
         // For each multi-matrix commitment,
-        commitment_data_with_opening_points: Vec<(
-            // The matrices and auxiliary prover data
-            &Self::ProverData,
-            // for each matrix,
-            Vec<
-                // points to open
-                Vec<Challenge>,
-            >,
-        )>,
+        commitment_data_with_opening_points: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
         challenger: &mut Challenger,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         /*
@@ -491,20 +392,25 @@ where
         // We extract those matrices to be able to refer to them directly.
         let mats_and_points = commitment_data_with_opening_points
             .iter()
-            .map(|(data, points)| {
-                let mats = self
-                    .mmcs
-                    .get_matrices(data)
-                    .into_iter()
-                    .map(|m| m.as_view())
-                    .collect_vec();
-                debug_assert_eq!(
-                    mats.len(),
-                    points.len(),
-                    "each matrix should have a corresponding set of evaluation points"
-                );
-                (mats, points)
-            })
+            .map(
+                |OpeningRequest {
+                     prover_data: data,
+                     points,
+                 }| {
+                    let mats = self
+                        .mmcs
+                        .get_matrices(data)
+                        .into_iter()
+                        .map(|m| m.as_view())
+                        .collect_vec();
+                    debug_assert_eq!(
+                        mats.len(),
+                        points.len(),
+                        "each matrix should have a corresponding set of evaluation points"
+                    );
+                    (mats, points)
+                },
+            )
             .collect_vec();
 
         // Find the maximum height and the maximum width of matrices in the batch.
@@ -734,16 +640,19 @@ where
         &self,
         // For each commitment:
         commitments_with_opening_points: Vec<
-            CommitmentWithOpeningPoints<Challenge, Self::Commitment, Self::Domain>,
+            CommitmentOpening<Challenge, Self::Commitment, Self::Domain>,
         >,
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
         // Write all evaluations to challenger.
         // Need to ensure to do this in the same order as the prover.
-        for (_, round) in &commitments_with_opening_points {
-            for (_, mat) in round {
-                for (_, point) in mat {
+        for CommitmentOpening {
+            matrices: round, ..
+        } in &commitments_with_opening_points
+        {
+            for MatrixOpening { points: mat, .. } in round {
+                for PointOpening { values: point, .. } in mat {
                     challenger.observe_algebra_slice(point);
                 }
             }
@@ -761,6 +670,106 @@ where
         )?;
 
         Ok(())
+    }
+}
+
+impl<Val, Dft, InputMmcs, FriMmcs, Challenge, Challenger> UnivariateStarkPcs<Challenge, Challenger>
+    for TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs>
+where
+    Val: TwoAdicField + PrimeField64,
+    Dft: TwoAdicSubgroupDft<Val>,
+    InputMmcs: Mmcs<Val, MultiProof: Sync, Error: Sync>,
+    FriMmcs: Mmcs<Challenge>,
+    Challenge: ExtensionField<Val>,
+    Challenger:
+        FieldChallenger<Val> + CanObserve<FriMmcs::Commitment> + GrindingChallenger<Witness = Val>,
+{
+    type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
+
+    const ZK: bool = false;
+
+    fn log_max_lde_height(&self) -> usize {
+        Val::TWO_ADICITY
+    }
+
+    fn get_quotient_ldes(
+        &self,
+        evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
+        _num_chunks: usize,
+    ) -> Vec<RowMajorMatrix<Val>> {
+        evaluations
+            .into_iter()
+            .map(|(domain, evals)| {
+                assert_eq!(domain.size(), evals.height());
+                // coset_lde_batch converts from evaluations over `xH` to evaluations over `shift * x * K`.
+                // Hence, letting `shift = g/x` the output will be evaluations over `gK` as desired.
+                // When `x = g`, we could just use the standard LDE but currently this doesn't seem
+                // to give a meaningful performance boost.
+                let shift = Val::GENERATOR / domain.shift();
+                // Compute the LDE with blowup factor fri.log_blowup.
+                // We bit reverse as this is required by our implementation of the FRI protocol.
+                self.dft
+                    .coset_lde_batch(evals, self.fri.log_blowup, shift)
+                    .bit_reverse_rows()
+                    .to_row_major_matrix()
+            })
+            .collect()
+    }
+
+    fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
+        // Opening assumes every committed matrix is an LDE at `self.fri.log_blowup` and recovers the
+        // underlying polynomial degree as `height >> log_blowup`. A matrix shorter than the blowup
+        // factor would silently yield a zero-height degree and a malformed proof, so reject it here.
+        let min_height = 1 << self.fri.log_blowup;
+        for lde in &ldes {
+            assert!(
+                lde.height() >= min_height,
+                "committed LDE height {} is smaller than the blowup factor {min_height}",
+                lde.height()
+            );
+        }
+        self.mmcs.commit(ldes)
+    }
+
+    /// Given the evaluations on a domain `gH`, return the evaluations on a different domain `g'K`.
+    ///
+    /// Arguments:
+    /// - `prover_data`: The prover data containing all committed evaluation matrices.
+    /// - `idx`: The index of the matrix containing the evaluations we want. These evaluations
+    ///   are assumed to be over the coset `gH` where `g = Val::GENERATOR`.
+    /// - `domain`: The domain `g'K` on which to get evaluations on.
+    ///
+    /// When `g' = g` (i.e. `Val::GENERATOR`) and `K` is a subgroup of `H`, this is a simple
+    /// truncation of the bit-reversed LDE. Otherwise, we recover the polynomial coefficients
+    /// from the committed LDE and re-evaluate on the requested domain.
+    fn get_evaluations_on_domain<'a>(
+        &self,
+        prover_data: &'a Self::ProverData,
+        idx: usize,
+        domain: Self::Domain,
+    ) -> Self::EvaluationsOnDomain<'a> {
+        let lde = self.mmcs.get_matrices(prover_data)[idx];
+        if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
+            return lde.split_rows(domain.size()).0.as_cow().bit_reverse_rows();
+        }
+
+        // The committed LDE contains bit-reversed evaluations over `gH`.
+        // Un-bit-reverse, coset iDFT to recover coefficients, truncate to
+        // the original polynomial degree, then coset DFT onto the target domain.
+        let poly_height = lde.height() >> self.fri.log_blowup;
+        let lde_mat = lde.as_view().bit_reverse_rows().to_row_major_matrix();
+        let mut coeffs = self.dft.coset_idft_batch(lde_mat, Val::GENERATOR);
+        let width = coeffs.width();
+        coeffs.values.truncate(poly_height * width);
+        coeffs.values.resize(domain.size() * width, Val::ZERO);
+        let result = self
+            .dft
+            .coset_dft_batch(coeffs, domain.shift())
+            .bit_reverse_rows()
+            .to_row_major_matrix();
+        let result_width = result.width();
+
+        RowMajorMatrixCow::new(Cow::Owned(result.values), result_width).bit_reverse_rows()
     }
 
     fn build_periodic_lde_table(

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -4,7 +4,7 @@ use alloc::vec::Vec;
 
 use itertools::{Itertools, izip};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::Mmcs;
+use p3_commit::{CommitmentOpening, MatrixOpening, Mmcs, PointOpening};
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
     ExtensionField, Field, HornerIter, PrimeField64, TwoAdicField, batch_multiplicative_inverse,
@@ -291,7 +291,7 @@ where
     // With none, each guard would compare against nothing and pass.
     if commitments_with_opening_points
         .iter()
-        .all(|(_, mats)| mats.is_empty())
+        .all(|CommitmentOpening { matrices: mats, .. }| mats.is_empty())
     {
         return Err(FriError::NoCommittedMatrices);
     }
@@ -374,9 +374,10 @@ where
     // Folding sees one input per distinct height, tallest first.
     let mut input_log_heights: Vec<usize> = commitments_with_opening_points
         .iter()
-        .flat_map(|(_, mats)| {
-            mats.iter()
-                .map(|(domain, _)| log2_strict_usize(domain.size()) + params.log_blowup)
+        .flat_map(|CommitmentOpening { matrices: mats, .. }| {
+            mats.iter().map(|MatrixOpening { domain, .. }| {
+                log2_strict_usize(domain.size()) + params.log_blowup
+            })
         })
         .collect();
     input_log_heights.sort_unstable_by(|a, b| b.cmp(a));
@@ -828,7 +829,16 @@ where
     // Check every batch's openings against its commitment first, one shared
     // amortized verification per batch, so the arithmetic below only ever
     // reads authenticated values.
-    for (batch, (batch_opening, (batch_commit, mats))) in input_openings
+    for (
+        batch,
+        (
+            batch_opening,
+            CommitmentOpening {
+                commitment: batch_commit,
+                matrices: mats,
+            },
+        ),
+    ) in input_openings
         .iter()
         .zip(commitments_with_opening_points.iter())
         .enumerate()
@@ -859,28 +869,39 @@ where
         // assumed to always be Val::GENERATOR.
         let batch_heights = mats
             .iter()
-            .map(|(domain, _)| domain.size() << params.log_blowup)
+            .map(|MatrixOpening { domain, .. }| domain.size() << params.log_blowup)
             .collect_vec();
         let batch_dims = batch_heights
             .iter()
             .zip(mats)
             .enumerate()
-            .map(|(matrix, (&height, (_, points_and_values)))| {
-                // Pin each matrix width to its claimed evaluation count, never to the proof.
-                //
-                // Why: the leaf hash flattens all same-height rows into one stream.
-                //   - `check_widths` (in the MMCS) is the only authenticator of row boundaries
-                //   - a matrix opened at no points carries no claim to pin its width
-                //   - reading the width from the proof-supplied row leaves that boundary unchecked
-                // Every input matrix is opened at >= 1 point, so reject the degenerate case.
-                let (_, values) = points_and_values
-                    .first()
-                    .ok_or(FriError::MatrixWithoutOpeningPoints { batch, matrix })?;
-                Ok(Dimensions {
-                    width: values.len(),
-                    height,
-                })
-            })
+            .map(
+                |(
+                    matrix,
+                    (
+                        &height,
+                        MatrixOpening {
+                            points: points_and_values,
+                            ..
+                        },
+                    ),
+                )| {
+                    // Pin each matrix width to its claimed evaluation count, never to the proof.
+                    //
+                    // Why: the leaf hash flattens all same-height rows into one stream.
+                    //   - `check_widths` (in the MMCS) is the only authenticator of row boundaries
+                    //   - a matrix opened at no points carries no claim to pin its width
+                    //   - reading the width from the proof-supplied row leaves that boundary unchecked
+                    // Every input matrix is opened at >= 1 point, so reject the degenerate case.
+                    let PointOpening { values, .. } = points_and_values
+                        .first()
+                        .ok_or(FriError::MatrixWithoutOpeningPoints { batch, matrix })?;
+                    Ok(Dimensions {
+                        width: values.len(),
+                        height,
+                    })
+                },
+            )
             .collect::<Result<Vec<_>, FriError<FriMmcs::Error, InputMmcs::Error>>>()?;
 
         // If the maximum height of the batch is smaller than the global max height,
@@ -919,15 +940,26 @@ where
     // lockstep.
     let mut denominators = Vec::new();
     for &index in indices {
-        for (batch, (_, mats)) in commitments_with_opening_points.iter().enumerate() {
-            for (matrix, (mat_domain, mat_points_and_values)) in mats.iter().enumerate() {
+        for (batch, CommitmentOpening { matrices: mats, .. }) in
+            commitments_with_opening_points.iter().enumerate()
+        {
+            for (
+                matrix,
+                MatrixOpening {
+                    domain: mat_domain,
+                    points: mat_points_and_values,
+                },
+            ) in mats.iter().enumerate()
+            {
                 let log_height = log2_strict_usize(mat_domain.size()) + params.log_blowup;
                 let bits_reduced = log_global_max_height - log_height;
                 let rev_reduced_index = reverse_bits_len(index >> bits_reduced, log_height);
                 let x = Val::GENERATOR
                     * Val::two_adic_generator(log_height).exp_u64(rev_reduced_index as u64);
 
-                for (point, (z, _)) in mat_points_and_values.iter().enumerate() {
+                for (point, PointOpening { point: z, .. }) in
+                    mat_points_and_values.iter().enumerate()
+                {
                     let denominator = *z - x;
                     if denominator.is_zero() {
                         return Err(FriError::OpeningPointMatchesQueryPoint {
@@ -956,16 +988,23 @@ where
     // remaining `p_i(x)` half is a dot product of extension-field powers against an authenticated
     // base-field row. This mirrors how the prover builds the same combination in `TwoAdicFriPcs`.
     let opening_points = || {
-        commitments_with_opening_points
-            .iter()
-            .flat_map(|(_, mats)| {
-                mats.iter().flat_map(|(mat_domain, mat_points_and_values)| {
-                    let log_height = log2_strict_usize(mat_domain.size()) + params.log_blowup;
-                    mat_points_and_values
-                        .iter()
-                        .map(move |(_, ps_at_z)| (log_height, ps_at_z))
-                })
-            })
+        commitments_with_opening_points.iter().flat_map(
+            |CommitmentOpening { matrices: mats, .. }| {
+                mats.iter().flat_map(
+                    |MatrixOpening {
+                         domain: mat_domain,
+                         points: mat_points_and_values,
+                     }| {
+                        let log_height = log2_strict_usize(mat_domain.size()) + params.log_blowup;
+                        mat_points_and_values.iter().map(
+                            move |PointOpening {
+                                      values: ps_at_z, ..
+                                  }| (log_height, ps_at_z),
+                        )
+                    },
+                )
+            },
+        )
     };
 
     // The longest ladder over all heights bounds how many powers of alpha are ever needed.
@@ -1002,14 +1041,22 @@ where
             // The per-opening-point data above, replayed in the same order for this query.
             let mut reductions = point_reductions.iter();
 
-            for (batch, (batch_opening, (_, mats))) in input_openings
+            for (batch, (batch_opening, CommitmentOpening { matrices: mats, .. })) in input_openings
                 .iter()
                 .zip(commitments_with_opening_points.iter())
                 .enumerate()
             {
                 // For each matrix in the commitment
-                for (matrix, (mat_opening, (mat_domain, mat_points_and_values))) in batch_opening
-                    .opened_values[query]
+                for (
+                    matrix,
+                    (
+                        mat_opening,
+                        MatrixOpening {
+                            domain: mat_domain,
+                            points: mat_points_and_values,
+                        },
+                    ),
+                ) in batch_opening.opened_values[query]
                     .iter()
                     .zip(mats.iter())
                     .enumerate()
@@ -1023,7 +1070,14 @@ where
                     // For each opening point, combine this matrix's polynomials with the powers of
                     // alpha at that point's ladder position, map the combination through
                     // `(f(z) - f(x))/(z - x)` and add it to the reduced opening for this log_height.
-                    for (point, (_z, ps_at_z)) in mat_points_and_values.iter().enumerate() {
+                    for (
+                        point,
+                        PointOpening {
+                            point: _z,
+                            values: ps_at_z,
+                        },
+                    ) in mat_points_and_values.iter().enumerate()
+                    {
                         if mat_opening.len() != ps_at_z.len() {
                             return Err(FriError::PointEvaluationCountMismatch {
                                 batch,
@@ -1247,8 +1301,13 @@ mod tests {
         let mut p_challenger = Challenger::new(perm.clone());
         p_challenger.observe(&commitment);
         let zeta: Challenge = p_challenger.sample_algebra_element();
-        let (opened_values, proof) =
-            pcs.open(vec![(&prover_data, vec![vec![zeta]])], &mut p_challenger);
+        let (opened_values, proof) = pcs.open(
+            vec![p3_commit::OpeningRequest {
+                prover_data: &prover_data,
+                points: vec![vec![zeta]],
+            }],
+            &mut p_challenger,
+        );
 
         // Verifier side:
         // Replay the transcript up to the point where the top-level FRI verification begins.
@@ -1262,16 +1321,22 @@ mod tests {
 
         // Assemble the commitment-with-opening-points structure that the
         // verifier checks the proof against.
-        let cwop = vec![(
-            commitment,
-            vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
-        )];
+        let cwop: Vec<CommitmentWithOpeningPoints<_, _, _>> = vec![
+            (
+                commitment,
+                vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
+            )
+                .into(),
+        ];
 
         // Feed the opened evaluations into the verifier challenger.
         // This is the last transcript step before FRI verification begins.
-        for (_, round) in &cwop {
-            for (_, mat) in round {
-                for (_, point) in mat {
+        for CommitmentOpening {
+            matrices: round, ..
+        } in &cwop
+        {
+            for MatrixOpening { points: mat, .. } in round {
+                for PointOpening { values: point, .. } in mat {
                     v_challenger.observe_algebra_slice(point);
                 }
             }
@@ -1447,7 +1512,7 @@ mod tests {
         //     before: mats[0] points = [(zeta, values)]   → width pinned by claim
         //     after:  mats[0] points = []                 → no claim → reject
         let mut cwop = f.commitments_with_opening_points.clone();
-        cwop[0].1[0].1 = vec![];
+        cwop[0].matrices[0].points = vec![];
 
         let mut challenger = f.challenger.clone();
         let err = run_verify_fri(
@@ -1781,20 +1846,31 @@ mod tests {
         let mut p_challenger = Challenger::new(perm.clone());
         p_challenger.observe(&commitment);
         let zeta: Challenge = p_challenger.sample_algebra_element();
-        let (opened_values, proof) =
-            pcs.open(vec![(&prover_data, vec![vec![zeta]])], &mut p_challenger);
+        let (opened_values, proof) = pcs.open(
+            vec![p3_commit::OpeningRequest {
+                prover_data: &prover_data,
+                points: vec![vec![zeta]],
+            }],
+            &mut p_challenger,
+        );
 
         let mut v_challenger = Challenger::new(perm);
         v_challenger.observe(&commitment);
         let _: Challenge = v_challenger.sample_algebra_element();
 
-        let cwop = vec![(
-            commitment,
-            vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
-        )];
-        for (_, round) in &cwop {
-            for (_, mat) in round {
-                for (_, point) in mat {
+        let cwop: Vec<CommitmentWithOpeningPoints<_, _, _>> = vec![
+            (
+                commitment,
+                vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
+            )
+                .into(),
+        ];
+        for CommitmentOpening {
+            matrices: round, ..
+        } in &cwop
+        {
+            for MatrixOpening { points: mat, .. } in round {
+                for PointOpening { values: point, .. } in mat {
                     v_challenger.observe_algebra_slice(point);
                 }
             }
@@ -1933,7 +2009,10 @@ mod tests {
         let h_in = f
             .commitments_with_opening_points
             .iter()
-            .flat_map(|(_, mats)| mats.iter().map(|(d, _)| log2_strict_usize(d.size())))
+            .flat_map(|CommitmentOpening { matrices: mats, .. }| {
+                mats.iter()
+                    .map(|MatrixOpening { domain: d, .. }| log2_strict_usize(d.size()))
+            })
             .max()
             .expect("fixture commits at least one matrix")
             + log_blowup;
@@ -2185,9 +2264,10 @@ mod tests {
         //     point 0 claims:  [f_0(z), f_1(z)]            (length 2)
         //     point 1 claims:  [0, 0, 0]                   (length 3)
         //     → 2 != 3 → error at point 1
-        cwop[0].1[0]
-            .1
-            .push((Challenge::ZERO, vec![Challenge::ZERO; 3]));
+        cwop[0].matrices[0].points.push(PointOpening {
+            point: Challenge::ZERO,
+            values: vec![Challenge::ZERO; 3],
+        });
 
         let mut challenger = f.challenger.clone();
         let err = run_verify_fri(
@@ -2229,7 +2309,7 @@ mod tests {
         //     opened values:  [f_0(x), f_1(x)]             (length 2)
         //     claims:         [f_0(z), f_1(z), EXTRA]      (length 3)
         //     → expected width 3, opened row has 2 → error
-        cwop[0].1[0].1[0].1.push(Challenge::ZERO);
+        cwop[0].matrices[0].points[0].values.push(Challenge::ZERO);
 
         let mut challenger = f.challenger.clone();
         let err = run_verify_fri(
@@ -2666,7 +2746,13 @@ mod tests {
         let mut challenger = Challenger::new(perm);
         challenger.observe(&commitment);
         let zeta: Challenge = challenger.sample_algebra_element();
-        let _ = pcs.open(vec![(&prover_data, vec![vec![zeta]])], &mut challenger);
+        let _ = pcs.open(
+            vec![p3_commit::OpeningRequest {
+                prover_data: &prover_data,
+                points: vec![vec![zeta]],
+            }],
+            &mut challenger,
+        );
     }
 
     #[test]
@@ -2699,7 +2785,8 @@ mod tests {
         //     opening point z : GENERATOR   (claimed value is irrelevant; the denominator fails first)
         //     query point   x : GENERATOR
         let z = Challenge::from(Val::GENERATOR);
-        let cwop = vec![(commit, vec![(domain, vec![(z, vec![Challenge::ZERO])])])];
+        let cwop: Vec<CommitmentWithOpeningPoints<_, _, _>> =
+            vec![(commit, vec![(domain, vec![(z, vec![Challenge::ZERO])])]).into()];
 
         let err = open_inputs::<Val, Challenge, ValMmcs, ChallengeMmcs>(
             &f.fri_params,

--- a/fri/tests/fri.rs
+++ b/fri/tests/fri.rs
@@ -102,7 +102,10 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R, log_final_poly_len: usize, polynomial_lo
         let open_data = vec![(&prover_data, vec![vec![zeta]; num_evaluations])]; // open every chunk at zeta
 
         // Open all polynomials at zeta and produce the opening proof.
-        let (opened_values, opening_proof) = pcs.open(open_data, &mut challenger);
+        let (opened_values, opening_proof) = pcs.open(
+            open_data.into_iter().map(Into::into).collect(),
+            &mut challenger,
+        );
 
         // Return the commitment, opened values, opening proof and challenger.
         // The first three of these are always passed to the verifier. The
@@ -144,7 +147,10 @@ fn do_test_fri_ldt<R: Rng>(rng: &mut R, log_final_poly_len: usize, polynomial_lo
 
         // Verify the opening proof.
         let verification = pcs.verify(
-            commitments_with_opening_points,
+            commitments_with_opening_points
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             &opening_proof,
             &mut challenger,
         );

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -1,7 +1,7 @@
 use itertools::{Itertools, izip};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{CanObserve, DuplexChallenger, FieldChallenger};
-use p3_commit::{ExtensionMmcs, Pcs, PolynomialSpace};
+use p3_commit::{ExtensionMmcs, Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{ExtensionField, Field};
@@ -65,7 +65,11 @@ fn do_test_fri_pcs<Val, Challenge, Challenger, P>(
         .iter()
         .map(|log_degrees| vec![vec![zeta]; log_degrees.len()])
         .collect_vec();
-    let data_and_points = data_by_round.iter().zip(points_by_round).collect();
+    let data_and_points = data_by_round
+        .iter()
+        .zip(points_by_round)
+        .map(Into::into)
+        .collect();
     let (opening_by_round, proof) = pcs.open(data_and_points, &mut p_challenger);
     assert_eq!(opening_by_round.len(), num_rounds);
 
@@ -91,8 +95,15 @@ fn do_test_fri_pcs<Val, Challenge, Challenger, P>(
     .collect_vec();
     assert_eq!(commits_and_claims_by_round.len(), num_rounds);
 
-    pcs.verify(commits_and_claims_by_round, &proof, &mut v_challenger)
-        .unwrap();
+    pcs.verify(
+        commits_and_claims_by_round
+            .into_iter()
+            .map(Into::into)
+            .collect(),
+        &proof,
+        &mut v_challenger,
+    )
+    .unwrap();
 }
 
 // Set it up so we create tests inside a module for each pcs, so we get nice error reports
@@ -242,7 +253,7 @@ mod babybear_fri_pcs {
             <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, [(domain, trace.clone())]);
 
         let disjoint_domain = domain.create_disjoint_domain(degree);
-        let evals = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
+        let evals = <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::get_evaluations_on_domain(
             &pcs,
             &data,
             0,

--- a/stir/benches/stir_pcs.rs
+++ b/stir/benches/stir_pcs.rs
@@ -128,7 +128,10 @@ fn bench_open(c: &mut Criterion) {
                 |(mut challenger, points)| {
                     <MyPcs as Pcs<Challenge, Challenger>>::open(
                         &pcs,
-                        vec![(&data, points)],
+                        vec![p3_commit::OpeningRequest {
+                            prover_data: &data,
+                            points,
+                        }],
                         &mut challenger,
                     )
                 },
@@ -155,7 +158,10 @@ fn bench_verify(c: &mut Criterion) {
         let points: Vec<Vec<Challenge>> = inputs.iter().map(|_| vec![zeta]).collect();
         let (opened, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, points)],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
             &mut p_challenger,
         );
 
@@ -178,7 +184,7 @@ fn bench_verify(c: &mut Criterion) {
                 |mut challenger| {
                     <MyPcs as Pcs<Challenge, Challenger>>::verify(
                         &pcs,
-                        vec![(commit.clone(), claims.clone())],
+                        vec![(commit.clone(), claims.clone()).into()],
                         &proof,
                         &mut challenger,
                     )

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -67,7 +67,10 @@ use p3_challenger::{
     CanObserve, CanSampleUniformBits, DuplexChallenger, FieldChallenger, GrindingChallenger,
     SerializingChallenger32,
 };
-use p3_commit::{Mmcs, OpenedValues, Pcs};
+use p3_commit::{
+    CommitmentOpening, MatrixOpening, Mmcs, OpenedValues, OpeningRequest, Pcs, PointOpening,
+    UnivariateStarkPcs,
+};
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
@@ -672,7 +675,7 @@ type BucketCombine<Challenge> = Option<(
 
 /// One commitment's prover data alongside the opening points of each of its matrices.
 type ProverDataWithPoints<'a, Val, InputMmcs, Challenge> =
-    (&'a StirProverData<Val, InputMmcs>, Vec<Vec<Challenge>>);
+    OpeningRequest<'a, StirProverData<Val, InputMmcs>, Challenge>;
 
 /// Everything `open` settles before STIR runs.
 struct PreparedOpen<Val, Challenge, StirMmcs, Challenger> {
@@ -720,14 +723,23 @@ where
         // Step 1: Compute evaluations at opening points using Lagrange interpolation.
         let mats_and_points: Vec<_> = commitment_data_with_opening_points
             .iter()
-            .map(|(data, points)| (lde_views(&self.input_mmcs, data), points))
+            .map(
+                |OpeningRequest {
+                     prover_data: data,
+                     points,
+                 }| (lde_views(&self.input_mmcs, data), points),
+            )
             .collect();
 
         // `(native height, group LDE height)` per matrix, in caller order: the first selects
         // the `Combine` class, the second selects which STIR instance that class feeds.
         let matrix_layouts: Vec<Vec<(usize, usize)>> = commitment_data_with_opening_points
             .iter()
-            .map(|(data, _)| data.matrix_layout())
+            .map(
+                |OpeningRequest {
+                     prover_data: data, ..
+                 }| data.matrix_layout(),
+            )
             .collect();
 
         let (global_max_height, global_max_width) = mats_and_points
@@ -1036,19 +1048,13 @@ where
     type Domain = TwoAdicMultiplicativeCoset<Val>;
     type Commitment = StirCommitment<InputMmcs::Commitment>;
     type ProverData = StirProverData<Val, InputMmcs>;
-    type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
+
     /// See `StirPcsProof`.
     type Proof = StirPcsProof<Val, Challenge, InputMmcs, StirMmcs>;
     type Error = StirError<StirMmcs::Error, InputMmcs::Error>;
 
-    const ZK: bool = false;
-
     fn natural_domain_for_degree(&self, degree: usize) -> Self::Domain {
         TwoAdicMultiplicativeCoset::new(Val::ONE, log2_strict_usize(degree)).unwrap()
-    }
-
-    fn log_max_lde_height(&self) -> usize {
-        Val::TWO_ADICITY.saturating_sub(self.stir.log_blowup)
     }
 
     #[instrument(name = "STIR PCS commit", skip_all)]
@@ -1100,140 +1106,20 @@ where
         self.commit_groups(&plan, grouped, &log_native_heights)
     }
 
-    fn get_evaluations_on_domain<'a>(
-        &self,
-        prover_data: &'a Self::ProverData,
-        idx: usize,
-        domain: Self::Domain,
-    ) -> Self::EvaluationsOnDomain<'a> {
-        let (group_idx, idx_in_group) = prover_data.placement[idx];
-        let group = &prover_data.groups[group_idx];
-        let lde = self.input_mmcs.get_matrices(&group.data)[idx_in_group].as_view();
-        if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
-            let width = lde.width();
-            let values: &'a [Val] = lde.values;
-            return RowMajorMatrixView::new(&values[..domain.size() * width], width)
-                .as_cow()
-                .bit_reverse_rows();
-        }
-        let poly_height = 1usize << group.log_native_heights[idx_in_group];
-        let width = lde.width();
-        // In bit-reversed order the first `poly_height` rows are the polynomial's values on
-        // the native-size GENERATOR-shifted sub-coset. Interpolate only those rows instead of
-        // the whole committed LDE and discarding the high zero coefficients afterwards.
-        let native_lde = RowMajorMatrixView::new(&lde.values[..poly_height * width], width)
-            .bit_reverse_rows()
-            .to_row_major_matrix();
-        let mut coeffs = self.dft.coset_idft_batch(native_lde, Val::GENERATOR);
-        coeffs.values.resize(domain.size() * width, Val::ZERO);
-        let result = self
-            .dft
-            .coset_dft_batch(coeffs, domain.shift())
-            .bit_reverse_rows()
-            .to_row_major_matrix();
-        let result_width = result.width();
-        RowMajorMatrixCow::new(Cow::Owned(result.values), result_width).bit_reverse_rows()
-    }
-
-    fn get_quotient_ldes(
-        &self,
-        evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
-        _num_chunks: usize,
-    ) -> Vec<RowMajorMatrix<Val>> {
-        let min_height = 1usize << self.stir.log_starting_folding_factor;
-        evaluations
-            .into_iter()
-            .map(|(domain, evals)| {
-                assert!(
-                    evals.height() >= min_height,
-                    "STIR PCS quotient: matrix height {} is below 2^{} required by \
-                     log_starting_folding_factor = {}.",
-                    evals.height(),
-                    self.stir.log_starting_folding_factor,
-                    self.stir.log_starting_folding_factor,
-                );
-                let shift = Val::GENERATOR / domain.shift();
-                self.dft
-                    .coset_lde_batch(evals, self.stir.log_blowup, shift)
-                    .bit_reverse_rows()
-                    .to_row_major_matrix()
-            })
-            .collect()
-    }
-
-    fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
-        let min_lde_height =
-            1usize << (self.stir.log_starting_folding_factor + self.stir.log_blowup);
-        assert!(
-            !ldes.is_empty(),
-            "STIR PCS: commit_ldes requires at least one matrix"
-        );
-        for lde in &ldes {
-            assert!(
-                lde.height() >= min_lde_height,
-                "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
-                 log_starting_folding_factor + log_blowup = {} + {}.",
-                lde.height(),
-                self.stir.log_starting_folding_factor + self.stir.log_blowup,
-                min_lde_height,
-                self.stir.log_starting_folding_factor,
-                self.stir.log_blowup,
-            );
-        }
-
-        // `ldes[i]` is already bit-reversed at `2^(native_i + log_blowup)`, GENERATOR-shifted
-        // (matching `get_quotient_ldes`'s output convention). Shorter ones are re-extended
-        // onto the shared domain sized to the tallest.
-        let log_native_heights: Vec<usize> = ldes
-            .iter()
-            .map(|lde| log2_strict_usize(lde.height()) - self.stir.log_blowup)
-            .collect();
-        let plan = self.plan_groups(&log_native_heights);
-
-        let grouped: Vec<_> = ldes
-            .into_iter()
-            .zip(&log_native_heights)
-            .zip(&plan.group_of_matrix)
-            .map(|((lde, &log_native_height), &group_idx)| {
-                let log_lde_height = plan.log_lde_heights[group_idx];
-                if lde.height() == 1usize << log_lde_height {
-                    lde
-                } else {
-                    // Recovering the polynomial and evaluating it on the wider coset is a
-                    // forward transform of its coefficients, zero-padded to the target size.
-                    // A second `lde` would instead read those coefficients back as evaluations
-                    // on a subgroup, and extend a different polynomial.
-                    let native_height = 1usize << log_native_height;
-                    let width = lde.width();
-                    let mut native_lde = lde;
-                    native_lde.values.truncate(native_height * width);
-                    let natural_native_lde = native_lde.bit_reverse_rows().to_row_major_matrix();
-                    let mut coeffs = self
-                        .dft
-                        .coset_idft_batch(natural_native_lde, Val::GENERATOR);
-                    coeffs
-                        .values
-                        .resize((1usize << log_lde_height) * width, Val::ZERO);
-                    self.dft
-                        .coset_dft_batch(coeffs, Val::GENERATOR)
-                        .bit_reverse_rows()
-                        .to_row_major_matrix()
-                }
-            })
-            .collect();
-        self.commit_groups(&plan, grouped, &log_native_heights)
-    }
-
     #[instrument(name = "STIR PCS open", skip_all)]
     fn open(
         &self,
-        commitment_data_with_opening_points: Vec<(&Self::ProverData, Vec<Vec<Challenge>>)>,
+        commitment_data_with_opening_points: Vec<OpeningRequest<'_, Self::ProverData, Challenge>>,
         challenger: &mut Challenger,
     ) -> (OpenedValues<Challenge>, Self::Proof) {
         let prepared = self.prepare_open(&commitment_data_with_opening_points, challenger);
         let prover_data: Vec<&Self::ProverData> = commitment_data_with_opening_points
             .iter()
-            .map(|(data, _)| *data)
+            .map(
+                |OpeningRequest {
+                     prover_data: data, ..
+                 }| *data,
+            )
             .collect();
         self.prove_buckets(&prover_data, prepared, challenger)
     }
@@ -1241,10 +1127,9 @@ where
     #[instrument(name = "STIR PCS verify", skip_all)]
     fn verify(
         &self,
-        commitments_with_opening_points: Vec<(
-            Self::Commitment,
-            Vec<(Self::Domain, Vec<(Challenge, Vec<Challenge>)>)>,
-        )>,
+        commitments_with_opening_points: Vec<
+            CommitmentOpening<Challenge, Self::Commitment, Self::Domain>,
+        >,
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
@@ -1255,12 +1140,23 @@ where
         // runs and therefore whether `r_comb` is drawn, so it has to be settled before the
         // transcript can fork on it. Depends only on the public claims (mirrors
         // `fri::verifier::FriError::MatrixWithoutOpeningPoints`).
-        for (commitment, domain_claims) in commitments_with_opening_points
-            .iter()
-            .enumerate()
-            .map(|(commit_idx, (_, domain_claims))| (commit_idx, domain_claims))
-        {
-            for (matrix, (_, point_claims)) in domain_claims.iter().enumerate() {
+        for (commitment, domain_claims) in commitments_with_opening_points.iter().enumerate().map(
+            |(
+                commit_idx,
+                CommitmentOpening {
+                    matrices: domain_claims,
+                    ..
+                },
+            )| (commit_idx, domain_claims),
+        ) {
+            for (
+                matrix,
+                MatrixOpening {
+                    points: point_claims,
+                    ..
+                },
+            ) in domain_claims.iter().enumerate()
+            {
                 if point_claims.is_empty() {
                     return Err(StirError::MatrixWithoutOpeningPoints { commitment, matrix });
                 }
@@ -1268,9 +1164,21 @@ where
         }
 
         // Observe all opened values to keep the transcript in sync.
-        for (_, domain_claims) in &commitments_with_opening_points {
-            for (_, point_claims) in domain_claims {
-                for (_, opened_vals) in point_claims {
+        for CommitmentOpening {
+            matrices: domain_claims,
+            ..
+        } in &commitments_with_opening_points
+        {
+            for MatrixOpening {
+                points: point_claims,
+                ..
+            } in domain_claims
+            {
+                for PointOpening {
+                    values: opened_vals,
+                    ..
+                } in point_claims
+                {
                     challenger.observe_algebra_slice(opened_vals);
                 }
             }
@@ -1285,20 +1193,26 @@ where
         // and fails the input opening check below.
         let plans: Vec<GroupPlan> = commitments_with_opening_points
             .iter()
-            .map(|(_, domain_claims)| {
-                let log_native_heights: Vec<usize> = domain_claims
-                    .iter()
-                    .map(|(domain, _)| log2_strict_usize(domain.size()))
-                    .collect();
-                self.plan_groups(&log_native_heights)
-            })
+            .map(
+                |CommitmentOpening {
+                     matrices: domain_claims,
+                     ..
+                 }| {
+                    let log_native_heights: Vec<usize> = domain_claims
+                        .iter()
+                        .map(|MatrixOpening { domain, .. }| log2_strict_usize(domain.size()))
+                        .collect();
+                    self.plan_groups(&log_native_heights)
+                },
+            )
             .collect();
 
         // SHAPE CHECK: one Merkle root per group of the layout the claims imply.
-        for (commit_idx, ((commitment, _), plan)) in commitments_with_opening_points
-            .iter()
-            .zip(&plans)
-            .enumerate()
+        for (commit_idx, (CommitmentOpening { commitment, .. }, plan)) in
+            commitments_with_opening_points
+                .iter()
+                .zip(&plans)
+                .enumerate()
         {
             if commitment.len() != plan.log_lde_heights.len() {
                 return Err(ProofShapeError::CommitmentRootCount {
@@ -1357,11 +1271,23 @@ where
 
         let global_max_width = commitments_with_opening_points
             .iter()
-            .flat_map(|(_, domain_claims)| {
-                domain_claims
-                    .iter()
-                    .flat_map(|(_, point_claims)| point_claims.iter().map(|(_, v)| v.len()))
-            })
+            .flat_map(
+                |CommitmentOpening {
+                     matrices: domain_claims,
+                     ..
+                 }| {
+                    domain_claims.iter().flat_map(
+                        |MatrixOpening {
+                             points: point_claims,
+                             ..
+                         }| {
+                            point_claims
+                                .iter()
+                                .map(|PointOpening { values: v, .. }| v.len())
+                        },
+                    )
+                },
+            )
             .max()
             .unwrap_or(0);
         let packed_alpha_powers =
@@ -1385,31 +1311,47 @@ where
         let point_data: Vec<Vec<Vec<(Challenge, Challenge)>>> = commitments_with_opening_points
             .iter()
             .zip(&matrix_lde_heights)
-            .map(|((_, domain_claims), lde_heights)| {
-                domain_claims
-                    .iter()
-                    .zip(lde_heights)
-                    .map(|((domain, point_claims), &log_lde_h)| {
-                        let key = (log_lde_h, log2_strict_usize(domain.size()));
-                        point_claims
-                            .iter()
-                            .map(|(_, vals)| {
-                                let count = class_num_reduced.entry(key).or_insert(0);
-                                let offset = alpha.exp_u64(*count as u64);
-                                *count += vals.len();
-
-                                let y_combined: Challenge = vals
+            .map(
+                |(
+                    CommitmentOpening {
+                        matrices: domain_claims,
+                        ..
+                    },
+                    lde_heights,
+                )| {
+                    domain_claims
+                        .iter()
+                        .zip(lde_heights)
+                        .map(
+                            |(
+                                MatrixOpening {
+                                    domain,
+                                    points: point_claims,
+                                },
+                                &log_lde_h,
+                            )| {
+                                let key = (log_lde_h, log2_strict_usize(domain.size()));
+                                point_claims
                                     .iter()
-                                    .zip(alpha_powers.iter())
-                                    .map(|(&y, &ap)| y * ap)
-                                    .sum();
+                                    .map(|PointOpening { values: vals, .. }| {
+                                        let count = class_num_reduced.entry(key).or_insert(0);
+                                        let offset = alpha.exp_u64(*count as u64);
+                                        *count += vals.len();
 
-                                (offset, y_combined)
-                            })
-                            .collect()
-                    })
-                    .collect()
-            })
+                                        let y_combined: Challenge = vals
+                                            .iter()
+                                            .zip(alpha_powers.iter())
+                                            .map(|(&y, &ap)| y * ap)
+                                            .sum();
+
+                                        (offset, y_combined)
+                                    })
+                                    .collect()
+                            },
+                        )
+                        .collect()
+                },
+            )
             .collect();
 
         // SHAPE CHECK: every bucket's input_openings has one slot per public commitment.
@@ -1439,13 +1381,23 @@ where
                 let mut native_heights: Vec<usize> = commitments_with_opening_points
                     .iter()
                     .zip(&matrix_lde_heights)
-                    .flat_map(|((_, domain_claims), lde_heights)| {
-                        domain_claims
-                            .iter()
-                            .zip(lde_heights)
-                            .filter(move |&(_, &log_lde_h)| log_lde_h == log_shared_h)
-                            .map(|((domain, _), _)| log2_strict_usize(domain.size()))
-                    })
+                    .flat_map(
+                        |(
+                            CommitmentOpening {
+                                matrices: domain_claims,
+                                ..
+                            },
+                            lde_heights,
+                        )| {
+                            domain_claims
+                                .iter()
+                                .zip(lde_heights)
+                                .filter(move |&(_, &log_lde_h)| log_lde_h == log_shared_h)
+                                .map(|(MatrixOpening { domain, .. }, _)| {
+                                    log2_strict_usize(domain.size())
+                                })
+                        },
+                    )
                     .collect();
                 native_heights.sort_unstable();
                 native_heights.dedup();
@@ -1534,14 +1486,29 @@ where
             let bucket_points: Vec<Challenge> = commitments_with_opening_points
                 .iter()
                 .zip(matrix_lde_heights.iter())
-                .flat_map(|((_, domain_claims), lde_heights)| {
-                    domain_claims
-                        .iter()
-                        .zip(lde_heights)
-                        .filter(move |&(_, &h)| h == log_h)
-                        .map(|(claim, _)| claim)
-                })
-                .flat_map(|(_, point_claims)| point_claims.iter().map(|(point, _)| *point))
+                .flat_map(
+                    |(
+                        CommitmentOpening {
+                            matrices: domain_claims,
+                            ..
+                        },
+                        lde_heights,
+                    )| {
+                        domain_claims
+                            .iter()
+                            .zip(lde_heights)
+                            .filter(move |&(_, &h)| h == log_h)
+                            .map(|(claim, _)| claim)
+                    },
+                )
+                .flat_map(
+                    |MatrixOpening {
+                         points: point_claims,
+                         ..
+                     }| {
+                        point_claims.iter().map(|PointOpening { point, .. }| *point)
+                    },
+                )
                 .fold(Vec::new(), |mut points, point| {
                     if !points.contains(&point) {
                         points.push(point);
@@ -1585,11 +1552,19 @@ where
             // A commitment feeds this bucket through at most one of its groups: the one
             // committed on this domain. Its other groups live in other trees at other heights
             // and belong to other buckets.
-            for (commit_idx, ((commitment, domain_claims), per_commit_opening)) in
-                commitments_with_opening_points
-                    .iter()
-                    .zip(input_openings.iter())
-                    .enumerate()
+            for (
+                commit_idx,
+                (
+                    CommitmentOpening {
+                        commitment,
+                        matrices: domain_claims,
+                    },
+                    per_commit_opening,
+                ),
+            ) in commitments_with_opening_points
+                .iter()
+                .zip(input_openings.iter())
+                .enumerate()
             {
                 let group_idx = group_indices[commit_idx];
 
@@ -1626,9 +1601,9 @@ where
                     .iter()
                     .map(|&idx| {
                         domain_claims[idx]
-                            .1
+                            .points
                             .first()
-                            .map(|(_, v)| v.len())
+                            .map(|PointOpening { values: v, .. }| v.len())
                             .expect("rejected up front in verify")
                     })
                     .collect();
@@ -1636,7 +1611,7 @@ where
                 let mat_class_indices: Vec<usize> = group_mats
                     .iter()
                     .map(|&idx| {
-                        let log_native_h = log2_strict_usize(domain_claims[idx].0.size());
+                        let log_native_h = log2_strict_usize(domain_claims[idx].domain.size());
                         native_heights
                             .iter()
                             .position(|&h| h == log_native_h)
@@ -1647,9 +1622,9 @@ where
                     .iter()
                     .map(|&idx| {
                         domain_claims[idx]
-                            .1
+                            .points
                             .iter()
-                            .map(|(point, _)| {
+                            .map(|PointOpening { point, .. }| {
                                 bucket_points
                                     .iter()
                                     .position(|p| p == point)
@@ -1779,6 +1754,155 @@ where
     }
 }
 
+impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger> UnivariateStarkPcs<Challenge, Challenger>
+    for TwoAdicStirPcs<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
+where
+    Val: TwoAdicField,
+    Dft: TwoAdicSubgroupDft<Val>,
+    InputMmcs: Mmcs<Val, Error: Sync + Debug, Commitment: Send> + Sync,
+    InputMmcs::ProverData<RowMajorMatrix<Val>>: Send,
+    StirMmcs: Mmcs<Challenge>,
+    Challenge: ExtensionField<Val> + TwoAdicField + BasedVectorSpace<Val>,
+    Challenger: FieldChallenger<Val>
+        + CanObserve<InputMmcs::Commitment>
+        + CanObserve<StirMmcs::Commitment>
+        + GrindingChallenger<Witness = Val>
+        + CanSampleUniformBits<Val>
+        + Clone,
+{
+    type EvaluationsOnDomain<'a> = BitReversedMatrixView<RowMajorMatrixCow<'a, Val>>;
+
+    const ZK: bool = false;
+
+    fn log_max_lde_height(&self) -> usize {
+        Val::TWO_ADICITY.saturating_sub(self.stir.log_blowup)
+    }
+
+    fn get_evaluations_on_domain<'a>(
+        &self,
+        prover_data: &'a Self::ProverData,
+        idx: usize,
+        domain: Self::Domain,
+    ) -> Self::EvaluationsOnDomain<'a> {
+        let (group_idx, idx_in_group) = prover_data.placement[idx];
+        let group = &prover_data.groups[group_idx];
+        let lde = self.input_mmcs.get_matrices(&group.data)[idx_in_group].as_view();
+        if domain.shift() == Val::GENERATOR && lde.height() >= domain.size() {
+            let width = lde.width();
+            let values: &'a [Val] = lde.values;
+            return RowMajorMatrixView::new(&values[..domain.size() * width], width)
+                .as_cow()
+                .bit_reverse_rows();
+        }
+        let poly_height = 1usize << group.log_native_heights[idx_in_group];
+        let width = lde.width();
+        // In bit-reversed order the first `poly_height` rows are the polynomial's values on
+        // the native-size GENERATOR-shifted sub-coset. Interpolate only those rows instead of
+        // the whole committed LDE and discarding the high zero coefficients afterwards.
+        let native_lde = RowMajorMatrixView::new(&lde.values[..poly_height * width], width)
+            .bit_reverse_rows()
+            .to_row_major_matrix();
+        let mut coeffs = self.dft.coset_idft_batch(native_lde, Val::GENERATOR);
+        coeffs.values.resize(domain.size() * width, Val::ZERO);
+        let result = self
+            .dft
+            .coset_dft_batch(coeffs, domain.shift())
+            .bit_reverse_rows()
+            .to_row_major_matrix();
+        let result_width = result.width();
+        RowMajorMatrixCow::new(Cow::Owned(result.values), result_width).bit_reverse_rows()
+    }
+
+    fn get_quotient_ldes(
+        &self,
+        evaluations: impl IntoIterator<Item = (Self::Domain, RowMajorMatrix<Val>)>,
+        _num_chunks: usize,
+    ) -> Vec<RowMajorMatrix<Val>> {
+        let min_height = 1usize << self.stir.log_starting_folding_factor;
+        evaluations
+            .into_iter()
+            .map(|(domain, evals)| {
+                assert!(
+                    evals.height() >= min_height,
+                    "STIR PCS quotient: matrix height {} is below 2^{} required by \
+                     log_starting_folding_factor = {}.",
+                    evals.height(),
+                    self.stir.log_starting_folding_factor,
+                    self.stir.log_starting_folding_factor,
+                );
+                let shift = Val::GENERATOR / domain.shift();
+                self.dft
+                    .coset_lde_batch(evals, self.stir.log_blowup, shift)
+                    .bit_reverse_rows()
+                    .to_row_major_matrix()
+            })
+            .collect()
+    }
+
+    fn commit_ldes(&self, ldes: Vec<RowMajorMatrix<Val>>) -> (Self::Commitment, Self::ProverData) {
+        let min_lde_height =
+            1usize << (self.stir.log_starting_folding_factor + self.stir.log_blowup);
+        assert!(
+            !ldes.is_empty(),
+            "STIR PCS: commit_ldes requires at least one matrix"
+        );
+        for lde in &ldes {
+            assert!(
+                lde.height() >= min_lde_height,
+                "STIR PCS: pre-computed LDE height {} is below 2^{} (= {}) required by \
+                 log_starting_folding_factor + log_blowup = {} + {}.",
+                lde.height(),
+                self.stir.log_starting_folding_factor + self.stir.log_blowup,
+                min_lde_height,
+                self.stir.log_starting_folding_factor,
+                self.stir.log_blowup,
+            );
+        }
+
+        // `ldes[i]` is already bit-reversed at `2^(native_i + log_blowup)`, GENERATOR-shifted
+        // (matching `get_quotient_ldes`'s output convention). Shorter ones are re-extended
+        // onto the shared domain sized to the tallest.
+        let log_native_heights: Vec<usize> = ldes
+            .iter()
+            .map(|lde| log2_strict_usize(lde.height()) - self.stir.log_blowup)
+            .collect();
+        let plan = self.plan_groups(&log_native_heights);
+
+        let grouped: Vec<_> = ldes
+            .into_iter()
+            .zip(&log_native_heights)
+            .zip(&plan.group_of_matrix)
+            .map(|((lde, &log_native_height), &group_idx)| {
+                let log_lde_height = plan.log_lde_heights[group_idx];
+                if lde.height() == 1usize << log_lde_height {
+                    lde
+                } else {
+                    // Recovering the polynomial and evaluating it on the wider coset is a
+                    // forward transform of its coefficients, zero-padded to the target size.
+                    // A second `lde` would instead read those coefficients back as evaluations
+                    // on a subgroup, and extend a different polynomial.
+                    let native_height = 1usize << log_native_height;
+                    let width = lde.width();
+                    let mut native_lde = lde;
+                    native_lde.values.truncate(native_height * width);
+                    let natural_native_lde = native_lde.bit_reverse_rows().to_row_major_matrix();
+                    let mut coeffs = self
+                        .dft
+                        .coset_idft_batch(natural_native_lde, Val::GENERATOR);
+                    coeffs
+                        .values
+                        .resize((1usize << log_lde_height) * width, Val::ZERO);
+                    self.dft
+                        .coset_dft_batch(coeffs, Val::GENERATOR)
+                        .bit_reverse_rows()
+                        .to_row_major_matrix()
+                }
+            })
+            .collect();
+        self.commit_groups(&plan, grouped, &log_native_heights)
+    }
+}
+
 /// One entry per distinct shared LDE height across every commitment's groups (descending). A
 /// commitment contributes to one entry per group it holds. Each entry holds:
 /// - the STIR IOP proof for that bucket, whose initial oracle is the bucket's reduced
@@ -1850,7 +1974,7 @@ fn positions_to_row_indices(positions: &[usize], log_h: usize) -> Vec<usize> {
 }
 
 /// One commitment's claims: per matrix, its domain and its `(point, values)` pairs.
-type CommitmentClaims<C, D, EF> = (C, Vec<(D, Vec<(EF, Vec<EF>)>)>);
+type CommitmentClaims<C, D, EF> = CommitmentOpening<EF, C, D>;
 
 /// Locate the claim that contributed `point`, as `(commitment, matrix, point)` indices.
 ///
@@ -1862,17 +1986,31 @@ fn locate_opening_point<C, D, EF: PartialEq>(
     commitments_with_opening_points
         .iter()
         .enumerate()
-        .flat_map(|(commitment, (_, domain_claims))| {
-            domain_claims
-                .iter()
-                .enumerate()
-                .flat_map(move |(matrix, (_, point_claims))| {
-                    point_claims
-                        .iter()
-                        .enumerate()
-                        .map(move |(slot, (claimed, _))| (commitment, matrix, slot, claimed))
-                })
-        })
+        .flat_map(
+            |(
+                commitment,
+                CommitmentOpening {
+                    matrices: domain_claims,
+                    ..
+                },
+            )| {
+                domain_claims.iter().enumerate().flat_map(
+                    move |(
+                        matrix,
+                        MatrixOpening {
+                            points: point_claims,
+                            ..
+                        },
+                    )| {
+                        point_claims.iter().enumerate().map(
+                            move |(slot, PointOpening { point: claimed, .. })| {
+                                (commitment, matrix, slot, claimed)
+                            },
+                        )
+                    },
+                )
+            },
+        )
         .find_map(|(commitment, matrix, slot, claimed)| {
             (claimed == point).then_some((commitment, matrix, slot))
         })
@@ -2627,17 +2765,26 @@ mod tests {
                 let zeta: EF = base.sample_algebra_element();
                 let (values, proof) = <TestPcs as Pcs<EF, TestChallenger>>::open(
                     &pcs,
-                    vec![(&data, vec![vec![zeta]; 3])],
+                    vec![OpeningRequest {
+                        prover_data: &data,
+                        points: vec![vec![zeta]; 3],
+                    }],
                     &mut base.clone(),
                 );
-                let claims = vec![(
-                    commit,
-                    domains
+                let claims = vec![CommitmentOpening {
+                    commitment: commit,
+                    matrices: domains
                         .into_iter()
                         .enumerate()
-                        .map(|(i, domain)| (domain, vec![(zeta, values[0][i][0].clone())]))
+                        .map(|(i, domain)| MatrixOpening {
+                            domain,
+                            points: vec![PointOpening {
+                                point: zeta,
+                                values: values[0][i][0].clone(),
+                            }],
+                        })
                         .collect(),
-                )];
+                }];
                 <TestPcs as Pcs<EF, TestChallenger>>::verify(&pcs, claims, &proof, &mut base)
                     .expect("ordinary and Combine proofs verify under their own options");
             }
@@ -2681,7 +2828,10 @@ mod tests {
                 let mut full_p = base.clone();
                 let (values, full_proof) = <TestPcs as Pcs<EF, TestChallenger>>::open(
                     &pcs,
-                    vec![(&data, vec![vec![zeta]; 3])],
+                    vec![OpeningRequest {
+                        prover_data: &data,
+                        points: vec![vec![zeta]; 3],
+                    }],
                     &mut full_p,
                 );
                 // Clone only after opening has warmed both ordinary and Combine schedules.
@@ -2692,20 +2842,29 @@ mod tests {
                 let mut compact_p = base.clone();
                 let (compact_values, compact_proof) = <TestPcs as Pcs<EF, TestChallenger>>::open(
                     &compact,
-                    vec![(&data, vec![vec![zeta]; 3])],
+                    vec![OpeningRequest {
+                        prover_data: &data,
+                        points: vec![vec![zeta]; 3],
+                    }],
                     &mut compact_p,
                 );
                 assert_eq!(values, compact_values);
                 let next: EF = full_p.sample_algebra_element();
                 assert_eq!(next, compact_p.sample_algebra_element::<EF>());
-                let claims = vec![(
-                    commit,
-                    domains
+                let claims = vec![CommitmentOpening {
+                    commitment: commit,
+                    matrices: domains
                         .into_iter()
                         .enumerate()
-                        .map(|(i, domain)| (domain, vec![(zeta, values[0][i][0].clone())]))
+                        .map(|(i, domain)| MatrixOpening {
+                            domain,
+                            points: vec![PointOpening {
+                                point: zeta,
+                                values: values[0][i][0].clone(),
+                            }],
+                        })
                         .collect::<Vec<_>>(),
-                )];
+                }];
                 for (pcs, proof) in [(&pcs, &full_proof), (&compact, &compact_proof)] {
                     let mut v_ch = base.clone();
                     <TestPcs as Pcs<EF, TestChallenger>>::verify(
@@ -2764,7 +2923,13 @@ mod tests {
         let zeta: EF = challenger.sample_algebra_element();
 
         let mut p_ch = challenger.clone();
-        let mut prepared = pcs.prepare_open(&[(&data, vec![vec![zeta]])], &mut p_ch);
+        let mut prepared = pcs.prepare_open(
+            &[OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut p_ch,
+        );
         assert_eq!(prepared.initial_codewords.len(), 1);
 
         // A random polynomial of the same degree bound, evaluated on the same coset in the
@@ -2783,8 +2948,13 @@ mod tests {
             commit,
             vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
         )];
-        let err = <TestPcs as Pcs<EF, TestChallenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("a low-degree oracle that is not the reduced opening must be rejected");
+        let err = <TestPcs as Pcs<EF, TestChallenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("a low-degree oracle that is not the reduced opening must be rejected");
         assert!(
             matches!(err, StirError::InitialOracleMismatch { log_height, .. } if log_height == log_lde),
             "expected InitialOracleMismatch, got {err:?}"
@@ -2817,7 +2987,13 @@ mod tests {
         let zeta: EF = challenger.sample_algebra_element();
 
         let mut p_ch = challenger.clone();
-        let mut prepared = pcs.prepare_open(&[(&data, vec![vec![zeta]])], &mut p_ch);
+        let mut prepared = pcs.prepare_open(
+            &[OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut p_ch,
+        );
         assert_eq!(
             prepared.stir_configs[0].num_rounds(),
             0,
@@ -2838,8 +3014,13 @@ mod tests {
             commit,
             vec![(domain, vec![(zeta, opened_values[0][0][0].clone())])],
         )];
-        let err = <TestPcs as Pcs<EF, TestChallenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("a low-degree oracle that is not the reduced opening must be rejected");
+        let err = <TestPcs as Pcs<EF, TestChallenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("a low-degree oracle that is not the reduced opening must be rejected");
         assert!(
             matches!(err, StirError::InitialOracleMismatch { log_height, .. } if log_height == log_lde),
             "expected InitialOracleMismatch, got {err:?}"
@@ -2875,7 +3056,13 @@ mod tests {
 
         // The whole prover side, lanes included.
         let mut ch_full = base.clone();
-        let prepared = pcs.prepare_open(&[(&data, vec![vec![zeta]])], &mut ch_full);
+        let prepared = pcs.prepare_open(
+            &[OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut ch_full,
+        );
         let log_arity0 = prepared.stir_configs[0].log_starting_folding_factor;
         let final_queries = prepared.stir_configs[0].final_queries;
         let _ = pcs.prove_buckets(&[&data], prepared, &mut ch_full);
@@ -2883,7 +3070,13 @@ mod tests {
         // The same transcript, stopped right after STIR so the lane draws can be replayed by
         // hand at both counts.
         let mut ch_draws = base;
-        let prepared = pcs.prepare_open(&[(&data, vec![vec![zeta]])], &mut ch_draws);
+        let prepared = pcs.prepare_open(
+            &[OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
+            &mut ch_draws,
+        );
         let PreparedOpen {
             stir_configs,
             initial_codewords,

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -9,7 +9,7 @@ use core::fmt::Debug;
 use p3_challenger::{
     CanObserve, CanSampleUniformBits, DuplexChallenger, FieldChallenger, GrindingChallenger,
 };
-use p3_commit::{ExtensionMmcs, Mmcs, Pcs};
+use p3_commit::{ExtensionMmcs, Mmcs, Pcs, UnivariateStarkPcs};
 use p3_dft::{Radix2DitParallel, TwoAdicSubgroupDft};
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField};
@@ -1491,7 +1491,7 @@ mod babybear_pcs {
         // Strictly taller than the committed LDE (`d` folded by `log_blowup = 1`), so the fast
         // path's `lde.height() >= domain.size()` guard cannot fire.
         let tall_domain = TwoAdicMultiplicativeCoset::new(Val::GENERATOR, log_d + 2).unwrap();
-        let evals = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
+        let evals = <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::get_evaluations_on_domain(
             &pcs,
             &data,
             0,
@@ -1535,10 +1535,11 @@ mod babybear_pcs {
         let native_coeffs = dft.idft_batch(trace);
         for log_target in [log_d, log_d + 2] {
             let target = TwoAdicMultiplicativeCoset::new(Val::from_u64(7), log_target).unwrap();
-            let actual = <MyPcs as Pcs<Challenge, Challenger>>::get_evaluations_on_domain(
-                &pcs, &data, 0, target,
-            )
-            .to_row_major_matrix();
+            let actual =
+                <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::get_evaluations_on_domain(
+                    &pcs, &data, 0, target,
+                )
+                .to_row_major_matrix();
 
             let mut padded_coeffs = native_coeffs.clone();
             padded_coeffs
@@ -1588,8 +1589,14 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(pcs, vec![(&data, points)], &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            pcs,
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
+            &mut p_ch,
+        );
 
         let mut v_ch = challenger_template.clone();
         observe_commitment(&mut v_ch, &commit);
@@ -1604,7 +1611,7 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             pcs,
-            vec![(commit.clone(), claims)],
+            vec![(commit.clone(), claims).into()],
             &proof,
             &mut v_ch,
         )
@@ -1677,14 +1684,15 @@ mod babybear_pcs {
                 })
                 .collect();
 
-            let ldes = <MyPcs as Pcs<Challenge, Challenger>>::get_quotient_ldes(
+            let ldes = <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::get_quotient_ldes(
                 &pcs,
                 domains_and_polys.iter().cloned(),
                 1,
             );
 
             let mut p_ch = challenger_template.clone();
-            let (commit, data) = <MyPcs as Pcs<Challenge, Challenger>>::commit_ldes(&pcs, ldes);
+            let (commit, data) =
+                <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::commit_ldes(&pcs, ldes);
 
             let (direct_commit, _) = <MyPcs as Pcs<Challenge, Challenger>>::commit(
                 &pcs,
@@ -1705,8 +1713,14 @@ mod babybear_pcs {
             observe_commitment(&mut p_ch, &commit);
             let zeta: Challenge = p_ch.sample_algebra_element();
             let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
-            let (opening_values, proof) =
-                <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+            let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+                &pcs,
+                vec![p3_commit::OpeningRequest {
+                    prover_data: &data,
+                    points,
+                }],
+                &mut p_ch,
+            );
 
             let mut v_ch = challenger_template;
             observe_commitment(&mut v_ch, &commit);
@@ -1721,7 +1735,7 @@ mod babybear_pcs {
 
             <MyPcs as Pcs<Challenge, Challenger>>::verify(
                 &pcs,
-                vec![(commit, claims)],
+                vec![(commit, claims).into()],
                 &proof,
                 &mut v_ch,
             )
@@ -1784,8 +1798,11 @@ mod babybear_pcs {
             (&data_a, vec![vec![zeta], vec![zeta]]),
             (&data_b, vec![vec![zeta], vec![zeta]]),
         ];
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
 
         // One shared 2^9 domain, so one STIR instance for both commitments.
         assert_eq!(proof.len(), 1);
@@ -1811,8 +1828,8 @@ mod babybear_pcs {
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
             vec![
-                (commit_a, claims(0, &domains_a)),
-                (commit_b, claims(1, &domains_b)),
+                (commit_a, claims(0, &domains_a)).into(),
+                (commit_b, claims(1, &domains_b)).into(),
             ],
             &proof,
             &mut v_ch,
@@ -1871,7 +1888,10 @@ mod babybear_pcs {
         let data_and_points: Vec<_> = datas
             .iter()
             .zip(&mats)
-            .map(|(data, per_commit)| (data, per_commit.iter().map(|_| vec![zeta]).collect()))
+            .map(|(data, per_commit)| p3_commit::OpeningRequest {
+                prover_data: data,
+                points: per_commit.iter().map(|_| vec![zeta]).collect(),
+            })
             .collect();
         let (opening_values, proof) =
             <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
@@ -1901,7 +1921,7 @@ mod babybear_pcs {
                         )
                     })
                     .collect::<Vec<_>>();
-                (commit, claims)
+                (commit, claims).into()
             })
             .collect();
 
@@ -1953,7 +1973,10 @@ mod babybear_pcs {
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &prover_pcs,
-            vec![(&data, points)],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
             &mut p_ch,
         );
 
@@ -1970,7 +1993,7 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &verifier_pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_ch,
         )
@@ -2021,7 +2044,7 @@ mod babybear_pcs {
     fn test_pcs_log_max_lde_height_reserves_blowup_bits() {
         let (pcs, _challenger) = get_pcs();
         assert_eq!(
-            <MyPcs as Pcs<Challenge, Challenger>>::log_max_lde_height(&pcs),
+            <MyPcs as UnivariateStarkPcs<Challenge, Challenger>>::log_max_lde_height(&pcs),
             Val::TWO_ADICITY - 1
         );
     }
@@ -2056,8 +2079,11 @@ mod babybear_pcs {
 
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
         let data_and_points = vec![(&data, points)];
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_challenger);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_challenger,
+        );
 
         // Verify.
         let mut v_challenger = challenger_template;
@@ -2073,7 +2099,7 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_challenger,
         )
@@ -2154,8 +2180,11 @@ mod babybear_pcs {
 
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
         let data_and_points = vec![(&data, points)];
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_challenger);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_challenger,
+        );
 
         let mut v_challenger = challenger_template;
         observe_commitment(&mut v_challenger, &commit);
@@ -2170,7 +2199,7 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_challenger,
         )
@@ -2231,7 +2260,10 @@ mod babybear_pcs {
         let zeta: Challenge = fri_p_ch.sample_algebra_element();
         let (fri_openings, fri_proof) = <FriPcs as Pcs<Challenge, Challenger>>::open(
             &fri_pcs,
-            vec![(&fri_data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &fri_data,
+                points: vec![vec![zeta]],
+            }],
             &mut fri_p_ch,
         );
 
@@ -2242,7 +2274,7 @@ mod babybear_pcs {
         let fri_claims = vec![(fri_domain, vec![(zeta, fri_openings[0][0][0].clone())])];
         <FriPcs as Pcs<Challenge, Challenger>>::verify(
             &fri_pcs,
-            vec![(fri_commit, fri_claims)],
+            vec![(fri_commit, fri_claims).into()],
             &fri_proof,
             &mut fri_v_ch,
         )
@@ -2261,7 +2293,10 @@ mod babybear_pcs {
         let stir_zeta: Challenge = stir_p_ch.sample_algebra_element();
         let (stir_openings, stir_proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &stir_pcs,
-            vec![(&stir_data, vec![vec![stir_zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &stir_data,
+                points: vec![vec![stir_zeta]],
+            }],
             &mut stir_p_ch,
         );
 
@@ -2275,7 +2310,7 @@ mod babybear_pcs {
         )];
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &stir_pcs,
-            vec![(stir_commit, stir_claims)],
+            vec![(stir_commit, stir_claims).into()],
             &stir_proof,
             &mut stir_v_ch,
         )
@@ -2365,8 +2400,11 @@ mod babybear_pcs {
 
         // Each commitment has one matrix, opened at the same `zeta`.
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
 
         // Verify.
         let mut v_ch = challenger_template;
@@ -2385,7 +2423,10 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            commitments_with_claims,
+            commitments_with_claims
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             &proof,
             &mut v_ch,
         )
@@ -2419,8 +2460,11 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
 
         let mut v_ch = challenger_template;
         observe_commitment(&mut v_ch, &commit_a);
@@ -2434,8 +2478,13 @@ mod babybear_pcs {
             (commit_a, vec![(domain, vec![(zeta, opening_a)])]),
             (commit_b, vec![(domain, vec![(zeta, opening_b)])]),
         ];
-        <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .unwrap_or_else(|e| panic!("two-commitment same-bucket verification failed: {e:?}"));
+        <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .unwrap_or_else(|e| panic!("two-commitment same-bucket verification failed: {e:?}"));
     }
 
     /// Committing a matrix and then opening it at no points would emit a proof that cannot
@@ -2465,7 +2514,11 @@ mod babybear_pcs {
 
         // `mat_a` is opened at `zeta`; `mat_b` is opened at no points at all.
         let data_and_points = vec![(&data, vec![vec![zeta], vec![]])];
-        let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
     }
 
     /// The degenerate extreme of the above: nothing is opened at all, so the prover would
@@ -2487,7 +2540,11 @@ mod babybear_pcs {
         observe_commitment(&mut p_ch, &commit);
 
         let data_and_points = vec![(&data, vec![vec![]])];
-        let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let _ = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
     }
 
     /// Prove honestly at `prove_log_degrees`, then verify with matrix `emptied`'s claims
@@ -2525,8 +2582,14 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         let points: Vec<Vec<Challenge>> = prove_log_degrees.iter().map(|_| vec![zeta]).collect();
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
+            &mut p_ch,
+        );
 
         let mut v_ch = challenger_template;
         observe_commitment(&mut v_ch, &commit);
@@ -2550,7 +2613,7 @@ mod babybear_pcs {
 
         let result = <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_ch,
         );
@@ -2627,8 +2690,11 @@ mod babybear_pcs {
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
-        let (opening_values, mut proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
 
         // Drop the second commitment's input-opening vector. The verifier must reject:
         // skipping a commit's openings would let the proof verify against a proper subset
@@ -2649,7 +2715,12 @@ mod babybear_pcs {
             (commit_a, vec![(domain, vec![(zeta, opening_a)])]),
             (commit_b, vec![(domain, vec![(zeta, opening_b)])]),
         ];
-        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        );
         let err = res.expect_err("truncated input_openings must be rejected");
         assert_eq!(
             shape_of(err),
@@ -2687,8 +2758,11 @@ mod babybear_pcs {
 
         let zeta: Challenge = p_ch.sample_algebra_element();
         let data_and_points = vec![(&data_a, vec![vec![zeta]]), (&data_b, vec![vec![zeta]])];
-        let (opening_values, mut proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
 
         // Both commitments land in the same bucket, so both slots start as `Some`. Blank
         // out the first one in place, keeping the vector's length untouched.
@@ -2709,7 +2783,12 @@ mod babybear_pcs {
             (commit_a, vec![(domain, vec![(zeta, opening_a)])]),
             (commit_b, vec![(domain, vec![(zeta, opening_b)])]),
         ];
-        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        );
         let err = res.expect_err("a blanked input opening must be rejected");
         assert_eq!(
             shape_of(err),
@@ -2741,7 +2820,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (_, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -2795,7 +2877,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -2812,8 +2897,13 @@ mod babybear_pcs {
             commit,
             vec![(domain, vec![(zeta, opening_values[0][0][0].clone())])],
         )];
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("a tampered initial-oracle fiber must be rejected");
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("a tampered initial-oracle fiber must be rejected");
         assert!(
             matches!(
                 err,
@@ -2844,7 +2934,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -2860,8 +2953,13 @@ mod babybear_pcs {
             commit,
             vec![(domain, vec![(zeta, opening_values[0][0][0].clone())])],
         )];
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("a tampered input row must be rejected");
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("a tampered input row must be rejected");
         assert!(
             matches!(err, StirError::InputError(_)),
             "expected the input Merkle check to fail, got {err:?}"
@@ -2889,7 +2987,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -2908,7 +3009,12 @@ mod babybear_pcs {
 
         let opening = opening_values[0][0][0].clone();
         let claims = vec![(commit, vec![(domain, vec![(zeta, opening)])])];
-        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        );
         let err = res.expect_err("truncated opened_values must be rejected");
         assert_eq!(
             shape_of(err),
@@ -2955,8 +3061,14 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
 
         let points: Vec<Vec<Challenge>> = prove_log_degrees.iter().map(|_| vec![zeta]).collect();
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
+            &mut p_ch,
+        );
 
         let mut v_ch = challenger_template;
         observe_commitment(&mut v_ch, &commit);
@@ -2977,7 +3089,7 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_ch,
         )
@@ -3059,8 +3171,14 @@ mod babybear_pcs {
         observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
+            &mut p_ch,
+        );
 
         let mut v_ch = challenger_template;
         observe_commitment(&mut v_ch, &commit);
@@ -3085,7 +3203,7 @@ mod babybear_pcs {
 
         let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_ch,
         );
@@ -3137,8 +3255,14 @@ mod babybear_pcs {
         observe_commitment(&mut p_ch, &commit);
         let zeta: Challenge = p_ch.sample_algebra_element();
         let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
-        let (opening_values, proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, vec![(&data, points)], &mut p_ch);
+        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points,
+            }],
+            &mut p_ch,
+        );
 
         let mut v_ch = challenger_template;
         observe_commitment(&mut v_ch, &commit);
@@ -3153,7 +3277,7 @@ mod babybear_pcs {
 
         <MyPcs as Pcs<Challenge, Challenger>>::verify(
             &pcs,
-            vec![(commit, claims)],
+            vec![(commit, claims).into()],
             &proof,
             &mut v_ch,
         )
@@ -3178,7 +3302,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -3194,7 +3321,12 @@ mod babybear_pcs {
         tampered[0] += Challenge::from(Val::ONE);
 
         let claims = vec![(commit, vec![(domain, vec![(zeta, tampered)])])];
-        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch);
+        let res = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        );
         assert!(
             res.is_err(),
             "PCS verify must reject a tampered claimed opening"
@@ -3224,7 +3356,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -3239,8 +3374,13 @@ mod babybear_pcs {
             commit,
             vec![(domain, vec![(coset_point, opening_values[0][0][0].clone())])],
         )];
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("an opening point on the evaluation domain must be rejected");
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("an opening point on the evaluation domain must be rejected");
         assert!(
             matches!(
                 err,
@@ -3271,7 +3411,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -3287,8 +3430,13 @@ mod babybear_pcs {
             commit,
             vec![(domain, vec![(v_zeta, opening_values[0][0][0].clone())])],
         )];
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("a missing height bucket must be rejected");
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("a missing height bucket must be rejected");
         assert_eq!(
             shape_of(err),
             ProofShapeError::BucketCount {
@@ -3330,8 +3478,11 @@ mod babybear_pcs {
             (&data_tall, vec![vec![zeta]]),
             (&data_short, vec![vec![zeta]]),
         ];
-        let (opening_values, mut proof) =
-            <MyPcs as Pcs<Challenge, Challenger>>::open(&pcs, data_and_points, &mut p_ch);
+        let (opening_values, mut proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
+            &pcs,
+            data_and_points.into_iter().map(Into::into).collect(),
+            &mut p_ch,
+        );
         assert_eq!(proof.len(), 2, "two heights must give two buckets");
 
         // Copy the short commitment's own opening into its (rightly empty) slot at the tall
@@ -3359,8 +3510,13 @@ mod babybear_pcs {
                 )],
             ),
         ];
-        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, &proof, &mut v_ch)
-            .expect_err("an opening at the wrong bucket must be rejected");
+        let err = <MyPcs as Pcs<Challenge, Challenger>>::verify(
+            &pcs,
+            claims.into_iter().map(Into::into).collect(),
+            &proof,
+            &mut v_ch,
+        )
+        .expect_err("an opening at the wrong bucket must be rejected");
         assert_eq!(
             shape_of(err),
             ProofShapeError::UnexpectedInputOpening {
@@ -3387,7 +3543,10 @@ mod babybear_pcs {
         let zeta: Challenge = p_ch.sample_algebra_element();
         let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
             &pcs,
-            vec![(&data, vec![vec![zeta]])],
+            vec![p3_commit::OpeningRequest {
+                prover_data: &data,
+                points: vec![vec![zeta]],
+            }],
             &mut p_ch,
         );
 
@@ -3399,7 +3558,12 @@ mod babybear_pcs {
                 commit.clone(),
                 vec![(domain, vec![(v_zeta, opening_values[0][0][0].clone())])],
             )];
-            <MyPcs as Pcs<Challenge, Challenger>>::verify(&pcs, claims, proof, &mut v_ch)
+            <MyPcs as Pcs<Challenge, Challenger>>::verify(
+                &pcs,
+                claims.into_iter().map(Into::into).collect(),
+                proof,
+                &mut v_ch,
+            )
         };
 
         // STIR commits the initial oracle itself, and that commitment is what the round-0

--- a/uni-stark/src/config.rs
+++ b/uni-stark/src/config.rs
@@ -1,7 +1,7 @@
 use core::marker::PhantomData;
 
 use p3_challenger::{CanObserve, CanSample, FieldChallenger};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_field::{ExtensionField, Field};
 
 pub type PcsError<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
@@ -43,7 +43,7 @@ pub type PackedChallenge<SC> =
 
 pub trait StarkGenericConfig: Clone {
     /// The [`Pcs`] implementation used to commit to trace polynomials.
-    type Pcs: Pcs<Self::Challenge, Self::Challenger>;
+    type Pcs: UnivariateStarkPcs<Self::Challenge, Self::Challenger>;
 
     /// The [`ExtensionField`] from which most random challenges are drawn.
     type Challenge: ExtensionField<Val<Self>>;
@@ -161,7 +161,7 @@ impl<Pcs: Clone, Challenge: Clone, Challenger: Clone> StarkConfig<Pcs, Challenge
 impl<Pcs, Challenge, Challenger> StarkGenericConfig for StarkConfig<Pcs, Challenge, Challenger>
 where
     Challenge: ExtensionField<<Pcs::Domain as PolynomialSpace>::Val> + Clone,
-    Pcs: p3_commit::Pcs<Challenge, Challenger> + Clone,
+    Pcs: p3_commit::UnivariateStarkPcs<Challenge, Challenger> + Clone,
     Challenger: FieldChallenger<<Pcs::Domain as PolynomialSpace>::Val>
         + CanObserve<Pcs::Commitment>
         + CanSample<Challenge>
@@ -185,5 +185,27 @@ where
 
     fn ood_proof_of_work_bits(&self) -> usize {
         self.ood_proof_of_work_bits
+    }
+}
+
+/// Commitment positions in the univariate STARK opening batch.
+///
+/// A hiding proof prepends a randomization commitment. The optional preprocessed
+/// commitment follows trace and quotient; batch STARK appends lookup commitments.
+#[derive(Clone, Copy, Debug)]
+pub struct StarkOpeningLayout {
+    pub trace: usize,
+    pub quotient: usize,
+    pub preprocessed: usize,
+}
+
+impl StarkOpeningLayout {
+    pub const fn new(is_zk: bool) -> Self {
+        let trace = is_zk as usize;
+        Self {
+            trace,
+            quotient: trace + 1,
+            preprocessed: trace + 2,
+        }
     }
 }

--- a/uni-stark/src/preprocessed.rs
+++ b/uni-stark/src/preprocessed.rs
@@ -1,4 +1,4 @@
-use p3_commit::Pcs;
+use p3_commit::{Pcs, UnivariateStarkPcs};
 use p3_matrix::Matrix;
 use tracing::debug_span;
 

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, get_symbolic_constraints};
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{Pcs, PolynomialSpace, UnivariateStarkPcs};
 #[cfg(all(target_arch = "aarch64", target_feature = "neon"))]
 use p3_field::Field;
 use p3_field::{PackedFieldExtension, PackedValue, PrimeCharacteristicRing};
@@ -378,6 +378,7 @@ where
     let is_random = opt_r_data.is_some();
     let main_next = !air.main_next_row_columns().is_empty();
     let pre_next = !air.preprocessed_next_row_columns().is_empty();
+    let opening_layout = crate::StarkOpeningLayout::new(SC::Pcs::ZK);
     let (opened_values, opening_proof) = info_span!("open").in_scope(|| {
         let round0 = opt_r_data.as_ref().map(|r_data| (r_data, vec![vec![zeta]]));
         let round1_points = if main_next {
@@ -400,12 +401,17 @@ where
             .into_iter()
             .chain([round1, round2])
             .chain(round3)
+            .map(Into::into)
             .collect();
 
-        pcs.open_with_preprocessing(rounds, &mut challenger, preprocessed_data_ref.is_some())
+        pcs.open_with_preprocessing(
+            rounds,
+            &mut challenger,
+            preprocessed_data_ref.map(|_| opening_layout.preprocessed),
+        )
     });
-    let trace_idx = SC::Pcs::TRACE_IDX;
-    let quotient_idx = SC::Pcs::QUOTIENT_IDX;
+    let trace_idx = opening_layout.trace;
+    let quotient_idx = opening_layout.quotient;
     let trace_local = opened_values[trace_idx][0][0].clone();
     let trace_next = if main_next {
         Some(opened_values[trace_idx][0][1].clone())
@@ -422,9 +428,9 @@ where
         None
     };
     let (preprocessed_local, preprocessed_next) = if preprocessed_width > 0 {
-        let local = Some(opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX][0][0].clone());
+        let local = Some(opened_values[opening_layout.preprocessed][0][0].clone());
         let next = if pre_next {
-            Some(opened_values[SC::Pcs::PREPROCESSED_TRACE_IDX][0][1].clone())
+            Some(opened_values[opening_layout.preprocessed][0][1].clone())
         } else {
             None
         };

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use p3_air::symbolic::SymbolicAirBuilder;
 use p3_air::{Air, RowWindow};
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
-use p3_commit::{Pcs, PolynomialSpace};
+use p3_commit::{Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_field::{BasedVectorSpace, ExtensionField, Field, PrimeCharacteristicRing};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
@@ -531,8 +531,12 @@ where
         ));
     }
 
-    pcs.verify(coms_to_verify, opening_proof, &mut challenger)
-        .map_err(VerificationError::InvalidOpeningArgument)?;
+    pcs.verify(
+        coms_to_verify.into_iter().map(Into::into).collect(),
+        opening_proof,
+        &mut challenger,
+    )
+    .map_err(VerificationError::InvalidOpeningArgument)?;
 
     let quotient = recompose_quotient_from_chunks::<SC>(
         &quotient_chunks_domains,

--- a/whir/benches/fri_vs_whir.rs
+++ b/whir/benches/fri_vs_whir.rs
@@ -622,7 +622,7 @@ where
     let t = Instant::now();
     let (openings, proof) = <TwoAdicFriPcs<F, Dft, InMmcs, ChMmcs> as Pcs<EF, Ch>>::open(
         &rig.pcs,
-        data_and_points,
+        data_and_points.into_iter().map(Into::into).collect(),
         &mut prover_challenger,
     );
     let open_ms = t.elapsed().as_millis();
@@ -669,7 +669,7 @@ where
     let t = Instant::now();
     <TwoAdicFriPcs<F, Dft, InMmcs, ChMmcs> as Pcs<EF, Ch>>::verify(
         &rig.pcs,
-        claims,
+        claims.into_iter().map(Into::into).collect(),
         proof,
         &mut verifier_challenger,
     )


### PR DESCRIPTION
`Pcs` requires STARK-specific operations even for callers that only commit, open, and verify polynomials. Split those capabilities into `UnivariateStarkPcs`, leaving a core PCS interface that a standalone implementation can satisfy without STARK stubs.

Use named opening requests and claims in place of nested input tuples, move commitment positions into STARK-owned `StarkOpeningLayout`, and pass the preprocessing request index explicitly to hiding PCS code. Migrate all five univariate backends and workspace callers. Public Rust APIs change; `commit/README.md` documents the migration. Proof serialization structures and transcript traversal are preserved.

Validation:

- 470 impacted tests passed, including existing serialized-proof compatibility coverage.
- New core-only PCS regression and hiding-FRI regression with preprocessing at request index zero.
- Workspace all-target check and warnings-denied Clippy passed; no-default-feature checks and strict impacted-crate docs passed.
- Independent code review completed with no outstanding findings.
