### PR TITLE
test: share PCS opening contracts and batch fixtures

### DIFF
--- a/batch-stark/tests/common/config.rs
+++ b/batch-stark/tests/common/config.rs
@@ -1,0 +1,190 @@
+//! Deterministic backend configurations shared by the batch contract tests.
+
+use core::marker::PhantomData;
+
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
+use p3_circle::CirclePcs;
+use p3_commit::ExtensionMmcs;
+use p3_dft::Radix2DitParallel;
+use p3_field::Field;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs};
+use p3_keccak::Keccak256Hash;
+use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
+use p3_mersenne_31::Mersenne31;
+use p3_symmetric::{
+    CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
+};
+use p3_uni_stark::StarkConfig;
+use p3_util::{assert_clone, assert_send, assert_sync};
+use rand::SeedableRng;
+use rand::rngs::{SmallRng, StdRng};
+
+pub(super) type Val = BabyBear;
+pub(super) type Challenge = BinomialExtensionField<Val, 4>;
+type Perm = Poseidon2BabyBear<16>;
+type PermWide = Poseidon2BabyBear<32>;
+type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
+type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
+type MyCompressWide = TruncatedPermutation<PermWide, 4, 8, 32>;
+type ValMmcs =
+    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 2, 8>;
+type ValMmcsWide =
+    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompressWide, 4, 8>;
+type HidingValMmcs = MerkleTreeHidingMmcs<
+    <Val as Field>::Packing,
+    <Val as Field>::Packing,
+    MyHash,
+    MyCompress,
+    StdRng,
+    2,
+    8,
+    4,
+>;
+type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
+type ChallengeMmcsWide = ExtensionMmcs<Val, Challenge, ValMmcsWide>;
+type HidingChallengeMmcs = ExtensionMmcs<Val, Challenge, HidingValMmcs>;
+type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
+type Dft = Radix2DitParallel<Val>;
+type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
+type MyPcsWide = TwoAdicFriPcs<Val, Dft, ValMmcsWide, ChallengeMmcsWide>;
+type HidingPcs = HidingFriPcs<Val, Dft, HidingValMmcs, HidingChallengeMmcs, StdRng>;
+pub(super) type MyConfig = StarkConfig<MyPcs, Challenge, Challenger>;
+pub(super) type MyConfigWide = StarkConfig<MyPcsWide, Challenge, Challenger>;
+pub(super) type MyHidingConfig = StarkConfig<HidingPcs, Challenge, Challenger>;
+
+pub(super) fn make_config(seed: u64) -> MyConfig {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft::default();
+    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
+    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
+    let challenger = Challenger::new(perm);
+    StarkConfig::new(pcs, challenger)
+}
+
+/// Minimal FRI shape so a tiny trace still completes `prove_batch` / `verify_batch`.
+pub(super) fn make_config_allow_tiny_trace(seed: u64) -> MyConfig {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft::default();
+    let fri_params = FriParameters {
+        log_blowup: 1,
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 2,
+        batch_proof_of_work_bits: 0,
+        commit_proof_of_work_bits: 1,
+        query_proof_of_work_bits: 1,
+        mmcs: challenge_mmcs,
+    };
+    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
+    let challenger = Challenger::new(perm);
+    StarkConfig::new(pcs, challenger)
+}
+
+/// Same as make_config, but with a different arity.
+pub(super) fn make_config_wide(seed: u64) -> MyConfigWide {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let perm_wide = PermWide::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompressWide::new(perm_wide);
+    let val_mmcs = ValMmcsWide::new(hash, compress, 0);
+    let challenge_mmcs = ChallengeMmcsWide::new(val_mmcs.clone());
+    let dft = Dft::default();
+    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
+    let pcs = MyPcsWide::new(dft, val_mmcs, fri_params);
+    let challenger = Challenger::new(perm);
+    StarkConfig::new(pcs, challenger)
+}
+
+pub(super) fn make_two_adic_compat_config(seed: u64) -> MyConfig {
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = ValMmcs::new(hash, compress, 1);
+    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft::default();
+    let fri_params = FriParameters {
+        log_blowup: 2,
+        log_final_poly_len: 2,
+        max_log_arity: 1,
+        num_queries: 2,
+        batch_proof_of_work_bits: 0,
+        commit_proof_of_work_bits: 1,
+        query_proof_of_work_bits: 1,
+        mmcs: challenge_mmcs,
+    };
+    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
+    let challenger = Challenger::new(perm);
+    StarkConfig::new(pcs, challenger)
+}
+
+pub(super) fn make_config_zk(seed: u64) -> MyHidingConfig {
+    assert_clone::<HidingValMmcs>();
+    assert_sync::<HidingValMmcs>();
+    assert_send::<HidingPcs>();
+    assert_sync::<HidingPcs>();
+    assert_sync::<MyHidingConfig>();
+
+    let mut rng = SmallRng::seed_from_u64(seed);
+    let perm = Perm::new_from_rng_128(&mut rng);
+    let hash = MyHash::new(perm.clone());
+    let compress = MyCompress::new(perm.clone());
+    let val_mmcs = HidingValMmcs::new(hash, compress, 2, StdRng::seed_from_u64(1));
+    let challenge_mmcs = HidingChallengeMmcs::new(val_mmcs.clone());
+    let dft = Dft::default();
+    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
+    let pcs = HidingPcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
+    let challenger = Challenger::new(perm);
+    StarkConfig::new(pcs, challenger)
+}
+
+pub(super) type CircleVal = Mersenne31;
+type CircleChallenge = BinomialExtensionField<CircleVal, 3>;
+type CircleByteHash = Keccak256Hash;
+type CircleFieldHash = SerializingHasher<CircleByteHash>;
+type CircleCompress = CompressionFunctionFromHasher<CircleByteHash, 2, 32>;
+type CircleValMmcs = MerkleTreeMmcs<CircleVal, u8, CircleFieldHash, CircleCompress, 2, 32>;
+type CircleChallengeMmcs = ExtensionMmcs<CircleVal, CircleChallenge, CircleValMmcs>;
+type CircleChallenger = SerializingChallenger32<CircleVal, HashChallenger<u8, CircleByteHash, 32>>;
+type CirclePcsType = CirclePcs<CircleVal, CircleValMmcs, CircleChallengeMmcs>;
+pub(super) type CircleConfig = StarkConfig<CirclePcsType, CircleChallenge, CircleChallenger>;
+
+pub(super) fn make_circle_config() -> CircleConfig {
+    let byte_hash = CircleByteHash {};
+    let field_hash = CircleFieldHash::new(byte_hash);
+    let compress = CircleCompress::new(byte_hash);
+    let val_mmcs = CircleValMmcs::new(field_hash, compress, 3);
+    let challenge_mmcs = CircleChallengeMmcs::new(val_mmcs.clone());
+
+    let fri_params = FriParameters {
+        log_blowup: 1,
+        log_final_poly_len: 0,
+        max_log_arity: 1,
+        num_queries: 40,
+        batch_proof_of_work_bits: 0,
+        commit_proof_of_work_bits: 8,
+        query_proof_of_work_bits: 8,
+        mmcs: challenge_mmcs,
+    };
+
+    let pcs = CirclePcsType {
+        mmcs: val_mmcs,
+        fri_params,
+        _phantom: PhantomData,
+    };
+    let challenger = CircleChallenger::from_hasher(vec![], byte_hash);
+    CircleConfig::new(pcs, challenger)
+}

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -1,36 +1,29 @@
+#[path = "common/config.rs"]
+mod config;
+
 use core::borrow::Borrow;
 use core::fmt::Debug;
