### PR TITLE
refactor(lookup): remove univariate STARK dependency

### DIFF
--- a/batch-stark/src/folder.rs
+++ b/batch-stark/src/folder.rs
@@ -8,8 +8,7 @@ use p3_uni_stark::{
     VerifierConstraintFolder,
 };
 
-use crate::builder::InteractionBuilder;
-use crate::count::Count;
+use p3_lookup::{Count, InteractionBuilder};
 
 pub struct ProverConstraintFolderWithLookups<'a, SC: StarkGenericConfig> {
     pub inner: ProverConstraintFolder<'a, SC>,

--- a/batch-stark/src/folder.rs
+++ b/batch-stark/src/folder.rs
@@ -1,14 +1,13 @@
 use alloc::vec::Vec;
 
 use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder, RowWindow};
+use p3_lookup::{Count, InteractionBuilder};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::ViewPair;
 use p3_uni_stark::{
     PackedChallenge, PackedVal, ProverConstraintFolder, StarkGenericConfig, Val,
     VerifierConstraintFolder,
 };
-
-use p3_lookup::{Count, InteractionBuilder};
 
 pub struct ProverConstraintFolderWithLookups<'a, SC: StarkGenericConfig> {
     pub inner: ProverConstraintFolder<'a, SC>,

--- a/batch-stark/src/lib.rs
+++ b/batch-stark/src/lib.rs
@@ -8,6 +8,7 @@ mod check_constraints;
 pub mod common;
 pub mod config;
 pub mod error;
+pub mod folder;
 pub mod proof;
 pub mod prover;
 pub mod security;

--- a/batch-stark/src/prover.rs
+++ b/batch-stark/src/prover.rs
@@ -14,7 +14,6 @@ use p3_field::{
     Algebra, BasedVectorSpace, PackedFieldExtension, PackedValue, PrimeCharacteristicRing,
     PrimeField,
 };