-use core::marker::PhantomData;
 use core::slice::from_ref;
 use std::borrow::Cow;
 
+use config::{
+    Challenge, CircleConfig, CircleVal, MyConfig, MyConfigWide, MyHidingConfig, Val,
+    make_circle_config, make_config, make_config_allow_tiny_trace, make_config_wide,
+    make_config_zk, make_two_adic_compat_config,
+};
 use p3_air::{Air, AirBuilder, BaseAir, PermutationAirBuilder, WindowAccess};
-use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_batch_stark::proof::{BatchProof, OpenedValuesWithLookups};
 use p3_batch_stark::{
     BatchVerificationError, InvalidLookupPow, ProverData, StarkGenericConfig, StarkInstance,
     VerificationError, prove_batch, verify_batch,
 };
-use p3_challenger::{DuplexChallenger, HashChallenger, SerializingChallenger32};
-use p3_circle::CirclePcs;
-use p3_commit::ExtensionMmcs;
-use p3_dft::Radix2DitParallel;
-use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
-use p3_fri::{FriParameters, HidingFriPcs, TwoAdicFriPcs};
-use p3_keccak::Keccak256Hash;
+use p3_fri::FriParameters;
 use p3_lookup::{Count, InteractionBuilder, LookupError, LookupTerminal};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
-use p3_merkle_tree::{MerkleTreeHidingMmcs, MerkleTreeMmcs};
-use p3_mersenne_31::Mersenne31;
-use p3_symmetric::{
-    CompressionFunctionFromHasher, PaddingFreeSponge, SerializingHasher, TruncatedPermutation,
-};
-use p3_uni_stark::{InvalidProofShapeError, OpeningShape, PeriodicColumnError, StarkConfig};
-use p3_util::{assert_clone, assert_send, assert_sync, log2_strict_usize};
-use rand::SeedableRng;
-use rand::rngs::{SmallRng, StdRng};
+use p3_uni_stark::{InvalidProofShapeError, OpeningShape, PeriodicColumnError};
+use p3_util::log2_strict_usize;
 
 const TWO_ADIC_FIXTURE: &str = "tests/fixtures/batch_stark_two_adic_v0_8_0.postcard";
 const CIRCLE_FIXTURE: &str = "tests/fixtures/batch_stark_circle_v0_8_0.postcard";
@@ -487,176 +480,6 @@ fn preprocessed_mul_trace<F: Field>(rows: usize, multiplier: u64) -> RowMajorMat
         *val = F::from_u64(i as u64 * multiplier);
     }
     RowMajorMatrix::new(v, 1)
-}
-
-// --- Config types ---
-
-type Val = BabyBear;
-type Challenge = BinomialExtensionField<Val, 4>;
-type Perm = Poseidon2BabyBear<16>;
-type PermWide = Poseidon2BabyBear<32>;
-type MyHash = PaddingFreeSponge<Perm, 16, 8, 8>;
-type MyCompress = TruncatedPermutation<Perm, 2, 8, 16>;
-type MyCompressWide = TruncatedPermutation<PermWide, 4, 8, 32>;
-type ValMmcs =
-    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompress, 2, 8>;
-type ValMmcsWide =
-    MerkleTreeMmcs<<Val as Field>::Packing, <Val as Field>::Packing, MyHash, MyCompressWide, 4, 8>;
-type HidingValMmcs = MerkleTreeHidingMmcs<
-    <Val as Field>::Packing,
-    <Val as Field>::Packing,
-    MyHash,
-    MyCompress,
-    StdRng,
-    2,
-    8,
-    4,
->;
-type ChallengeMmcs = ExtensionMmcs<Val, Challenge, ValMmcs>;
-type ChallengeMmcsWide = ExtensionMmcs<Val, Challenge, ValMmcsWide>;
-type HidingChallengeMmcs = ExtensionMmcs<Val, Challenge, HidingValMmcs>;
-type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
-type Dft = Radix2DitParallel<Val>;
-type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
-type MyPcsWide = TwoAdicFriPcs<Val, Dft, ValMmcsWide, ChallengeMmcsWide>;
-type HidingPcs = HidingFriPcs<Val, Dft, HidingValMmcs, HidingChallengeMmcs, StdRng>;
-type MyConfig = StarkConfig<MyPcs, Challenge, Challenger>;
-type MyConfigWide = StarkConfig<MyPcsWide, Challenge, Challenger>;
-type MyHidingConfig = StarkConfig<HidingPcs, Challenge, Challenger>;
-
-fn make_config(seed: u64) -> MyConfig {
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let perm = Perm::new_from_rng_128(&mut rng);
-    let hash = MyHash::new(perm.clone());
-    let compress = MyCompress::new(perm.clone());
-    let val_mmcs = ValMmcs::new(hash, compress, 0);
-    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-    let dft = Dft::default();
-    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
-    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
-    let challenger = Challenger::new(perm);
-    StarkConfig::new(pcs, challenger)
-}
-
-/// Minimal FRI shape so a tiny trace still completes `prove_batch` / `verify_batch`.
-fn make_config_allow_tiny_trace(seed: u64) -> MyConfig {
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let perm = Perm::new_from_rng_128(&mut rng);
-    let hash = MyHash::new(perm.clone());
-    let compress = MyCompress::new(perm.clone());
-    let val_mmcs = ValMmcs::new(hash, compress, 0);
-    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-    let dft = Dft::default();
-    let fri_params = FriParameters {
-        log_blowup: 1,
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 2,
-        batch_proof_of_work_bits: 0,
-        commit_proof_of_work_bits: 1,
-        query_proof_of_work_bits: 1,
-        mmcs: challenge_mmcs,
-    };
-    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
-    let challenger = Challenger::new(perm);
-    StarkConfig::new(pcs, challenger)
-}
-
-/// Same as make_config, but with a different arity.
-fn make_config_wide(seed: u64) -> MyConfigWide {
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let perm = Perm::new_from_rng_128(&mut rng);
-    let perm_wide = PermWide::new_from_rng_128(&mut rng);
-    let hash = MyHash::new(perm.clone());
-    let compress = MyCompressWide::new(perm_wide);
-    let val_mmcs = ValMmcsWide::new(hash, compress, 0);
-    let challenge_mmcs = ChallengeMmcsWide::new(val_mmcs.clone());
-    let dft = Dft::default();
-    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
-    let pcs = MyPcsWide::new(dft, val_mmcs, fri_params);
-    let challenger = Challenger::new(perm);
-    StarkConfig::new(pcs, challenger)
-}
-
-fn make_two_adic_compat_config(seed: u64) -> MyConfig {
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let perm = Perm::new_from_rng_128(&mut rng);
-    let hash = MyHash::new(perm.clone());
-    let compress = MyCompress::new(perm.clone());
-    let val_mmcs = ValMmcs::new(hash, compress, 1);
-    let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
-    let dft = Dft::default();
-    let fri_params = FriParameters {
-        log_blowup: 2,
-        log_final_poly_len: 2,
-        max_log_arity: 1,
-        num_queries: 2,
-        batch_proof_of_work_bits: 0,
-        commit_proof_of_work_bits: 1,
-        query_proof_of_work_bits: 1,
-        mmcs: challenge_mmcs,
-    };
-    let pcs = MyPcs::new(dft, val_mmcs, fri_params);
-    let challenger = Challenger::new(perm);
-    StarkConfig::new(pcs, challenger)
-}
-
-fn make_config_zk(seed: u64) -> MyHidingConfig {
-    assert_clone::<HidingValMmcs>();
-    assert_sync::<HidingValMmcs>();
-    assert_send::<HidingPcs>();
-    assert_sync::<HidingPcs>();
-    assert_sync::<MyHidingConfig>();
-
-    let mut rng = SmallRng::seed_from_u64(seed);
-    let perm = Perm::new_from_rng_128(&mut rng);
-    let hash = MyHash::new(perm.clone());
-    let compress = MyCompress::new(perm.clone());
-    let val_mmcs = HidingValMmcs::new(hash, compress, 2, StdRng::seed_from_u64(1));
-    let challenge_mmcs = HidingChallengeMmcs::new(val_mmcs.clone());
-    let dft = Dft::default();
-    let fri_params = FriParameters::new_testing(challenge_mmcs, 2);
-    let pcs = HidingPcs::new(dft, val_mmcs, fri_params, 4, StdRng::seed_from_u64(2));
-    let challenger = Challenger::new(perm);
-    StarkConfig::new(pcs, challenger)
-}
-
-type CircleVal = Mersenne31;
-type CircleChallenge = BinomialExtensionField<CircleVal, 3>;
-type CircleByteHash = Keccak256Hash;
-type CircleFieldHash = SerializingHasher<CircleByteHash>;
-type CircleCompress = CompressionFunctionFromHasher<CircleByteHash, 2, 32>;
-type CircleValMmcs = MerkleTreeMmcs<CircleVal, u8, CircleFieldHash, CircleCompress, 2, 32>;
-type CircleChallengeMmcs = ExtensionMmcs<CircleVal, CircleChallenge, CircleValMmcs>;
-type CircleChallenger = SerializingChallenger32<CircleVal, HashChallenger<u8, CircleByteHash, 32>>;
-type CirclePcsType = CirclePcs<CircleVal, CircleValMmcs, CircleChallengeMmcs>;
-type CircleConfig = StarkConfig<CirclePcsType, CircleChallenge, CircleChallenger>;
-
-fn make_circle_config() -> CircleConfig {
-    let byte_hash = CircleByteHash {};
-    let field_hash = CircleFieldHash::new(byte_hash);
-    let compress = CircleCompress::new(byte_hash);
-    let val_mmcs = CircleValMmcs::new(field_hash, compress, 3);
-    let challenge_mmcs = CircleChallengeMmcs::new(val_mmcs.clone());
-
-    let fri_params = FriParameters {
-        log_blowup: 1,
-        log_final_poly_len: 0,
-        max_log_arity: 1,
-        num_queries: 40,
-        batch_proof_of_work_bits: 0,
-        commit_proof_of_work_bits: 8,
-        query_proof_of_work_bits: 8,
-        mmcs: challenge_mmcs,
-    };
-
-    let pcs = CirclePcsType {
-        mmcs: val_mmcs,
-        fri_params,
-        _phantom: PhantomData,
-    };
-    let challenger = CircleChallenger::from_hasher(vec![], byte_hash);
-    CircleConfig::new(pcs, challenger)
 }
 
 // Heterogeneous enum wrapper for batching