-use p3_lookup::folder::ProverConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
 use p3_lookup::{
     InteractionSymbolicBuilder, Lookup, LookupProtocol, LookupTerminal,
@@ -29,6 +28,7 @@ use tracing::{debug_span, info_span, instrument};
 
 use crate::common::ProverData;
 use crate::config::{Challenge, Domain, StarkGenericConfig as SGC, Val};
+use crate::folder::ProverConstraintFolderWithLookups;
 use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof, OpenedValuesWithLookups};
 use crate::symbolic::{
     get_constraint_layout, get_log_num_quotient_chunks_for_domain, get_symbolic_constraints,
@@ -257,13 +257,14 @@ where
         .for_each(|((i, inst), ext_domain)| {
             if !all_lookups[i].is_empty() {
                 // Compute the permutation argument trace and the AIR's single terminal.
-                let (generated_perm, terminal) = lookup_gadget.generate_permutation::<SC>(
-                    inst.trace,
-                    &inst.air.preprocessed_trace(),
-                    &inst.public_values,
-                    all_lookups[i],
-                    &challenges_per_instance[i],
-                );
+                let (generated_perm, terminal) = lookup_gadget
+                    .generate_permutation::<Val<SC>, SC::Challenge>(
+                        inst.trace,
+                        &inst.air.preprocessed_trace(),
+                        &inst.public_values,
+                        all_lookups[i],
+                        &challenges_per_instance[i],
+                    );
 
                 // Record the AIR's terminal for transcript observation and proof emission.
                 lookup_terminals[i] = terminal;

--- a/batch-stark/src/verifier/data.rs
+++ b/batch-stark/src/verifier/data.rs
@@ -3,13 +3,13 @@ use core::fmt::Debug;
 use p3_air::{Air, RowWindow};
 use p3_commit::PolynomialSpace;
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::{Lookup, LookupProtocol};
 use p3_matrix::dense::RowMajorMatrixView;
 use p3_matrix::stack::VerticalPair;
 use p3_uni_stark::{VerificationError, VerifierConstraintFolder};
 
 use crate::config::{Domain, StarkGenericConfig as SGC, Val};
+use crate::folder::VerifierConstraintFolderWithLookups;
 
 /// Structure storing all data needed for verifying one instance's constraints at the out-of-domain point.
 pub struct VerifierData<'a, SC: SGC> {

--- a/batch-stark/src/verifier/mod.rs
+++ b/batch-stark/src/verifier/mod.rs
@@ -9,7 +9,6 @@ use p3_air::{Air, BaseAir};
 use p3_challenger::GrindingChallenger;
 use p3_commit::{CommitmentWithOpeningPoints, Pcs, PolynomialSpace};
 use p3_field::{Algebra, BasedVectorSpace, ExtensionField, PrimeCharacteristicRing, PrimeField};
-use p3_lookup::folder::VerifierConstraintFolderWithLookups;
 use p3_lookup::logup::LogUpGadget;
 use p3_lookup::{
     InteractionSymbolicBuilder, LookupError, LookupProtocol, check_multiplicity_height_bound,
@@ -25,6 +24,7 @@ use tracing::{info_span, instrument};
 use crate::common::CommonData;
 use crate::config::{Challenge, Commitment, Domain, PcsError, StarkGenericConfig as SGC, Val};
 use crate::error::BatchVerificationError;
+use crate::folder::VerifierConstraintFolderWithLookups;
 use crate::proof::{BatchCommitments, BatchOpenedValues, BatchProof};
 use crate::symbolic::get_log_num_quotient_chunks_for_domain;
 use crate::transcript::BatchTranscript;

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -20,20 +20,12 @@ p3-air = { workspace = true }
 p3-field = { workspace = true }
 p3-matrix = { workspace = true }
 p3-maybe-rayon = { workspace = true }
-p3-uni-stark = { workspace = true }
 serde = { workspace = true, features = ["derive", "alloc"] }
 thiserror.workspace = true
 tracing = { workspace = true }
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
-p3-challenger = { path = "../challenger" }
-p3-commit = { path = "../commit" }
-p3-dft = { path = "../dft" }
-p3-fri = { path = "../fri" }
-p3-merkle-tree = { path = "../merkle-tree" }
-p3-symmetric = { path = "../symmetric" }
-
 criterion.workspace = true
 rand.workspace = true
 serde_json.workspace = true

--- a/lookup/Cargo.toml
+++ b/lookup/Cargo.toml
@@ -25,8 +25,8 @@ thiserror.workspace = true
 tracing = { workspace = true }
 
 [dev-dependencies]
-p3-baby-bear = { path = "../baby-bear" }
 criterion.workspace = true
+p3-baby-bear = { path = "../baby-bear" }
 rand.workspace = true
 serde_json.workspace = true
 

--- a/lookup/README.md
+++ b/lookup/README.md
@@ -11,4 +11,15 @@ Key items:
 - `InteractionBuilder`, `InteractionSymbolicBuilder` — AIR-builder integration for declaring sends and receives
 - `debug_util` — out-of-circuit multiset balance checks for debugging
 
+## Migration from STARK configuration parameters
+
+Lookup trace generation now takes the base field `F` and extension field `EF`
+directly. Replace `LookupTraceBuilder<'a, SC>` and `RowEvalContext<'a, SC>` with
+`LookupTraceBuilder<'a, F, EF>` and `RowEvalContext<'a, F, EF>`. In a STARK caller,
+replace `generate_permutation::<SC>` with
+`generate_permutation::<Val<SC>, SC::Challenge>`.
+
+The STARK-specific constraint folders moved from `p3_lookup::folder` to
+`p3_batch_stark::folder`. Shared lookup code no longer depends on `p3-uni-stark`.
+
 Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.

--- a/lookup/benches/logup.rs
+++ b/lookup/benches/logup.rs
@@ -3,36 +3,18 @@ use std::sync::Arc;
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{AirBuilder, WindowAccess};
-use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_challenger::DuplexChallenger;
-use p3_commit::ExtensionMmcs;
-use p3_dft::Radix2DitParallel;
+use p3_baby_bear::BabyBear;
+use p3_field::PrimeCharacteristicRing;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{Field, PrimeCharacteristicRing};
-use p3_fri::TwoAdicFriPcs;
 use p3_lookup::LookupProtocol;
 use p3_lookup::logup::LogUpGadget;
 use p3_lookup::traits::{Kind, Lookup};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_merkle_tree::MerkleTreeMmcs;
-use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::StarkConfig;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
 type F = BabyBear;
 type EF = BinomialExtensionField<F, 4>;
-type Perm = Poseidon2BabyBear<16>;
-type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-type ValMmcs =
-    MerkleTreeMmcs<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress, 2, 8>;
-type ChallengeMmcs = ExtensionMmcs<F, EF, ValMmcs>;
-type Challenger = DuplexChallenger<F, Perm, 16, 8>;
-type Dft = Radix2DitParallel<F>;
-type MyPcs = TwoAdicFriPcs<F, Dft, ValMmcs, ChallengeMmcs>;
-type SC = StarkConfig<MyPcs, EF, Challenger>;
-
 /// Per-lookup column stride: `tuple_size` read keys, `tuple_size` provide keys, one selector.
 const fn cols_per_lookup(tuple_size: usize) -> usize {
     2 * tuple_size + 1
@@ -194,7 +176,7 @@ fn bench_generate_permutation(c: &mut Criterion) {
             ),
             |b| {
                 b.iter(|| {
-                    gadget.generate_permutation::<SC>(
+                    gadget.generate_permutation::<F, EF>(
                         &main_trace,
                         &None,
                         &[],
@@ -323,7 +305,7 @@ fn bench_exclusive_vs_additive(c: &mut Criterion) {
             ),
             |b| {
                 b.iter(|| {
-                    gadget.generate_permutation::<SC>(
+                    gadget.generate_permutation::<F, EF>(
                         &trace,
                         &None,
                         &[],
@@ -340,7 +322,7 @@ fn bench_exclusive_vs_additive(c: &mut Criterion) {
             ),
             |b| {
                 b.iter(|| {
-                    gadget.generate_permutation::<SC>(
+                    gadget.generate_permutation::<F, EF>(
                         &trace,
                         &None,
                         &[],

--- a/lookup/src/lib.rs
+++ b/lookup/src/lib.rs
@@ -8,7 +8,6 @@ mod bus;
 mod challenges;
 mod count;
 pub mod debug_util;
-pub mod folder;
 pub mod logup;
 pub mod protocol;
 pub mod symbolic;

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -22,12 +22,11 @@ use alloc::vec::Vec;
 
 use itertools::Itertools;
 use p3_air::{ExtensionBuilder, PermutationAirBuilder, SymbolicExpression, WindowAccess};
-use p3_field::{Field, PrimeCharacteristicRing, dot_product};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing, dot_product};
 use p3_matrix::Matrix;
 use p3_matrix::dense::{RowMajorMatrix, RowMajorMatrixView};
 use p3_matrix::stack::VerticalPair;
 use p3_maybe_rayon::prelude::*;
-use p3_uni_stark::{StarkGenericConfig, Val};
 use tracing::instrument;
 
 use crate::protocol::LookupProtocol;
@@ -35,7 +34,7 @@ use crate::traits::LookupTraceBuilder;
 use crate::types::{Lookup, LookupError, LookupTerminal};
 
 /// Type alias for the row evaluation context used during permutation trace generation.
-pub type RowEvalContext<'a, SC> = LookupTraceBuilder<'a, SC>;
+pub type RowEvalContext<'a, F, EF> = LookupTraceBuilder<'a, F, EF>;
 
 /// Combine one tuple `(e_0, ..., e_{k-1})` into a single extension-field value.
 ///
@@ -49,22 +48,22 @@ pub type RowEvalContext<'a, SC> = LookupTraceBuilder<'a, SC>;
 /// - Those powers run `beta^{k-1}` down to `beta^1`, taken from `beta_powers[1..k]` reversed.
 /// - The product is extension times base, cheaper than the extension times extension a Horner fold uses.
 /// - This folding convention matches the symbolic side, so prover and verifier agree on the combined value.
-fn combine_tuple<SC: StarkGenericConfig>(
-    elts: &[SymbolicExpression<Val<SC>>],
-    beta_powers: &[SC::Challenge],
-    row_ctx: &RowEvalContext<'_, SC>,
-) -> SC::Challenge {
+fn combine_tuple<F: Field, EF: ExtensionField<F>>(
+    elts: &[SymbolicExpression<F>],
+    beta_powers: &[EF],
+    row_ctx: &RowEvalContext<'_, F, EF>,
+) -> EF {
     match elts.split_last() {
         // Empty tuple combines to zero.
-        None => SC::Challenge::ZERO,
+        None => EF::ZERO,
         // Width-1 tuple: the single element carries beta^0, so lift it directly.
         Some((last, [])) => last.resolve(row_ctx).into(),
         Some((last, leading)) => {
             // Powers beta^{k-1} down to beta^1, aligned with e_0 .. e_{k-2}.
             let high_powers = beta_powers[1..elts.len()].iter().rev().copied();
             let leading_resolved = leading.iter().map(|e| e.resolve(row_ctx));
-            let lifted_last: SC::Challenge = last.resolve(row_ctx).into();
-            lifted_last + dot_product::<SC::Challenge, _, _>(high_powers, leading_resolved)
+            let lifted_last: EF = last.resolve(row_ctx).into();
+            lifted_last + dot_product::<EF, _, _>(high_powers, leading_resolved)
         }
     }
 }
@@ -497,17 +496,14 @@ impl LookupProtocol for LogUpGadget {
     }
 
     #[instrument(name = "generate lookup permutation", skip_all, level = "debug")]
-    fn generate_permutation<SC: StarkGenericConfig>(
+    fn generate_permutation<F: Field, EF: ExtensionField<F>>(
         &self,
-        main: &RowMajorMatrix<Val<SC>>,
-        preprocessed: &Option<RowMajorMatrix<Val<SC>>>,
-        public_values: &[Val<SC>],
-        lookups: &[Lookup<Val<SC>>],
-        challenges: &[SC::Challenge],
-    ) -> (
-        RowMajorMatrix<SC::Challenge>,
-        Option<LookupTerminal<SC::Challenge>>,
-    ) {
+        main: &RowMajorMatrix<F>,
+        preprocessed: &Option<RowMajorMatrix<F>>,
+        public_values: &[F],
+        lookups: &[Lookup<F>],
+        challenges: &[EF],
+    ) -> (RowMajorMatrix<EF>, Option<LookupTerminal<EF>>) {
         // AIRs without lookups carry no permutation trace and no terminal.
         if lookups.is_empty() {
             return (RowMajorMatrix::new(Vec::new(), 0), None);
@@ -560,7 +556,7 @@ impl LookupProtocol for LogUpGadget {
         // Each lookup uses a pair (alpha, beta) that is constant across all rows.
         // - alpha is the rational-denominator challenge,
         // - beta combines tuple elements.
-        let lookup_challenges: Vec<(SC::Challenge, SC::Challenge)> = lookups
+        let lookup_challenges: Vec<(EF, EF)> = lookups
             .iter()
             .map(|lookup| {
                 // Index into the flat challenge array by the lookup's slot index.
@@ -583,7 +579,7 @@ impl LookupProtocol for LogUpGadget {
             .map(Vec::len)
             .max()
             .unwrap_or(0);
-        let beta_powers: Vec<Vec<SC::Challenge>> = lookup_challenges
+        let beta_powers: Vec<Vec<EF>> = lookup_challenges
             .iter()
             .map(|&(_, beta)| beta.powers().collect_n(max_tuple_width))
             .collect();
@@ -618,12 +614,12 @@ impl LookupProtocol for LogUpGadget {
         //
         //     col 0:      acc           ← filled from row_totals (parallel prefix sum, below)
         //     col i + 1:  frac_i = V/U  ← filled per row during the batch-invert chunks
-        let mut aux_trace = SC::Challenge::zero_vec(height * width);
+        let mut aux_trace = EF::zero_vec(height * width);
 
         // Per-row sum of every fraction column.
         //
         // Used as the per-row delta when building the accumulator.
-        let mut row_totals = SC::Challenge::zero_vec(height);
+        let mut row_totals = EF::zero_vec(height);
 
         aux_trace
             .par_chunks_mut(CHUNK_SIZE * width)
@@ -636,8 +632,8 @@ impl LookupProtocol for LogUpGadget {
                 let num_rows = chunk_aux.len() / width;
 
                 // Thread-local denominator and multiplicity buffers.
-                let mut local_denoms = SC::Challenge::zero_vec(num_rows * denoms_per_row);
-                let mut local_mults = Val::<SC>::zero_vec(num_rows * denoms_per_row);
+                let mut local_denoms = EF::zero_vec(num_rows * denoms_per_row);
+                let mut local_mults = F::zero_vec(num_rows * denoms_per_row);
 
                 // Phase 1: Fill denominators and multiplicities for every row in this chunk.
                 for local_i in 0..num_rows {
@@ -673,7 +669,7 @@ impl LookupProtocol for LogUpGadget {
 
                     // Concrete evaluator: resolves symbolic expressions to field values
                     // using the current row's data.
-                    let row_ctx: RowEvalContext<'_, SC> = RowEvalContext::new(
+                    let row_ctx: RowEvalContext<'_, F, EF> = RowEvalContext::new(
                         main_rows,
                         preprocessed_rows,
                         public_values,
@@ -706,9 +702,9 @@ impl LookupProtocol for LogUpGadget {
                                     // - The verifier reads the real denominator from the trace.
                                     // - So the zero term drops from both sides of `U * f = V`.
                                     local_denoms[offset] = if mult.is_zero() {
-                                        SC::Challenge::ONE
+                                        EF::ONE
                                     } else {
-                                        alpha - combine_tuple::<SC>(elts, powers, &row_ctx)
+                                        alpha - combine_tuple::<F, EF>(elts, powers, &row_ctx)
                                     };
                                     offset += 1;
                                 }
@@ -726,9 +722,9 @@ impl LookupProtocol for LogUpGadget {
                                 //
                                 //   N = sum_k flag_k * mult_k
                                 //   D = sum_k flag_k * (alpha - combine_k) + (1 - sum_k flag_k)
-                                let mut numerator = Val::<SC>::ZERO;
-                                let mut flag_sum = Val::<SC>::ZERO;
-                                let mut denom = SC::Challenge::ZERO;
+                                let mut numerator = F::ZERO;
+                                let mut flag_sum = F::ZERO;
+                                let mut denom = EF::ZERO;
                                 for (k, elts) in lookup.elements.iter().enumerate() {
                                     let flag = flags[k].resolve(&row_ctx);
 
@@ -737,7 +733,7 @@ impl LookupProtocol for LogUpGadget {
                                     //
                                     // - each flag is boolean (selects or skips its branch),
                                     debug_assert!(
-                                        flag.is_zero() || flag == Val::<SC>::ONE,
+                                        flag.is_zero() || flag == F::ONE,
                                         "exclusive flag must be boolean"
                                     );
 
@@ -751,19 +747,20 @@ impl LookupProtocol for LogUpGadget {
 
                                     let mult = lookup.multiplicities[k].resolve(&row_ctx);
                                     numerator += flag * mult;
-                                    let term = alpha - combine_tuple::<SC>(elts, powers, &row_ctx);
-                                    denom += term * SC::Challenge::from(flag);
+                                    let term =
+                                        alpha - combine_tuple::<F, EF>(elts, powers, &row_ctx);
+                                    denom += term * EF::from(flag);
                                 }
 
                                 // - at most one flag fires, so the boolean flags sum to 0 or 1.
                                 debug_assert!(
-                                    flag_sum.is_zero() || flag_sum == Val::<SC>::ONE,
+                                    flag_sum.is_zero() || flag_sum == F::ONE,
                                     "exclusive flags must sum to at most one per row"
                                 );
 
                                 // Fallback: an all-inactive row gets denominator 1.
                                 // Its fraction is then 0.
-                                denom += SC::Challenge::from(Val::<SC>::ONE - flag_sum);
+                                denom += EF::from(F::ONE - flag_sum);
                                 local_denoms[offset] = denom;
                                 local_mults[offset] = numerator;
                                 offset += 1;
@@ -791,7 +788,7 @@ impl LookupProtocol for LogUpGadget {
                 for (local_i, row_total_slot) in chunk_row_totals.iter_mut().enumerate() {
                     let inv_base = local_i * denoms_per_row;
                     let row_offset = local_i * width;
-                    let mut row_total = SC::Challenge::ZERO;
+                    let mut row_total = EF::ZERO;
                     for lookup_idx in 0..lookups.len() {
                         // Slice out the range of denominators belonging to this lookup.
                         let start = lookup_denom_offsets[lookup_idx];
@@ -839,7 +836,7 @@ impl LookupProtocol for LogUpGadget {
 
         // Phase B — Combine chunk totals into cumulative offsets.
         // Only as many entries as there are chunks (one per thread), so this is tiny.
-        let mut offsets = SC::Challenge::zero_vec(height.div_ceil(chunk_size));
+        let mut offsets = EF::zero_vec(height.div_ceil(chunk_size));
         for i in 1..offsets.len() {
             offsets[i] = offsets[i - 1] + row_totals[i * chunk_size - 1];
         }

--- a/lookup/src/logup.rs
+++ b/lookup/src/logup.rs
@@ -749,7 +749,7 @@ impl LookupProtocol for LogUpGadget {
                                     numerator += flag * mult;
                                     let term =
                                         alpha - combine_tuple::<F, EF>(elts, powers, &row_ctx);
-                                    denom += term * EF::from(flag);
+                                    denom += term * flag;
                                 }
 
                                 // - at most one flag fires, so the boolean flags sum to 0 or 1.
@@ -760,7 +760,7 @@ impl LookupProtocol for LogUpGadget {
 
                                 // Fallback: an all-inactive row gets denominator 1.
                                 // Its fraction is then 0.
-                                denom += EF::from(F::ONE - flag_sum);
+                                denom += F::ONE - flag_sum;
                                 local_denoms[offset] = denom;
                                 local_mults[offset] = numerator;
                                 offset += 1;

--- a/lookup/src/protocol.rs
+++ b/lookup/src/protocol.rs
@@ -1,9 +1,8 @@
 //! The lookup protocol trait.
 
 use p3_air::{Air, PermutationAirBuilder};
-use p3_field::Field;
+use p3_field::{ExtensionField, Field};
 use p3_matrix::dense::RowMajorMatrix;
-use p3_uni_stark::{StarkGenericConfig, Val};
 
 use crate::types::{Lookup, LookupError, LookupTerminal};
 
@@ -88,17 +87,14 @@ pub trait LookupProtocol {
     /// - A trace matrix with the accumulator at column `0` and one fraction
     ///   column per declared lookup.
     /// - The AIR's terminal: `Some(_)` when any lookup is declared, `None` otherwise.
-    fn generate_permutation<SC: StarkGenericConfig>(
+    fn generate_permutation<F: Field, EF: ExtensionField<F>>(
         &self,
-        main: &RowMajorMatrix<Val<SC>>,
-        preprocessed: &Option<RowMajorMatrix<Val<SC>>>,
-        public_values: &[Val<SC>],
-        lookups: &[Lookup<Val<SC>>],
-        challenges: &[SC::Challenge],
-    ) -> (
-        RowMajorMatrix<SC::Challenge>,
-        Option<LookupTerminal<SC::Challenge>>,
-    );
+        main: &RowMajorMatrix<F>,
+        preprocessed: &Option<RowMajorMatrix<F>>,
+        public_values: &[F],
+        lookups: &[Lookup<F>],
+        challenges: &[EF],
+    ) -> (RowMajorMatrix<EF>, Option<LookupTerminal<EF>>);
 
     /// Verify the cross-AIR sum of committed terminals is zero.
     ///

--- a/lookup/src/tests.rs
+++ b/lookup/src/tests.rs
@@ -7,18 +7,11 @@ use p3_air::symbolic::{AirLayout, SymbolicAirBuilder, SymbolicExpression};
 use p3_air::{
     Air, AirBuilder, BaseAir, BaseLeaf, ExtensionBuilder, PermutationAirBuilder, WindowAccess,
 };
-use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-use p3_challenger::DuplexChallenger;
-use p3_commit::ExtensionMmcs;
-use p3_dft::Radix2DitParallel;
+use p3_baby_bear::BabyBear;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
-use p3_fri::TwoAdicFriPcs;
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_merkle_tree::MerkleTreeMmcs;
-use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
-use p3_uni_stark::StarkConfig;
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
@@ -33,18 +26,6 @@ use crate::types::{Kind, Lookup, LookupError, LookupTerminal};
 type F = BabyBear;
 /// Quartic extension field.
 type EF = BinomialExtensionField<F, 4>;
-
-// Minimal stark-config used as the `SC` parameter for `generate_permutation`.
-type Perm = Poseidon2BabyBear<16>;
-type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-type ValMmcs =
-    MerkleTreeMmcs<<F as Field>::Packing, <F as Field>::Packing, MyHash, MyCompress, 2, 8>;
-type ChallengeMmcs = ExtensionMmcs<F, EF, ValMmcs>;
-type Challenger = DuplexChallenger<F, Perm, 16, 8>;
-type Dft = Radix2DitParallel<F>;
-type MyPcs = TwoAdicFriPcs<F, Dft, ValMmcs, ChallengeMmcs>;
-type TestConfig = StarkConfig<MyPcs, EF, Challenger>;
 
 fn create_symbolic_with_degree(degree: usize) -> SymbolicExpression<F> {
     let x = Arc::new(SymbolicExpression::Leaf(BaseLeaf::Constant(F::ONE)));
@@ -479,7 +460,7 @@ fn generate_permutation_balances_to_zero_terminal() {
     let challenges = vec![EF::from_u32(7), EF::from_u32(11)];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 
     // The aux trace carries one accumulator column plus one fraction column.
     assert_eq!(aux.width(), 2);
@@ -530,7 +511,7 @@ fn generate_permutation_flag_zero_skip_matches_real_denominators() {
     let challenges = vec![alpha, beta];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 
     // Reference fraction per row, built from the real denominators:
     //   f[r] = 1 / (alpha - query[r])  +  (-mult[r]) / (alpha - table[r])
@@ -605,8 +586,7 @@ fn generate_permutation_multi_element_combine_matches_reference() {
     let beta = EF::from_u32(11);
     let challenges = vec![alpha, beta];
 
-    let (aux, _) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+    let (aux, _) = gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 
     // Reference: f[r] = mult[r] / (alpha - (e_0[r] * beta + e_1[r])).
     for r in 0..height {
@@ -628,7 +608,7 @@ fn eval_all_passes_on_balanced_trace() {
     let challenges = vec![EF::from_u32(0x12345678), EF::from_u32(0x87654321)];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
     let terminal = terminal.unwrap();
 
     // Walk every row and check the lookup constraints fire without panic.
@@ -671,7 +651,7 @@ fn eval_all_passes_on_multi_lookup_balanced_trace() {
     ];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
     // 1 accumulator + 2 fraction columns.
     assert_eq!(aux.width(), 3);
     let terminal = terminal.unwrap();
@@ -696,7 +676,7 @@ fn eval_all_rejects_unbalanced_trace() {
     let challenges = vec![EF::from_u32(13), EF::from_u32(17)];
 
     let (mut aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 
     // Tamper with the fraction column on row 2: violates U * frac - V = 0.
     let aux_width = aux.width();
@@ -806,14 +786,14 @@ fn eval_all_global_lookup_carries_terminal_through_permutation_values() {
     // Both AIRs share the same (alpha, beta) for the same bus.
     let challenges = vec![EF::from_u32(0x1234), EF::from_u32(0x5678)];
 
-    let (sender_aux, sender_terminal) = gadget.generate_permutation::<TestConfig>(
+    let (sender_aux, sender_terminal) = gadget.generate_permutation::<F, EF>(
         &sender_main,
         &None,
         &[],
         core::slice::from_ref(&sender_lookup),
         &challenges,
     );
-    let (receiver_aux, receiver_terminal) = gadget.generate_permutation::<TestConfig>(
+    let (receiver_aux, receiver_terminal) = gadget.generate_permutation::<F, EF>(
         &receiver_main,
         &None,
         &[],
@@ -862,7 +842,7 @@ fn eval_all_global_lookup_carries_terminal_through_permutation_values() {
 fn empty_lookups_produce_no_permutation_trace() {
     let gadget = LogUpGadget::new();
     let main = RowMajorMatrix::new(F::zero_vec(4), 1);
-    let (aux, terminal) = gadget.generate_permutation::<TestConfig>(&main, &None, &[], &[], &[]);
+    let (aux, terminal) = gadget.generate_permutation::<F, EF>(&main, &None, &[], &[], &[]);
     assert_eq!(aux.width(), 0);
     assert_eq!(aux.values.len(), 0);
     assert!(terminal.is_none());
@@ -1005,7 +985,7 @@ fn test_nontrivial_permutation() {
     let challenges = vec![EF::from_u32(0x1234_5678), EF::from_u32(0x9abc_def0)];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main_trace, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main_trace, &None, &[], &lookups, &challenges);
     let terminal = terminal.unwrap();
 
     // Balanced multiset → terminal is zero with overwhelming probability.
@@ -1044,7 +1024,7 @@ fn test_zero_multiplicity_is_not_counted() {
     let challenges = vec![EF::from_u8(123), EF::from_u8(111)];
 
     let (_aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main_trace, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main_trace, &None, &[], &lookups, &challenges);
     let terminal = terminal.unwrap();
 
     // The unread `10` survives into the terminal.
@@ -1087,7 +1067,7 @@ fn test_inconsistent_witness_fails_transition() {
     let challenges = vec![EF::from_u32(31), EF::from_u32(41)];
 
     let (mut aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main_trace, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main_trace, &None, &[], &lookups, &challenges);
 
     // Corrupt acc[2] (accumulator column, row 2) by injecting a non-zero delta.
     //
@@ -1203,7 +1183,7 @@ fn test_tuple_lookup() {
     let challenges = vec![EF::from_u32(31), EF::from_u32(41)];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main_trace, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main_trace, &None, &[], &lookups, &challenges);
     let terminal = terminal.unwrap();
 
     // Balanced multiset → terminal zero.
@@ -1372,7 +1352,7 @@ fn generate_permutation_exclusive_selects_active_branch() {
     let challenges = vec![alpha, beta];
 
     let (aux, terminal) =
-        gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+        gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 
     // The fraction column equals the selected branch's value, or 0 when inactive.
     for (r, &which) in active.iter().enumerate() {
@@ -1452,7 +1432,7 @@ fn generate_permutation_exclusive_rejects_non_boolean_flag() {
 
     let gadget = LogUpGadget::new();
     let challenges = vec![EF::from_u32(17), EF::from_u32(11)];
-    let _ = gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+    let _ = gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 }
 
 #[test]
@@ -1484,7 +1464,7 @@ fn generate_permutation_exclusive_rejects_two_active_flags() {
 
     let gadget = LogUpGadget::new();
     let challenges = vec![EF::from_u32(17), EF::from_u32(11)];
-    let _ = gadget.generate_permutation::<TestConfig>(&main, &None, &[], &lookups, &challenges);
+    let _ = gadget.generate_permutation::<F, EF>(&main, &None, &[], &lookups, &challenges);
 }
 
 #[test]

--- a/lookup/src/traits.rs
+++ b/lookup/src/traits.rs
@@ -1,26 +1,25 @@
 use p3_air::{AirBuilder, ExtensionBuilder, PermutationAirBuilder, RowWindow};
-use p3_field::PrimeCharacteristicRing;
+use p3_field::{ExtensionField, Field};
 use p3_matrix::stack::ViewPair;
-use p3_uni_stark::{StarkGenericConfig, Val};
 
 pub use crate::types::{Kind, Lookup, LookupError, LookupTerminal};
 
 /// A builder to generate the lookup traces, given the main trace, public values and permutation challenges.
-pub struct LookupTraceBuilder<'a, SC: StarkGenericConfig> {
-    main: ViewPair<'a, Val<SC>>,
-    preprocessed: RowWindow<'a, Val<SC>>,
-    public_values: &'a [Val<SC>],
-    permutation_challenges: &'a [SC::Challenge],
+pub struct LookupTraceBuilder<'a, F: Field, EF: ExtensionField<F>> {
+    main: ViewPair<'a, F>,
+    preprocessed: RowWindow<'a, F>,
+    public_values: &'a [F],
+    permutation_challenges: &'a [EF],
     height: usize,
     row: usize,
 }
 
-impl<'a, SC: StarkGenericConfig> LookupTraceBuilder<'a, SC> {
+impl<'a, F: Field, EF: ExtensionField<F>> LookupTraceBuilder<'a, F, EF> {
     pub fn new(
-        main: ViewPair<'a, Val<SC>>,
-        preprocessed: ViewPair<'a, Val<SC>>,
-        public_values: &'a [Val<SC>],
-        permutation_challenges: &'a [SC::Challenge],
+        main: ViewPair<'a, F>,
+        preprocessed: ViewPair<'a, F>,
+        public_values: &'a [F],
+        permutation_challenges: &'a [EF],
         height: usize,
         row: usize,
     ) -> Self {
@@ -38,14 +37,14 @@ impl<'a, SC: StarkGenericConfig> LookupTraceBuilder<'a, SC> {
     }
 }
 
-impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
-    type F = Val<SC>;
-    type Expr = Val<SC>;
-    type Var = Val<SC>;
-    type PreprocessedWindow = RowWindow<'a, Val<SC>>;
-    type MainWindow = RowWindow<'a, Val<SC>>;
-    type PublicVar = Val<SC>;
-    type PeriodicVar = Val<SC>;
+impl<'a, F: Field, EF: ExtensionField<F>> AirBuilder for LookupTraceBuilder<'a, F, EF> {
+    type F = F;
+    type Expr = F;
+    type Var = F;
+    type PreprocessedWindow = RowWindow<'a, F>;
+    type MainWindow = RowWindow<'a, F>;
+    type PublicVar = F;
+    type PeriodicVar = F;
 
     #[inline]
     fn main(&self) -> Self::MainWindow {
@@ -89,31 +88,31 @@ impl<'a, SC: StarkGenericConfig> AirBuilder for LookupTraceBuilder<'a, SC> {
     }
 }
 
-impl<SC: StarkGenericConfig> ExtensionBuilder for LookupTraceBuilder<'_, SC> {
-    type EF = SC::Challenge;
-    type ExprEF = SC::Challenge;
-    type VarEF = SC::Challenge;
+impl<F: Field, EF: ExtensionField<F>> ExtensionBuilder for LookupTraceBuilder<'_, F, EF> {
+    type EF = EF;
+    type ExprEF = EF;
+    type VarEF = EF;
 
     fn assert_zero_ext<I: Into<Self::ExprEF>>(&mut self, x: I) {
-        assert!(x.into() == SC::Challenge::ZERO);
+        assert!(x.into() == EF::ZERO);
     }
 }
 
-impl<'a, SC: StarkGenericConfig> PermutationAirBuilder for LookupTraceBuilder<'a, SC> {
-    type MP = RowWindow<'a, SC::Challenge>;
-    type RandomVar = SC::Challenge;
+impl<'a, F: Field, EF: ExtensionField<F>> PermutationAirBuilder for LookupTraceBuilder<'a, F, EF> {
+    type MP = RowWindow<'a, EF>;
+    type RandomVar = EF;
 
-    type PermutationVar = SC::Challenge;
+    type PermutationVar = EF;
 
     fn permutation(&self) -> Self::MP {
         panic!("we should not be accessing the permutation matrix while building it");
     }
 
-    fn permutation_randomness(&self) -> &[SC::Challenge] {
+    fn permutation_randomness(&self) -> &[EF] {
         self.permutation_challenges
     }
 
-    fn permutation_values(&self) -> &[SC::Challenge] {
+    fn permutation_values(&self) -> &[EF] {
         &[]
     }
 }


### PR DESCRIPTION
Shared lookup generation currently depends on an entire univariate STARK configuration, pulling `p3-uni-stark` into consumers such as multilinear proving. Parameterize lookup trace generation directly by base and extension fields, and move the univariate constraint-folder adapters into `p3_batch_stark::folder`.

Remove the normal `p3-uni-stark` dependency and unused configuration-fixture dependencies, migrate callers/tests/benchmarks, and document the public API changes in `lookup/README.md`. Lookup arithmetic, challenge order, accumulator layout, and serialization are preserved.

Validation:

- Lookup: 55 tests passed; batch-STARK: 61 passed; multilinear STARK: 105 passed.
- Default/parallel all-target checks, warnings-denied Clippy, and docs passed for the affected crates.
- Cargo dependency graphs confirm that lookup and multilinear STARK no longer include `p3-uni-stark` through lookup.
- Independent code review completed with no outstanding findings.