--- a/commit/README.md
+++ b/commit/README.md
@@ -18,8 +18,9 @@ Implementations live in `p3-merkle-tree` (Mmcs), `p3-fri`, `p3-circle` and
 `testing::assert_pcs_opening_contract` exercises real transparent backends with
 caller-supplied matrices and independently computed expected values. It checks
 batched opening order, honest verification, transcript agreement, and rejection
-of modified values and missing matrix/column claims. FRI, Circle, and STIR use
-this helper alongside their backend-specific tests.
+of swapped point fields, modified values and missing matrix/column claims. Fixtures
+must include a multi-matrix commitment and point-dependent expected values. FRI,
+Circle, and STIR use this helper alongside their backend-specific tests.
 
 Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.
 

--- a/commit/README.md
+++ b/commit/README.md
@@ -10,10 +10,16 @@ Key items:
 - `Mmcs` — "Mixed Matrix Commitment Scheme", a vector-commitment abstraction over batches of matrices of differing heights
 - `PolynomialSpace` and `TwoAdicMultiplicativeCoset` — evaluation-domain abstractions
 - `periodic` — periodic-column evaluation helpers
-- `testing` — mock instantiations for downstream tests
+- `testing` (the opt-in `test-utils` feature) — mock instantiations and shared PCS contract checks for downstream tests
 
 Implementations live in `p3-merkle-tree` (Mmcs), `p3-fri`, `p3-circle` and
 `p3-whir` (Pcs).
+
+`testing::assert_pcs_opening_contract` exercises real transparent backends with
+caller-supplied matrices and independently computed expected values. It checks
+batched opening order, honest verification, transcript agreement, and rejection
+of modified values and missing matrix/column claims. FRI, Circle, and STIR use
+this helper alongside their backend-specific tests.
 
 Part of [Plonky3](https://github.com/Plonky3/Plonky3), dual-licensed under MIT and Apache 2.0.
 

--- a/commit/src/testing.rs
+++ b/commit/src/testing.rs
@@ -1,3 +1,5 @@
+mod pcs;
+
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
@@ -9,6 +11,7 @@ use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
 use p3_util::log2_strict_usize;
 use p3_util::zip_eq::zip_eq;
+pub use pcs::assert_pcs_opening_contract;
 use serde::{Deserialize, Serialize};
 
 use crate::{

--- a/commit/src/testing/pcs.rs
+++ b/commit/src/testing/pcs.rs
@@ -1,0 +1,172 @@
+//! Shared opening checks for transparent, batched univariate commitment backends.
+
+use alloc::vec::Vec;
+
+use p3_challenger::{CanObserve, FieldChallenger};
+use p3_field::ExtensionField;
+use p3_matrix::Matrix;
+use p3_matrix::dense::RowMajorMatrix;
+
+use crate::{
+    CommitmentOpening, MatrixOpening, OpeningRequest, Pcs, PointOpening, PolynomialSpace, Val,
+};
+
+/// Check a backend's batched opening values, verification, transcript and claim-shape handling.
+///
+/// The caller supplies evaluation matrices grouped by commitment, and an independent evaluator
+/// for their columns. The evaluator receives `(commitment_index, matrix_index, opening_point)`.
+/// It must compute the expected values from the intended polynomials, not from PCS output.
+///
+/// Two points are sampled after absorbing all commitments. Their order alternates between
+/// matrices, exercising the association of commitments, matrices, points and columns. After
+/// honest verification, the next prover and verifier challenge must agree. Fresh copies of the
+/// verifier transcript also check rejection of a changed value, a missing column and a missing
+/// matrix. Backend-specific proof mutations and serialization fixtures belong in the caller's
+/// tests.
+///
+/// Intended for transparent backends with a fixed matrix/column opening shape, such as FRI,
+/// Circle and STIR. Hiding backends may use a different preprocessing/opening protocol.
+///
+/// # Panics
+///
+/// Panics on any failed contract check. The fixture must contain at least one commitment,
+/// every commitment must contain a matrix, and every matrix must have at least one column
+/// and the height required by its domain. The supplied transcript must yield two distinct,
+/// valid opening points for the backend.
+#[allow(clippy::type_complexity)]
+pub fn assert_pcs_opening_contract<P, Challenge, Challenger>(
+    pcs: &P,
+    challenger: &Challenger,
+    rounds: &[Vec<(P::Domain, RowMajorMatrix<Val<P::Domain>>)>],
+    expected: impl Fn(usize, usize, Challenge) -> Vec<Challenge>,
+) where
+    P: Pcs<Challenge, Challenger>,
+    Challenge: ExtensionField<Val<P::Domain>>,
+    Challenger: Clone + CanObserve<P::Commitment> + FieldChallenger<Val<P::Domain>>,
+{
+    assert!(!rounds.is_empty(), "fixture needs a commitment");
+    for round in rounds {
+        assert!(!round.is_empty(), "fixture needs a matrix per commitment");
+        for (domain, matrix) in round {
+            assert_ne!(matrix.width(), 0, "fixture needs nonempty columns");
+            assert_eq!(domain.size(), matrix.height(), "fixture domain height");
+        }
+    }
+
+    let (commitments, prover_data): (Vec<_>, Vec<_>) = rounds
+        .iter()
+        .map(|round| pcs.commit(round.iter().cloned()))
+        .unzip();
+    let mut prover = challenger.clone();
+    prover.observe_slice(&commitments);
+    let points: [Challenge; 2] = [
+        prover.sample_algebra_element(),
+        prover.sample_algebra_element(),
+    ];
+    assert_ne!(
+        points[0], points[1],
+        "fixture needs distinct opening points"
+    );
+    let opening_points: Vec<Vec<Vec<Challenge>>> = rounds
+        .iter()
+        .enumerate()
+        .map(|(r, round)| {
+            (0..round.len())
+                .map(|m| {
+                    let mut points = points.to_vec();
+                    if (r + m) % 2 == 1 {
+                        points.reverse();
+                    }
+                    points
+                })
+                .collect()
+        })
+        .collect();
+    let (opened, proof) = pcs.open(
+        prover_data
+            .iter()
+            .zip(opening_points.clone())
+            .map(|(prover_data, points)| OpeningRequest {
+                prover_data,
+                points,
+            })
+            .collect(),
+        &mut prover,
+    );
+    assert_eq!(opened.len(), rounds.len(), "commitment opening count");
+
+    let claims: Vec<_> = commitments
+        .iter()
+        .cloned()
+        .enumerate()
+        .map(|(r, commitment)| {
+            assert_eq!(opened[r].len(), rounds[r].len(), "matrix opening count");
+            let matrices = rounds[r]
+                .iter()
+                .enumerate()
+                .map(|(m, (domain, matrix))| {
+                    assert_eq!(opened[r][m].len(), 2, "point opening count");
+                    let values = opening_points[r][m]
+                        .iter()
+                        .copied()
+                        .enumerate()
+                        .map(|(p, point)| {
+                            let values = expected(r, m, point);
+                            assert_eq!(values.len(), matrix.width(), "expected column count");
+                            assert_eq!(opened[r][m][p], values, "opening at ({r}, {m}, {p})");
+                            PointOpening { point, values }
+                        })
+                        .collect();
+                    MatrixOpening {
+                        domain: *domain,
+                        points: values,
+                    }
+                })
+                .collect();
+            CommitmentOpening {
+                commitment,
+                matrices,
+            }
+        })
+        .collect();
+
+    let mut verifier = challenger.clone();
+    verifier.observe_slice(&commitments);
+    let verifier_points: [Challenge; 2] = [
+        verifier.sample_algebra_element(),
+        verifier.sample_algebra_element(),
+    ];
+    assert_eq!(verifier_points, points, "opening-point transcript");
+    let mut opening_transcript = verifier.clone();
+    pcs.verify(claims.clone(), &proof, &mut verifier)
+        .expect("honest opening must verify");
+    assert_eq!(
+        prover.sample_algebra_element::<Challenge>(),
+        verifier.sample_algebra_element::<Challenge>(),
+        "prover and verifier transcript after opening"
+    );
+
+    let mut wrong_value = claims.clone();
+    wrong_value[0].matrices[0].points[0].values[0] += Challenge::ONE;
+    assert!(
+        pcs.verify(wrong_value, &proof, &mut opening_transcript.clone())
+            .is_err(),
+        "changed claimed value must be rejected"
+    );
+
+    let mut missing_column = claims.clone();
+    missing_column[0].matrices[0].points[0].values.pop();
+    assert!(
+        pcs.verify(missing_column, &proof, &mut opening_transcript.clone())
+            .is_err(),
+        "missing claimed column must be rejected"
+    );
+
+    let mut missing_matrix = claims;
+    missing_matrix[0].matrices.pop();
+    assert!(
+        pcs.verify(missing_matrix, &proof, &mut opening_transcript)
+            .is_err(),
+        "missing claimed matrix must be rejected"
+    );
+}

--- a/commit/src/testing/pcs.rs
+++ b/commit/src/testing/pcs.rs
@@ -20,9 +20,10 @@ use crate::{
 /// Two points are sampled after absorbing all commitments. Their order alternates between
 /// matrices, exercising the association of commitments, matrices, points and columns. After
 /// honest verification, the next prover and verifier challenge must agree. Fresh copies of the
-/// verifier transcript also check rejection of a changed value, a missing column and a missing
-/// matrix. Backend-specific proof mutations and serialization fixtures belong in the caller's
-/// tests.
+/// verifier transcript also check rejection of swapped point fields, changed first and last
+/// values, a missing column and a missing matrix. Value and shape mutations may also change the
+/// backend's transcript; the point swap preserves the values and their observation order.
+/// Backend-specific proof mutations and serialization fixtures belong in the caller's tests.
 ///
 /// Intended for transparent backends with a fixed matrix/column opening shape, such as FRI,
 /// Circle and STIR. Hiding backends may use a different preprocessing/opening protocol.
@@ -30,9 +31,10 @@ use crate::{
 /// # Panics
 ///
 /// Panics on any failed contract check. The fixture must contain at least one commitment,
-/// every commitment must contain a matrix, and every matrix must have at least one column
-/// and the height required by its domain. The supplied transcript must yield two distinct,
-/// valid opening points for the backend.
+/// every commitment must contain a matrix, and at least one commitment must contain two matrices.
+/// Every matrix must have at least one column and the height required by its domain. The supplied
+/// transcript must yield two distinct, valid opening points for the backend, and at least one
+/// matrix must have different expected values at those points.
 #[allow(clippy::type_complexity)]
 pub fn assert_pcs_opening_contract<P, Challenge, Challenger>(
     pcs: &P,
@@ -52,6 +54,10 @@ pub fn assert_pcs_opening_contract<P, Challenge, Challenger>(
             assert_eq!(domain.size(), matrix.height(), "fixture domain height");
         }
     }
+    let multi_matrix_round = rounds
+        .iter()
+        .position(|round| round.len() >= 2)
+        .expect("fixture needs a commitment with at least two matrices");
 
     let (commitments, prover_data): (Vec<_>, Vec<_>) = rounds
         .iter()
@@ -67,6 +73,15 @@ pub fn assert_pcs_opening_contract<P, Challenge, Challenger>(
         points[0], points[1],
         "fixture needs distinct opening points"
     );
+    let (point_dependent_round, point_dependent_matrix) = rounds
+        .iter()
+        .enumerate()
+        .find_map(|(r, round)| {
+            (0..round.len())
+                .find(|&m| expected(r, m, points[0]) != expected(r, m, points[1]))
+                .map(|m| (r, m))
+        })
+        .expect("fixture needs a point-dependent column to test opening-point association");
     let opening_points: Vec<Vec<Vec<Challenge>>> = rounds
         .iter()
         .enumerate()
@@ -146,12 +161,36 @@ pub fn assert_pcs_opening_contract<P, Challenge, Challenger>(
         "prover and verifier transcript after opening"
     );
 
+    // These backends observe values, not point fields. Keep those values in place so this
+    // false claim must be rejected by the opening check rather than transcript divergence.
+    let mut swapped_points = claims.clone();
+    let matrix_points =
+        &mut swapped_points[point_dependent_round].matrices[point_dependent_matrix].points;
+    let (first, rest) = matrix_points.split_at_mut(1);
+    core::mem::swap(&mut first[0].point, &mut rest[0].point);
+    assert!(
+        pcs.verify(swapped_points, &proof, &mut opening_transcript.clone())
+            .is_err(),
+        "swapped opening points with unchanged values must be rejected"
+    );
+
     let mut wrong_value = claims.clone();
     wrong_value[0].matrices[0].points[0].values[0] += Challenge::ONE;
     assert!(
         pcs.verify(wrong_value, &proof, &mut opening_transcript.clone())
             .is_err(),
-        "changed claimed value must be rejected"
+        "changed first claimed value must be rejected"
+    );
+
+    let mut wrong_last_value = claims.clone();
+    let last_round = wrong_last_value.last_mut().unwrap();
+    let last_matrix = last_round.matrices.last_mut().unwrap();
+    let last_point = last_matrix.points.last_mut().unwrap();
+    *last_point.values.last_mut().unwrap() += Challenge::ONE;
+    assert!(
+        pcs.verify(wrong_last_value, &proof, &mut opening_transcript.clone())
+            .is_err(),
+        "changed last claimed value must be rejected"
     );
 
     let mut missing_column = claims.clone();
@@ -163,7 +202,7 @@ pub fn assert_pcs_opening_contract<P, Challenge, Challenger>(
     );
 
     let mut missing_matrix = claims;
-    missing_matrix[0].matrices.pop();
+    missing_matrix[multi_matrix_round].matrices.pop();
     assert!(
         pcs.verify(missing_matrix, &proof, &mut opening_transcript)
             .is_err(),

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -32,6 +32,7 @@ tracing.workspace = true
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
 p3-circle = { path = "../circle" }
+p3-commit = { path = "../commit", features = ["test-utils"] }
 p3-dft = { path = "../dft" }
 p3-goldilocks = { path = "../goldilocks" }
 p3-keccak = { path = "../keccak" }

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -1,10 +1,11 @@
 use itertools::{Itertools, izip};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::{CanObserve, DuplexChallenger, FieldChallenger};
+use p3_commit::testing::assert_pcs_opening_contract;
 use p3_commit::{ExtensionMmcs, Pcs, PolynomialSpace, UnivariateStarkPcs};
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
-use p3_field::{ExtensionField, Field};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing};
 use p3_fri::{FriParameters, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
@@ -106,10 +107,52 @@ fn do_test_fri_pcs<Val, Challenge, Challenger, P>(
     .unwrap();
 }
 
+// The column constants differ across commitments and matrices, so a backend that
+// reorders a batch cannot accidentally satisfy the expected openings.
+fn shared_opening_contract<Val, Challenge, Challenger, P>((pcs, challenger): &(P, Challenger))
+where
+    P: Pcs<Challenge, Challenger>,
+    P::Domain: PolynomialSpace<Val = Val>,
+    Val: Field,
+    Challenge: ExtensionField<Val>,
+    Challenger: Clone + CanObserve<P::Commitment> + FieldChallenger<Val>,
+{
+    let constants = [vec![vec![2, 7], vec![11]], vec![vec![19, 23, 29]]];
+    let heights = [vec![8, 16], vec![8]];
+    let rounds: Vec<_> = constants
+        .iter()
+        .zip(heights)
+        .map(|(round, heights)| {
+            round
+                .iter()
+                .zip(heights)
+                .map(|(columns, height)| {
+                    let row: Vec<_> = columns.iter().map(|&v| Val::from_u64(v)).collect();
+                    (
+                        pcs.natural_domain_for_degree(height),
+                        RowMajorMatrix::new(row.repeat(height), row.len()),
+                    )
+                })
+                .collect()
+        })
+        .collect();
+    assert_pcs_opening_contract(pcs, challenger, &rounds, |round, matrix, _point| {
+        constants[round][matrix]
+            .iter()
+            .map(|&v| Challenge::from_u64(v))
+            .collect()
+    });
+}
+
 // Set it up so we create tests inside a module for each pcs, so we get nice error reports
 // specific to a failing PCS.
 macro_rules! make_tests_for_pcs {
     ($p:expr) => {
+        #[test]
+        fn shared_opening_contract() {
+            $crate::shared_opening_contract(&$p);
+        }
+
         #[test]
         fn single() {
             let p = $p;
@@ -233,6 +276,33 @@ mod babybear_fri_pcs {
     }
     mod high_arity_blowup_1 {
         make_tests_for_pcs!(super::get_pcs_high_arity(1));
+    }
+
+    #[test]
+    fn shared_contract_preserves_opening_point_order() {
+        let (pcs, challenger) = get_pcs(1);
+        let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 8);
+        let mut x = domain.first_point();
+        let mut values = Vec::new();
+        for _ in 0..8 {
+            values.extend([x + Val::from_u64(2), x.square() + Val::from_u64(7)]);
+            x = domain.next_point(x).unwrap();
+        }
+        let matrix = RowMajorMatrix::new(values, 2);
+        assert_pcs_opening_contract(
+            &pcs,
+            &challenger,
+            &[
+                vec![(domain, matrix.clone()), (domain, matrix.clone())],
+                vec![(domain, matrix)],
+            ],
+            |_, _, point| {
+                vec![
+                    point + Challenge::from_u64(2),
+                    point.square() + Challenge::from_u64(7),
+                ]
+            },
+        );
     }
 
     #[test]

--- a/fri/tests/pcs.rs
+++ b/fri/tests/pcs.rs
@@ -107,10 +107,13 @@ fn do_test_fri_pcs<Val, Challenge, Challenger, P>(
     .unwrap();
 }
 
-// The column constants differ across commitments and matrices, so a backend that
-// reorders a batch cannot accidentally satisfy the expected openings.
-fn shared_opening_contract<Val, Challenge, Challenger, P>((pcs, challenger): &(P, Challenger))
-where
+// Add distinct constants to point-dependent basis polynomials, so neither point nor
+// matrix reordering can accidentally satisfy the expected openings.
+fn shared_opening_contract<Val, Challenge, Challenger, P>(
+    (pcs, challenger): &(P, Challenger),
+    basis: impl Fn(Val) -> [Val; 3],
+    extension_basis: impl Fn(Challenge) -> [Challenge; 3],
+) where
     P: Pcs<Challenge, Challenger>,
     P::Domain: PolynomialSpace<Val = Val>,
     Val: Field,
@@ -127,19 +130,28 @@ where
                 .iter()
                 .zip(heights)
                 .map(|(columns, height)| {
-                    let row: Vec<_> = columns.iter().map(|&v| Val::from_u64(v)).collect();
-                    (
-                        pcs.natural_domain_for_degree(height),
-                        RowMajorMatrix::new(row.repeat(height), row.len()),
-                    )
+                    let domain = pcs.natural_domain_for_degree(height);
+                    let mut x = domain.first_point();
+                    let mut values = Vec::new();
+                    for _ in 0..height {
+                        values.extend(
+                            columns
+                                .iter()
+                                .zip(basis(x))
+                                .map(|(&v, b)| b + Val::from_u64(v)),
+                        );
+                        x = domain.next_point(x).unwrap();
+                    }
+                    (domain, RowMajorMatrix::new(values, columns.len()))
                 })
                 .collect()
         })
         .collect();
-    assert_pcs_opening_contract(pcs, challenger, &rounds, |round, matrix, _point| {
+    assert_pcs_opening_contract(pcs, challenger, &rounds, |round, matrix, point| {
         constants[round][matrix]
             .iter()
-            .map(|&v| Challenge::from_u64(v))
+            .zip(extension_basis(point))
+            .map(|(&v, b)| b + Challenge::from_u64(v))
             .collect()
     });
 }
@@ -150,7 +162,7 @@ macro_rules! make_tests_for_pcs {
     ($p:expr) => {
         #[test]
         fn shared_opening_contract() {
-            $crate::shared_opening_contract(&$p);
+            $crate::shared_opening_contract(&$p, super::contract_basis, super::contract_basis);
         }
 
         #[test]
@@ -222,6 +234,10 @@ mod babybear_fri_pcs {
     type Challenger = DuplexChallenger<Val, Perm, 16, 8>;
     type MyPcs = TwoAdicFriPcs<Val, Dft, ValMmcs, ChallengeMmcs>;
 
+    fn contract_basis<F: Field>(point: F) -> [F; 3] {
+        [point, point.square(), point.exp_const_u64::<3>()]
+    }
+
     fn get_pcs(log_blowup: usize) -> (MyPcs, Challenger) {
         let perm = Perm::new_from_rng_128(&mut seeded_rng());
         let hash = MyHash::new(perm.clone());
@@ -279,7 +295,7 @@ mod babybear_fri_pcs {
     }
 
     #[test]
-    fn shared_contract_preserves_opening_point_order() {
+    fn shared_contract_finds_point_dependent_matrix_in_later_commitment() {
         let (pcs, challenger) = get_pcs(1);
         let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 8);
         let mut x = domain.first_point();
@@ -293,15 +309,36 @@ mod babybear_fri_pcs {
             &pcs,
             &challenger,
             &[
-                vec![(domain, matrix.clone()), (domain, matrix.clone())],
-                vec![(domain, matrix)],
+                vec![(
+                    domain,
+                    RowMajorMatrix::new([Val::from_u64(2), Val::from_u64(7)].repeat(8), 2),
+                )],
+                vec![(domain, matrix.clone()), (domain, matrix)],
             ],
-            |_, _, point| {
-                vec![
-                    point + Challenge::from_u64(2),
-                    point.square() + Challenge::from_u64(7),
-                ]
+            |round, _, point| {
+                if round == 0 {
+                    vec![Challenge::from_u64(2), Challenge::from_u64(7)]
+                } else {
+                    vec![
+                        point + Challenge::from_u64(2),
+                        point.square() + Challenge::from_u64(7),
+                    ]
+                }
             },
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "fixture needs a point-dependent column")]
+    fn shared_contract_rejects_constant_fixture() {
+        let (pcs, challenger) = get_pcs(1);
+        let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, 8);
+        let matrix = RowMajorMatrix::new(vec![Val::from_u64(2); 8], 1);
+        assert_pcs_opening_contract(
+            &pcs,
+            &challenger,
+            &[vec![(domain, matrix.clone()), (domain, matrix)]],
+            |_, _, _| vec![Challenge::from_u64(2)],
         );
     }
 
@@ -367,6 +404,15 @@ mod m31_fri_pcs {
     type Challenger = SerializingChallenger32<Val, HashChallenger<u8, ByteHash, 32>>;
 
     type Pcs = CirclePcs<Val, ValMmcs, ChallengeMmcs>;
+
+    fn contract_basis<F: Field>(point: F) -> [F; 3] {
+        // Domain iteration and opening points use the projective-line parameter t.
+        // The circle basis contains y, x and xy, not powers of t.
+        let inv_denom = (F::ONE + point.square()).inverse();
+        let x = (F::ONE - point.square()) * inv_denom;
+        let y = point.double() * inv_denom;
+        [y, x, x * y]
+    }
 
     fn get_pcs(log_blowup: usize) -> (Pcs, Challenger) {
         let byte_hash = ByteHash {};

--- a/stir/Cargo.toml
+++ b/stir/Cargo.toml
@@ -33,6 +33,7 @@ tracing.workspace = true
 [dev-dependencies]
 p3-air = { path = "../air" }
 p3-baby-bear = { path = "../baby-bear" }
+p3-commit = { path = "../commit", features = ["test-utils"] }
 p3-dft = { path = "../dft" }
 p3-fri = { path = "../fri" }
 p3-goldilocks = { path = "../goldilocks" }

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -2050,60 +2050,38 @@ mod babybear_pcs {
     }
 
     fn do_test_pcs(log_degrees: &[usize]) {
-        #[allow(unused_imports)]
-        use p3_commit::Pcs as _;
+        use p3_commit::PolynomialSpace;
+        use p3_commit::testing::assert_pcs_opening_contract;
 
-        let (pcs, challenger_template) = get_pcs();
-        let mut rng = seeded_rng();
-
-        let mut p_challenger = challenger_template.clone();
-
-        // Commit: one round with multiple matrices.
-        let domains_and_polys: Vec<_> = log_degrees
+        let (pcs, challenger) = get_pcs();
+        let matrices: Vec<_> = log_degrees
             .iter()
-            .map(|&log_d| {
-                let d = 1 << log_d;
-                let width = 3;
-                (
-                    <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(&pcs, d),
-                    RowMajorMatrix::<Val>::rand(&mut rng, d, width),
-                )
+            .enumerate()
+            .map(|(matrix_index, &log_degree)| {
+                let domain = <MyPcs as Pcs<Challenge, Challenger>>::natural_domain_for_degree(
+                    &pcs,
+                    1 << log_degree,
+                );
+                let mut x = domain.first_point();
+                let mut values = Vec::new();
+                for _ in 0..domain.size() {
+                    values.extend([
+                        x.square() + Val::from_usize(2 + matrix_index),
+                        x + Val::from_usize(7 + matrix_index),
+                        Val::from_usize(23 + matrix_index),
+                    ]);
+                    x = domain.next_point(x).unwrap();
+                }
+                (domain, RowMajorMatrix::new(values, 3))
             })
             .collect();
-
-        let (commit, data) =
-            <MyPcs as Pcs<Challenge, Challenger>>::commit(&pcs, domains_and_polys.iter().cloned());
-        observe_commitment(&mut p_challenger, &commit);
-
-        let zeta: Challenge = p_challenger.sample_algebra_element();
-
-        let points: Vec<Vec<Challenge>> = log_degrees.iter().map(|_| vec![zeta]).collect();
-        let data_and_points = vec![(&data, points)];
-        let (opening_values, proof) = <MyPcs as Pcs<Challenge, Challenger>>::open(
-            &pcs,
-            data_and_points.into_iter().map(Into::into).collect(),
-            &mut p_challenger,
-        );
-
-        // Verify.
-        let mut v_challenger = challenger_template;
-        observe_commitment(&mut v_challenger, &commit);
-        let v_zeta: Challenge = v_challenger.sample_algebra_element();
-        assert_eq!(v_zeta, zeta);
-
-        let claims: Vec<_> = domains_and_polys
-            .iter()
-            .zip(opening_values.first().unwrap().iter())
-            .map(|((domain, _), mat_openings)| (*domain, vec![(zeta, mat_openings[0].clone())]))
-            .collect();
-
-        <MyPcs as Pcs<Challenge, Challenger>>::verify(
-            &pcs,
-            vec![(commit, claims).into()],
-            &proof,
-            &mut v_challenger,
-        )
-        .unwrap_or_else(|e| panic!("PCS verification failed: {e:?}"));
+        assert_pcs_opening_contract(&pcs, &challenger, &[matrices], |_, matrix_index, point| {
+            vec![
+                point.square() + Challenge::from_usize(2 + matrix_index),
+                point + Challenge::from_usize(7 + matrix_index),
+                Challenge::from_usize(23 + matrix_index),
+            ]
+        });
     }
 
     #[test]

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -2054,6 +2054,12 @@ mod babybear_pcs {
         use p3_commit::testing::assert_pcs_opening_contract;
 
         let (pcs, challenger) = get_pcs();
+        if log_degrees.len() == 1 {
+            // Preserve the isolated schedules on random full-degree inputs. The shared
+            // batched contract needs a nonempty commitment after removing a matrix.
+            round_trip_under(&pcs, &challenger, log_degrees, &[3]);
+            return;
+        }
         let matrices: Vec<_> = log_degrees
             .iter()
             .enumerate()
@@ -2069,10 +2075,12 @@ mod babybear_pcs {
                         x.square() + Val::from_usize(2 + matrix_index),
                         x + Val::from_usize(7 + matrix_index),
                         Val::from_usize(23 + matrix_index),
+                        // Reach the degree bound while keeping the expected value independent.
+                        x.exp_u64((domain.size() - 1) as u64),
                     ]);
                     x = domain.next_point(x).unwrap();
                 }
-                (domain, RowMajorMatrix::new(values, 3))
+                (domain, RowMajorMatrix::new(values, 4))
             })
             .collect();
         assert_pcs_opening_contract(&pcs, &challenger, &[matrices], |_, matrix_index, point| {
@@ -2080,6 +2088,7 @@ mod babybear_pcs {
                 point.square() + Challenge::from_usize(2 + matrix_index),
                 point + Challenge::from_usize(7 + matrix_index),
                 Challenge::from_usize(23 + matrix_index),
+                point.exp_u64(((1usize << log_degrees[matrix_index]) - 1) as u64),
             ]
         });
     }


### PR DESCRIPTION
PCS backend tests repeat opening setup and do not share one check for claim ordering, independent expected evaluations, and transcript agreement. Add an opt-in `p3-commit::testing::assert_pcs_opening_contract` helper and use it with real FRI, Circle, and STIR backends.

The helper checks honest verification, commitment/matrix/point/column associations, prover/verifier transcript agreement, and rejection of altered values or missing claim elements. STIR matrices use distinct polynomials so equal-size matrix swaps remain detectable. Extract batch-STARK configuration fixtures into `tests/common/config.rs`, retaining backend-specific regressions and serialized-proof fixtures.

Depends on #2059. This PR targets `robin/refactor-pcs` so the diff contains only the shared tests and fixture extraction; retarget to `main` after the PCS refactor lands.

Validation:

- FRI/Circle PCS suite: 32 tests passed.
- STIR PCS suite: 40 tests passed.
- Batch integration suite: 53 tests passed; 2 fixture generators intentionally ignored.
- These suites passed with parallel enabled on the combined refactor checkout; targeted Clippy and strict docs also passed.
- Independent review and follow-up review completed with no outstanding findings.
