### PR TITLE
chore: share local and CI check commands

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -29,4 +29,4 @@ jobs:
       # field x algorithm x size sweep produces thousands of benchmark ids that
       # make even a single pass too slow.
       - name: Run each benchmark once
-        run: cargo bench --workspace --exclude p3-dft --features parallel -- --test
+        run: python3 scripts/check.py bench

--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -45,10 +45,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Test WHIR exhaustive sweep
-        run: cargo test -p p3-whir pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact
+        run: python3 scripts/check.py whir-exhaustive
 
       - name: Test WHIR exhaustive sweep with parallel
-        run: cargo test -p p3-whir --features parallel pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact
+        run: python3 scripts/check.py whir-exhaustive --parallel
 
   binary_pcs_large_configuration:
     name: binary-pcs 2^16 round trip
@@ -68,4 +68,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Test the 2^16 round trip
-        run: cargo test -p p3-binary-pcs --release --test end_to_end large_configuration_2_16_round_trips -- --ignored --exact
+        run: python3 scripts/check.py binary-large

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,35 +134,35 @@ jobs:
 
       - name: Test
         if: ${{ !matrix.compile_only && !matrix.parallel }}
-        run: cargo nextest run
+        run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py test
 
       - name: Test doctests
         if: ${{ !matrix.compile_only && !matrix.parallel }}
         # nextest doesn't run doctests, so cover them with plain `cargo test`.
-        run: cargo test --doc
+        run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py doctest
 
       - name: Test with parallel
         if: ${{ !matrix.compile_only && matrix.parallel }}
-        run: cargo nextest run --features parallel
+        run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py test --parallel
 
       - name: Test with parallel doctests
         if: ${{ !matrix.compile_only && matrix.parallel }}
-        run: cargo test --doc --features parallel
+        run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py doctest --parallel
 
       - name: Build
         if: ${{ matrix.compile_only && !matrix.parallel }}
         # Keep target-feature RUSTFLAGS off host build scripts and proc macros.
-        run: cargo build --target ${{ matrix.target }} --all-targets
+        run: python3 scripts/check.py architecture --target ${{ matrix.target }}
 
       - name: Build with parallel
         if: ${{ matrix.compile_only && matrix.parallel }}
-        run: cargo build --target ${{ matrix.target }} --all-targets --features parallel
+        run: python3 scripts/check.py architecture --target ${{ matrix.target }} --parallel
 
       - name: Test keccak (aarch64, no SHA3)
         if: ${{ matrix.os == 'macos-latest' && !matrix.parallel }}
         env:
           RUSTFLAGS: -C debuginfo=0 -C target-feature=-sha3
-        run: cargo nextest run -p p3-keccak
+        run: python3 scripts/check.py test --package p3-keccak
 
   check_embedded:
     name: Build embedded
@@ -182,55 +182,10 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      # NB: We omit, p3-field-testing, and p3-examples as they currently depend on std
-      # and hence don't compile on the given target.
+      # Library packages are discovered through Cargo metadata. Host-only packages
+      # explicitly opt out with `package.metadata.plonky3.embedded = false`.
       - name: Build
-        run: |
-          cargo build --verbose --target ${{ env.target }} -p p3-air
-          cargo build --verbose --target ${{ env.target }} -p p3-baby-bear
-          cargo build --verbose --target ${{ env.target }} -p p3-batch-stark
-          cargo build --verbose --target ${{ env.target }} -p p3-binary-dft
-          cargo build --verbose --target ${{ env.target }} -p p3-binary-field
-          cargo build --verbose --target ${{ env.target }} -p p3-blake3
-          cargo build --verbose --target ${{ env.target }} -p p3-blake3-air
-          cargo build --verbose --target ${{ env.target }} -p p3-bn254
-          cargo build --verbose --target ${{ env.target }} -p p3-challenger
-          cargo build --verbose --target ${{ env.target }} -p p3-circle
-          cargo build --verbose --target ${{ env.target }} -p p3-commit
-          cargo build --verbose --target ${{ env.target }} -p p3-dft
-          cargo build --verbose --target ${{ env.target }} -p p3-field
-          cargo build --verbose --target ${{ env.target }} -p p3-fri
-          # `--lib` here because p3-goldilocks has host-only bins that require std and would otherwise fail
-          cargo build --verbose --target ${{ env.target }} -p p3-goldilocks --lib
-          cargo build --verbose --target ${{ env.target }} -p p3-keccak
-          cargo build --verbose --target ${{ env.target }} -p p3-keccak-air
-          cargo build --verbose --target ${{ env.target }} -p p3-koala-bear
-          cargo build --verbose --target ${{ env.target }} -p p3-lookup
-          cargo build --verbose --target ${{ env.target }} -p p3-matrix
-          cargo build --verbose --target ${{ env.target }} -p p3-maybe-rayon
-          cargo build --verbose --target ${{ env.target }} -p p3-mds
-          cargo build --verbose --target ${{ env.target }} -p p3-merkle-tree
-          cargo build --verbose --target ${{ env.target }} -p p3-mersenne-31
-          cargo build --verbose --target ${{ env.target }} -p p3-monolith
-          cargo build --verbose --target ${{ env.target }} -p p3-monolith-air
-          cargo build --verbose --target ${{ env.target }} -p p3-monty-31
-          cargo build --verbose --target ${{ env.target }} -p p3-multi-stark
-          cargo build --verbose --target ${{ env.target }} -p p3-multilinear-util
-          cargo build --verbose --target ${{ env.target }} -p p3-poseidon1
-          cargo build --verbose --target ${{ env.target }} -p p3-poseidon1-air
-          cargo build --verbose --target ${{ env.target }} -p p3-poseidon2
-          cargo build --verbose --target ${{ env.target }} -p p3-poseidon2-air
-          cargo build --verbose --target ${{ env.target }} -p p3-rescue
-          cargo build --verbose --target ${{ env.target }} -p p3-sha256
-          cargo build --verbose --target ${{ env.target }} -p p3-sha256-air
-          cargo build --verbose --target ${{ env.target }} -p p3-security
-          cargo build --verbose --target ${{ env.target }} -p p3-stir
-          cargo build --verbose --target ${{ env.target }} -p p3-sumcheck
-          cargo build --verbose --target ${{ env.target }} -p p3-symmetric
-          cargo build --verbose --target ${{ env.target }} -p p3-uni-stark
-          cargo build --verbose --target ${{ env.target }} -p p3-util
-          cargo build --verbose --target ${{ env.target }} -p p3-whir
-          cargo build --verbose --target ${{ env.target }} -p p3-zk-codes
+        run: python3 scripts/check.py embedded --target ${{ env.target }}
 
   check_wasm32_simd128:
     name: Test wasm32 simd128
@@ -261,15 +216,15 @@ jobs:
           tar -xJf /tmp/wasmtime.tar.xz -C "$HOME"
           echo "$HOME/wasmtime-${WASMTIME_VERSION}-x86_64-linux" >> "$GITHUB_PATH"
       - name: Build p3-goldilocks for wasm32-unknown-unknown
-        run: cargo build --verbose --target ${{ env.build_target }} -p p3-goldilocks
+        run: python3 scripts/check.py wasm --step build --build-target ${{ env.build_target }}
       - name: Run wasm32+simd128 SIMD tests under wasmtime
-        run: cargo test --release --target ${{ env.run_target }} -p p3-goldilocks --lib wasm32_simd128
+        run: python3 scripts/check.py wasm --step test --run-target ${{ env.run_target }}
       - name: Run wasm_smoke under wasmtime
-        run: cargo run --release --target ${{ env.run_target }} --bin wasm_smoke -p p3-goldilocks
+        run: python3 scripts/check.py wasm --step smoke --run-target ${{ env.run_target }}
       - name: Run wasm_bench under wasmtime
-        run: cargo run --release --target ${{ env.run_target }} --bin wasm_bench -p p3-goldilocks
+        run: python3 scripts/check.py wasm --step bench --run-target ${{ env.run_target }}
       - name: Run wasm_merkle_bench under wasmtime
-        run: cargo run --release --target ${{ env.run_target }} --example wasm_merkle_bench -p p3-goldilocks
+        run: python3 scripts/check.py wasm --step merkle --run-target ${{ env.run_target }}
 
   lint:
     name: Formatting and Clippy
@@ -296,24 +251,27 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      - name: Test repository command interface
+        run: python3 scripts/check.py lint --check scripts
+
       - name: Sort Cargo.toml
-        run: cargo +stable sort --workspace --grouped --check
+        run: python3 scripts/check.py lint --check sort
 
       - name: Check TOML formatting
-        run: taplo fmt --check
+        run: python3 scripts/check.py lint --check toml
 
       # `--with-metadata` resolves each manifest through cargo.
       # Only that resolution makes dev-dependencies visible to the scan.
       - name: Unused dependencies
-        run: cargo machete --with-metadata
+        run: python3 scripts/check.py lint --check deps
 
       - name: Clippy
-        run: cargo +stable clippy --all-targets -- -D warnings
+        run: python3 scripts/check.py lint --check clippy
 
       - name: Docs
         env:
           RUSTDOCFLAGS: -D rustdoc::broken_intra_doc_links
-        run: cargo +stable doc --no-deps --workspace --document-private-items
+        run: python3 scripts/check.py lint --check docs
 
       - name: Format
-        run: cargo +nightly fmt --all -- --check
+        run: python3 scripts/check.py lint --check fmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing to Plonky3
+
+Plonky3 uses stable Rust for builds and Clippy, nightly rustfmt for formatting, and Python 3.9 or newer for the shared repository commands. Install the Rust targets or tools only when the check you are running needs them.
+
+Start with a host build and the test suite for the crate you are changing:
+
+```bash
+python3 scripts/check.py fast
+python3 scripts/check.py test --package p3-field
+python3 scripts/check.py doctest --package p3-field
+```
+
+On Windows, invoke the same script with `python` in place of `python3`. The script runs from any current directory and executes Cargo in the workspace root.
+
+The `test` command uses `cargo-nextest`, matching CI. Install the CI development tools when you need their checks:
+
+```bash
+cargo install cargo-nextest cargo-sort cargo-machete taplo-cli
+rustup component add clippy
+rustup toolchain install nightly --component rustfmt
+```
+
+Run `python3 scripts/check.py full` before opening a pull request. It covers the host check, sequential and `parallel` tests and doctests, dependency checks, Clippy, docs, and formatting. Use `--dry-run` before the command name to inspect a recipe without executing build or test commands. Commands that depend on the workspace package list still run the read-only `cargo metadata` query in dry-run mode.
+
+## Command reference
+
+| Command | Purpose | Options |
+| --- | --- | --- |
+| `fast` | Check all host targets without running them | `--package NAME`, `--parallel` |
+| `full` | Run all routine host checks | none |
+| `test` | Run tests through `cargo-nextest` | `--package NAME`, `--parallel` |
+| `doctest` | Run Rust documentation tests | `--package NAME`, `--parallel` |
+| `lint` | Run all CI script/lint/doc/format checks | `--check scripts\|sort\|toml\|deps\|clippy\|docs\|fmt` |
+| `architecture` | Compile all targets for a non-runnable target | `--target TARGET`, `--parallel` |
+| `embedded` | Build every eligible workspace library with `--lib` | `--target TARGET` |
+| `wasm` | Run the wasm compile and SIMD smoke recipes | `--step build\|test\|smoke\|bench\|merkle` |
+| `bench` | Execute every benchmark body once, excluding the large `p3-dft` sweep | none |
+| `whir-exhaustive` | Run the ignored exhaustive WHIR test | `--parallel` |
+| `binary-large` | Run the ignored binary PCS `2^16` round trip | none |
+
+`architecture` is a compile-only command. CI uses `test` and `doctest` only on architectures whose runner can execute the selected instructions, and uses `architecture` for AVX-512, VPCLMULQDQ, and SVE2 coverage where runner hardware is not guaranteed.
+
+The embedded package list comes from `cargo metadata`. Every workspace package with a library target is included unless its manifest declares:
+
+```toml
+[package.metadata.plonky3]
+embedded = false
+```
+
+`p3-examples` and `p3-field-testing` are explicit host-only exclusions. Building each selected package with `--lib` prevents host-only binaries and examples from breaking an otherwise `no_std` library build. New library crates therefore enter embedded coverage automatically.
+
+A package whose meaningful tests require a set of opt-in features can declare one additional CI invocation:
+
+```toml
+[package.metadata.plonky3.ci]
+test-features = ["backend-a", "backend-b"]
+```
+
+The listed features are enabled together. A parallel CI leg also enables `parallel` when that package defines it.
+
+See [the architecture guide](docs/architecture.md) for the crate map and backend capabilities. Keep pull requests focused, add behavioral coverage for fixes, and document security assumptions at the public API where they apply.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,18 @@ Plonky3 contains optimizations that rely on newer CPU instructions unavailable i
 RUSTFLAGS="-Ctarget-cpu=native" cargo test
 ```
 
+## Development
+
+Repository checks have one local and CI interface:
+
+```bash
+python3 scripts/check.py fast
+python3 scripts/check.py test --package p3-field
+python3 scripts/check.py full
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for prerequisites, focused commands, cross-target checks, and CI metadata. The [architecture guide](docs/architecture.md) maps the crates and records backend capabilities and hiding guarantees.
+
 ## Configuration
 
 ### Cargo features
@@ -125,7 +137,8 @@ RUSTFLAGS="-Ctarget-cpu=native" cargo test
 | --- | --- | --- |
 | `parallel` | Most crates | Routes hot loops through `rayon` instead of the sequential fallback. Off by default. Activate at the workspace root with `cargo … --features parallel`. |
 | `neon` | `p3-blake3` | Forwards to the upstream `blake3/neon` feature for aarch64. Off by default. |
-| `test-utils` | `p3-commit` (on by default), `p3-sumcheck` (off) | Compiles in-crate test helpers used by integration tests. |
+| `test-utils` | `p3-commit` (off by default) | Compiles in-crate test helpers used by integration tests. |
+| `test-util` | `p3-sumcheck` (off by default) | Compiles the sumcheck test helper module used by downstream tests. |
 
 There is no `nightly`, `asm`, or `simd` Cargo feature — SIMD code paths are gated by `cfg(target_feature = …)` and enabled through `RUSTFLAGS`, not features. See [CPU features](#cpu-features) above.
 
@@ -187,10 +200,10 @@ guidelines may result in your PR being rejected, ignored, or forgotten.
 
 ### General guidance for your PR
 
-Obviously, PRs will not be considered unless they pass our Github
-CI. The GitHub CI is not executed for PRs from forks, but you can
-simulate the GitHub CI by running the commands in
-`.github/workflows/ci.yml`.
+Obviously, PRs will not be considered unless they pass our GitHub CI.
+The GitHub CI is not executed for PRs from forks, but you can run its
+routine host checks locally with `python3 scripts/check.py full`; see
+[CONTRIBUTING.md](CONTRIBUTING.md) for targeted and cross-platform commands.
 
 Under no circumstances should a single PR mix different purposes: Your
 PR is either a bug fix, a new feature, or a performance improvement,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,49 @@
+# Plonky3 architecture
+
+Plonky3 is a collection of small crates rather than one fixed proof system. Applications select fields, transforms, commitments, challengers, and a STARK layer, then connect them through traits from the foundational crates.
+
+## Crate map
+
+| Area | Crates | Responsibility |
+| --- | --- | --- |
+| Interfaces and utilities | `p3-air`, `p3-field`, `p3-matrix`, `p3-commit`, `p3-symmetric`, `p3-util`, `p3-maybe-rayon` | AIR, field, matrix, commitment, hash/permutation, low-level utility, and sequential/parallel interfaces |
+| Prime fields | `p3-baby-bear`, `p3-koala-bear`, `p3-monty-31`, `p3-mersenne-31`, `p3-goldilocks`, `p3-bn254` | Scalar, extension, and packed field implementations |
+| Binary fields | `p3-binary-field` | Binary tower fields, GHASH representation, packed arithmetic, and binary challenger |
+| Transforms and codes | `p3-dft`, `p3-binary-dft`, `p3-multilinear-util`, `p3-sumcheck`, `p3-zk-codes` | Multiplicative FFTs, additive NTTs, multilinear operations, sumcheck, and ZK Reed–Solomon encoding |
+| Commitments | `p3-merkle-tree`, `p3-fri`, `p3-stir`, `p3-whir`, `p3-binary-pcs`, `p3-circle` | Matrix commitments and polynomial opening/proximity protocols |
+| Transcripts and analysis | `p3-challenger`, `p3-security` | Typed Fiat–Shamir challengers and composable soundness accounting |
+| STARK systems | `p3-uni-stark`, `p3-batch-stark`, `p3-multi-stark`, `p3-lookup` | Single-AIR, batched, and multilinear STARK proving plus LogUp lookup arguments |
+| Permutations and hashes | `p3-mds`, `p3-poseidon1`, `p3-poseidon2`, `p3-rescue`, `p3-monolith`, `p3-blake3`, `p3-keccak`, `p3-sha256` | Algebraic permutations, conventional hashes, and shared MDS layers |
+| AIR implementations | `p3-poseidon1-air`, `p3-poseidon2-air`, `p3-monolith-air`, `p3-blake3-air`, `p3-keccak-air`, `p3-sha256-air` | AIR constraints and trace generation for the corresponding primitive |
+| Development | `p3-field-testing`, `p3-examples` | Reusable field test helpers and runnable proof examples |
+
+The common univariate path is:
+
+```text
+AIR + trace
+    -> p3-uni-stark or p3-batch-stark
+    -> p3-commit::Pcs implementation
+    -> evaluation transform + MMCS/Merkle hashing
+    -> Fiat-Shamir challenger
+    -> proof / typed verification result
+```
+
+`p3-multi-stark` instead works with multilinear polynomials, sumcheck, and a `MultilinearPcs`. `p3-circle` supplies circle-domain FFT, FRI, and PCS machinery for Mersenne-31; the generic univariate and batched STARK crates consume that PCS.
+
+## Backend capabilities
+
+| Backend | Polynomial/domain model | Hiding PCS supplied | STARK integration |
+| --- | --- | --- | --- |
+| `p3-fri::TwoAdicFriPcs` | Univariate polynomials over two-adic multiplicative cosets | No; `p3-fri::HidingFriPcs` is the hiding variant | `p3-uni-stark` and `p3-batch-stark`; their ZK paths follow the backend's `ZK` capability |
+| `p3-stir::TwoAdicStirPcs` | Univariate Reed–Solomon proximity testing on two-adic domains | No hiding variant is exposed | Usable through the generic univariate PCS interface |
+| `p3-circle::CirclePcs` | Univariate evaluations on circle-group domains with circle FRI | No; the backend's `ZK` capability is false | Consumed by `p3-uni-stark` and `p3-batch-stark` |
+| `p3-whir` | Multilinear polynomials and constrained Reed–Solomon codes | Yes: `HidingWhirPcs` provides honest-verifier ZK at the PCS layer | Implements `MultilinearPcs`; applications must compose and analyze the complete protocol |
+| `p3-binary-pcs::BinaryPcs` | Multilinear polynomials over `BinaryField128` with an additive-domain code | No; query symbols and the final codeword are revealed | Used by the binary multilinear STARK example in an explicitly non-ZK composition |
+
+A hiding PCS is one part of a zero-knowledge proof system. It does not by itself establish that every trace commitment, auxiliary argument, transcript message, or application-level statement is zero knowledge. The univariate STARK implementations contain explicit paths selected by the backend's `ZK` capability and tests with hiding FRI; other compositions need their own complete protocol analysis.
+
+## Portability and features
+
+The workspace libraries are `no_std`. The embedded check selects library targets from Cargo metadata and excludes the host-oriented `p3-examples` and `p3-field-testing` packages explicitly. Host-only bins and examples do not affect that build because every selected package is built with `--lib`.
+
+The `parallel` feature switches participating crates from the sequential `p3-maybe-rayon` implementation to Rayon. SIMD implementations use Rust target features rather than Cargo features; see the root README for the supported CPU flags. Test-helper feature names are crate-specific: `p3-commit` exposes `test-utils`, while `p3-sumcheck` exposes `test-util`. Both are off by default.

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,6 +10,10 @@ keywords.workspace = true
 categories.workspace = true
 publish = false
 
+[package.metadata.plonky3]
+# This package contains host executables rather than an embedded library.
+embedded = false
+
 [dependencies]
 p3-air.workspace = true
 p3-blake3-air.workspace = true

--- a/field-testing/Cargo.toml
+++ b/field-testing/Cargo.toml
@@ -13,6 +13,10 @@ categories.workspace = true
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 criterion.workspace = true
 
+[package.metadata.plonky3]
+# Test helpers rely on host facilities and are not part of embedded coverage.
+embedded = false
+
 [dependencies]
 p3-dft.workspace = true
 p3-field.workspace = true

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Shared local and CI command recipes for the Plonky3 workspace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import shlex
+import subprocess
+import sys
+from typing import Any, Sequence
+
+
+LINT_COMMANDS = {
+    "sort": ["cargo", "+stable", "sort", "--workspace", "--grouped", "--check"],
+    "toml": ["taplo", "fmt", "--check"],
+    "deps": ["cargo", "machete", "--with-metadata"],
+    "clippy": ["cargo", "+stable", "clippy", "--all-targets", "--", "-D", "warnings"],
+    "docs": [
+        "cargo",
+        "+stable",
+        "doc",
+        "--no-deps",
+        "--workspace",
+        "--document-private-items",
+    ],
+    "fmt": ["cargo", "+nightly", "fmt", "--all", "--", "--check"],
+    "scripts": [sys.executable, "-m", "unittest", "scripts/test_check.py", "-v"],
+}
+
+
+def cargo_metadata(workspace_root: Path) -> dict[str, Any]:
+    command = ["cargo", "metadata", "--no-deps", "--format-version", "1"]
+    completed = subprocess.run(
+        command,
+        cwd=workspace_root,
+        stdout=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if completed.returncode:
+        raise subprocess.CalledProcessError(completed.returncode, command)
+    return json.loads(completed.stdout)
+
+
+def workspace_packages(metadata: dict[str, Any]) -> list[dict[str, Any]]:
+    members = set(metadata["workspace_members"])
+    return sorted(
+        (package for package in metadata["packages"] if package["id"] in members),
+        key=lambda package: package["name"],
+    )
+
+
+def plonky3_metadata(package: dict[str, Any]) -> dict[str, Any]:
+    metadata = package.get("metadata") or {}
+    value = metadata.get("plonky3", {})
+    return value if isinstance(value, dict) else {}
+
+
+def embedded_packages(metadata: dict[str, Any]) -> list[str]:
+    return [
+        package["name"]
+        for package in workspace_packages(metadata)
+        if any("lib" in target["kind"] for target in package["targets"])
+        and plonky3_metadata(package).get("embedded", True) is not False
+    ]
+
+
+def package_test_features(
+    metadata: dict[str, Any], package_name: str | None, parallel: bool
+) -> list[tuple[str, str]]:
+    runs = []
+    for package in workspace_packages(metadata):
+        if package_name is not None and package["name"] != package_name:
+            continue
+        ci = plonky3_metadata(package).get("ci", {})
+        if not isinstance(ci, dict):
+            continue
+        features = ci.get("test-features", [])
+        for feature in features:
+            if not isinstance(feature, str):
+                raise ValueError(
+                    f"{package['name']} metadata.plonky3.ci.test-features entries must be strings"
+                )
+        if features:
+            features = list(features)
+            if parallel and "parallel" in package.get("features", {}):
+                features.append("parallel")
+            runs.append((package["name"], ",".join(features)))
+    return runs
+
+
+def package_args(package: str | None) -> list[str]:
+    return ["-p", package] if package else []
+
+
+def feature_args(parallel: bool) -> list[str]:
+    return ["--features", "parallel"] if parallel else []
+
+
+def test_commands(
+    metadata: dict[str, Any], package: str | None, parallel: bool, doctest: bool
+) -> list[list[str]]:
+    if doctest:
+        base = ["cargo", "test", "--doc"]
+    else:
+        base = ["cargo", "nextest", "run"]
+    commands = [base + package_args(package) + feature_args(parallel)]
+    for name, features in package_test_features(metadata, package, parallel):
+        commands.append(base + ["-p", name, "--features", features])
+    return commands
+
+
+def lint_commands(check: str | None) -> list[list[str]]:
+    if check:
+        return [LINT_COMMANDS[check]]
+    return list(LINT_COMMANDS.values())
+
+
+def wasm_commands(step: str, build_target: str, run_target: str) -> list[list[str]]:
+    commands = {
+        "build": [
+            "cargo",
+            "build",
+            "--verbose",
+            "--target",
+            build_target,
+            "-p",
+            "p3-goldilocks",
+        ],
+        "test": [
+            "cargo",
+            "test",
+            "--release",
+            "--target",
+            run_target,
+            "-p",
+            "p3-goldilocks",
+            "--lib",
+            "wasm32_simd128",
+        ],
+        "smoke": [
+            "cargo",
+            "run",
+            "--release",
+            "--target",
+            run_target,
+            "--bin",
+            "wasm_smoke",
+            "-p",
+            "p3-goldilocks",
+        ],
+        "bench": [
+            "cargo",
+            "run",
+            "--release",
+            "--target",
+            run_target,
+            "--bin",
+            "wasm_bench",
+            "-p",
+            "p3-goldilocks",
+        ],
+        "merkle": [
+            "cargo",
+            "run",
+            "--release",
+            "--target",
+            run_target,
+            "--example",
+            "wasm_merkle_bench",
+            "-p",
+            "p3-goldilocks",
+        ],
+    }
+    return list(commands.values()) if step == "all" else [commands[step]]
+
+
+def commands_for(args: argparse.Namespace) -> list[list[str]]:
+    command = args.command
+    metadata = None
+    if command in {"full", "test", "doctest", "embedded"}:
+        metadata = cargo_metadata(args.workspace_root)
+
+    if command == "fast":
+        scope = package_args(args.package) if args.package else ["--workspace"]
+        return [["cargo", "check", *scope, "--all-targets", *feature_args(args.parallel)]]
+    if command == "test":
+        return test_commands(metadata, args.package, args.parallel, False)
+    if command == "doctest":
+        return test_commands(metadata, args.package, args.parallel, True)
+    if command == "lint":
+        return lint_commands(args.check)
+    if command == "full":
+        return [
+            ["cargo", "check", "--workspace", "--all-targets"],
+            *test_commands(metadata, None, False, False),
+            *test_commands(metadata, None, False, True),
+            *test_commands(metadata, None, True, False),
+            *test_commands(metadata, None, True, True),
+            *lint_commands(None),
+        ]
+    if command == "architecture":
+        return [
+            [
+                "cargo",
+                "build",
+                "--target",
+                args.target,
+                "--all-targets",
+                *feature_args(args.parallel),
+            ]
+        ]
+    if command == "embedded":
+        return [
+            [
+                "cargo",
+                "build",
+                "--verbose",
+                "--target",
+                args.target,
+                "-p",
+                package,
+                "--lib",
+            ]
+            for package in embedded_packages(metadata)
+        ]
+    if command == "bench":
+        return [
+            [
+                "cargo",
+                "bench",
+                "--workspace",
+                "--exclude",
+                "p3-dft",
+                "--features",
+                "parallel",
+                "--",
+                "--test",
+            ]
+        ]
+    if command == "wasm":
+        return wasm_commands(args.step, args.build_target, args.run_target)
+    if command == "whir-exhaustive":
+        return [
+            [
+                "cargo",
+                "test",
+                "-p",
+                "p3-whir",
+                *feature_args(args.parallel),
+                "pcs::tests::test_whir_end_to_end_exhaustive",
+                "--",
+                "--ignored",
+                "--exact",
+            ]
+        ]
+    if command == "binary-large":
+        return [
+            [
+                "cargo",
+                "test",
+                "-p",
+                "p3-binary-pcs",
+                "--release",
+                "--test",
+                "end_to_end",
+                "large_configuration_2_16_round_trips",
+                "--",
+                "--ignored",
+                "--exact",
+            ]
+        ]
+    raise AssertionError(f"unhandled command: {command}")
+
+
+def add_package_and_parallel(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--package", metavar="NAME", help="limit the command to one package")
+    parser.add_argument("--parallel", action="store_true", help="enable the parallel feature")
+
+
+def parser() -> argparse.ArgumentParser:
+    result = argparse.ArgumentParser(description=__doc__)
+    result.add_argument("--dry-run", action="store_true", help="print commands without running them")
+    result.add_argument(
+        "--workspace-root",
+        type=Path,
+        default=Path(__file__).resolve().parent.parent,
+        help=argparse.SUPPRESS,
+    )
+    subparsers = result.add_subparsers(dest="command", required=True)
+
+    fast = subparsers.add_parser("fast", help="check host targets without running tests")
+    add_package_and_parallel(fast)
+    subparsers.add_parser("full", help="run all host checks used by CI")
+    test = subparsers.add_parser("test", help="run tests with cargo-nextest")
+    add_package_and_parallel(test)
+    doctest = subparsers.add_parser("doctest", help="run Rust documentation tests")
+    add_package_and_parallel(doctest)
+    lint = subparsers.add_parser("lint", help="run formatting, lint, dependency and doc checks")
+    lint.add_argument("--check", choices=LINT_COMMANDS, help="run one lint check")
+    architecture = subparsers.add_parser(
+        "architecture", help="compile all targets for a non-runnable architecture"
+    )
+    architecture.add_argument("--target", required=True)
+    architecture.add_argument("--parallel", action="store_true")
+    embedded = subparsers.add_parser(
+        "embedded", help="build metadata-selected libraries for an embedded target"
+    )
+    embedded.add_argument("--target", default="thumbv7em-none-eabi")
+    subparsers.add_parser("bench", help="run each benchmark body once")
+    wasm = subparsers.add_parser("wasm", help="build or run wasm SIMD smoke coverage")
+    wasm.add_argument(
+        "--step", choices=("all", "build", "test", "smoke", "bench", "merkle"), default="all"
+    )
+    wasm.add_argument("--build-target", default="wasm32-unknown-unknown")
+    wasm.add_argument("--run-target", default="wasm32-wasip1")
+    whir = subparsers.add_parser("whir-exhaustive", help="run the ignored exhaustive WHIR sweep")
+    whir.add_argument("--parallel", action="store_true")
+    subparsers.add_parser("binary-large", help="run the ignored binary PCS 2^16 round trip")
+    return result
+
+
+def display(command: Sequence[str]) -> str:
+    return shlex.join(command)
+
+
+def command_environment(command: Sequence[str]) -> dict[str, str] | None:
+    if command[:3] != ["cargo", "+stable", "doc"]:
+        return None
+    environment = os.environ.copy()
+    deny_broken_links = "-D rustdoc::broken_intra_doc_links"
+    current = environment.get("RUSTDOCFLAGS", "")
+    if deny_broken_links not in current:
+        environment["RUSTDOCFLAGS"] = f"{current} {deny_broken_links}".strip()
+    return environment
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    args.workspace_root = args.workspace_root.resolve()
+    try:
+        commands = commands_for(args)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return error.returncode if isinstance(error, subprocess.CalledProcessError) else 1
+    for command in commands:
+        print(f"+ {display(command)}", flush=True)
+        if not args.dry_run:
+            completed = subprocess.run(
+                command,
+                cwd=args.workspace_root,
+                env=command_environment(command),
+                check=False,
+            )
+            if completed.returncode:
+                return completed.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -107,8 +107,12 @@ def test_commands(
         base = ["cargo", "test", "--doc"]
     else:
         base = ["cargo", "nextest", "run"]
-    commands = [base + package_args(package) + feature_args(parallel)]
-    for name, features in package_test_features(metadata, package, parallel):
+    feature_runs = package_test_features(metadata, package, parallel)
+    baseline = base + package_args(package) + feature_args(parallel)
+    if package and feature_runs and not doctest:
+        baseline += ["--no-tests", "warn"]
+    commands = [baseline]
+    for name, features in feature_runs:
         commands.append(base + ["-p", name, "--features", features])
     return commands
 

--- a/scripts/test_check.py
+++ b/scripts/test_check.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+
+import os
+from pathlib import Path
+import shlex
+import stat
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check.py")
+REPO = SCRIPT.parent.parent
+
+
+class CheckCliTests(unittest.TestCase):
+    def run_check(self, *args, cwd=REPO, env=None):
+        return subprocess.run(
+            [sys.executable, str(SCRIPT), "--workspace-root", str(cwd), *args],
+            cwd=cwd,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def dry_run_lines(self, *args, cwd=REPO):
+        result = self.run_check("--dry-run", *args, cwd=cwd)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        return result.stdout.splitlines()
+
+    def test_test_and_doctest_match_ci_recipes(self):
+        self.assertEqual(
+            self.dry_run_lines("test", "--parallel")[0],
+            "+ cargo nextest run --features parallel",
+        )
+        self.assertEqual(
+            self.dry_run_lines("doctest", "--package", "p3-util"),
+            ["+ cargo test --doc -p p3-util"],
+        )
+
+    def test_architecture_build_is_compile_only(self):
+        self.assertEqual(
+            self.dry_run_lines(
+                "architecture", "--target", "x86_64-unknown-linux-gnu", "--parallel"
+            ),
+            [
+                "+ cargo build --target x86_64-unknown-linux-gnu --all-targets --features parallel"
+            ],
+        )
+
+    def test_wasm_steps_preserve_build_and_runtime_coverage(self):
+        self.assertEqual(
+            self.dry_run_lines("wasm"),
+            [
+                "+ cargo build --verbose --target wasm32-unknown-unknown -p p3-goldilocks",
+                "+ cargo test --release --target wasm32-wasip1 -p p3-goldilocks --lib wasm32_simd128",
+                "+ cargo run --release --target wasm32-wasip1 --bin wasm_smoke -p p3-goldilocks",
+                "+ cargo run --release --target wasm32-wasip1 --bin wasm_bench -p p3-goldilocks",
+                "+ cargo run --release --target wasm32-wasip1 --example wasm_merkle_bench -p p3-goldilocks",
+            ],
+        )
+
+    def test_heavy_and_benchmark_recipes_are_exact(self):
+        self.assertEqual(
+            self.dry_run_lines("bench"),
+            [
+                "+ cargo bench --workspace --exclude p3-dft --features parallel -- --test"
+            ],
+        )
+        self.assertEqual(
+            self.dry_run_lines("whir-exhaustive", "--parallel"),
+            [
+                "+ cargo test -p p3-whir --features parallel pcs::tests::test_whir_end_to_end_exhaustive -- --ignored --exact"
+            ],
+        )
+        self.assertEqual(
+            self.dry_run_lines("binary-large"),
+            [
+                "+ cargo test -p p3-binary-pcs --release --test end_to_end large_configuration_2_16_round_trips -- --ignored --exact"
+            ],
+        )
+
+    def test_lint_can_run_each_existing_ci_check_independently(self):
+        expected = {
+            "sort": "+ cargo +stable sort --workspace --grouped --check",
+            "toml": "+ taplo fmt --check",
+            "deps": "+ cargo machete --with-metadata",
+            "clippy": "+ cargo +stable clippy --all-targets -- -D warnings",
+            "docs": "+ cargo +stable doc --no-deps --workspace --document-private-items",
+            "fmt": "+ cargo +nightly fmt --all -- --check",
+            "scripts": "+ "
+            + shlex.join([sys.executable, "-m", "unittest", "scripts/test_check.py", "-v"]),
+        }
+        for check, command in expected.items():
+            with self.subTest(check=check):
+                self.assertEqual(self.dry_run_lines("lint", "--check", check), [command])
+
+    def test_unknown_command_has_usage_error(self):
+        result = self.run_check("unknown")
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("invalid choice", result.stderr)
+
+    def test_subprocess_exit_status_is_propagated(self):
+        with tempfile.TemporaryDirectory() as temp:
+            bin_dir = Path(temp)
+            fake = bin_dir / "cargo"
+            fake.write_text("#!/bin/sh\nexit 23\n", encoding="utf-8")
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            (bin_dir / "cargo.bat").write_text("@exit /b 23\r\n", encoding="utf-8")
+            env = os.environ.copy()
+            env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+            result = self.run_check("fast", env=env)
+        self.assertEqual(result.returncode, 23)
+
+    def test_docs_preserve_rustdocflags_and_deny_broken_links(self):
+        with tempfile.TemporaryDirectory() as temp:
+            bin_dir = Path(temp)
+            capture = bin_dir / "rustdocflags.txt"
+            fake = bin_dir / "cargo"
+            fake.write_text(
+                '#!/bin/sh\nprintf "%s" "$RUSTDOCFLAGS" > "$CHECK_CAPTURE"\n',
+                encoding="utf-8",
+            )
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            (bin_dir / "cargo.bat").write_text(
+                '@echo|set /p="%RUSTDOCFLAGS%">"%CHECK_CAPTURE%"\r\n', encoding="utf-8"
+            )
+            env = os.environ.copy()
+            env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+            env["CHECK_CAPTURE"] = str(capture)
+            env["RUSTDOCFLAGS"] = "-D warnings"
+            result = self.run_check("lint", "--check", "docs", env=env)
+            captured_flags = capture.read_text(encoding="utf-8")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            captured_flags, "-D warnings -D rustdoc::broken_intra_doc_links"
+        )
+
+
+class CargoMetadataTests(unittest.TestCase):
+    def make_workspace(self, root):
+        root = Path(root)
+        (root / "Cargo.toml").write_text(
+            textwrap.dedent(
+                """
+                [workspace]
+                resolver = "2"
+                members = ["alpha", "beta", "runner", "featured"]
+                """
+            ).strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        self.make_package(root, "alpha", "p3-alpha", "")
+        self.make_package(
+            root,
+            "beta",
+            "p3-beta",
+            "[package.metadata.plonky3]\nembedded = false\n",
+        )
+        self.make_package(root, "runner", "p3-runner", "", target="bin")
+        self.make_package(
+            root,
+            "featured",
+            "p3-featured",
+            """
+            [features]
+            backend-a = []
+            backend-b = []
+            parallel = []
+
+            [package.metadata.plonky3.ci]
+            test-features = ["backend-a", "backend-b"]
+            """,
+        )
+
+    def make_package(self, root, directory, name, extra, target="lib"):
+        package = root / directory
+        (package / "src").mkdir(parents=True)
+        (package / "Cargo.toml").write_text(
+            textwrap.dedent(
+                f"""
+                [package]
+                name = "{name}"
+                version = "0.1.0"
+                edition = "2021"
+
+                {extra}
+                """
+            ),
+            encoding="utf-8",
+        )
+        source = package / "src" / ("lib.rs" if target == "lib" else "main.rs")
+        source.write_text("pub fn marker() {}\n" if target == "lib" else "fn main() {}\n")
+
+    def run_fixture(self, root, *args):
+        return subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--workspace-root",
+                str(root),
+                "--dry-run",
+                *args,
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+
+    def test_embedded_uses_real_workspace_metadata_and_library_targets(self):
+        with tempfile.TemporaryDirectory() as temp:
+            self.make_workspace(temp)
+            result = self.run_fixture(temp, "embedded", "--target", "thumb-test")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                "+ cargo build --verbose --target thumb-test -p p3-alpha --lib",
+                "+ cargo build --verbose --target thumb-test -p p3-featured --lib",
+            ],
+        )
+
+    def test_workspace_member_added_to_metadata_is_automatically_embedded(self):
+        with tempfile.TemporaryDirectory() as temp:
+            self.make_workspace(temp)
+            root = Path(temp)
+            manifest = root / "Cargo.toml"
+            manifest.write_text(
+                manifest.read_text(encoding="utf-8").replace(
+                    '"featured"]', '"featured", "new-lib"]'
+                ),
+                encoding="utf-8",
+            )
+            self.make_package(root, "new-lib", "p3-new-lib", "")
+            result = self.run_fixture(root, "embedded")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("-p p3-new-lib --lib", result.stdout)
+
+    def test_test_features_from_metadata_are_enabled_together(self):
+        with tempfile.TemporaryDirectory() as temp:
+            self.make_workspace(temp)
+            result = self.run_fixture(temp, "test", "--parallel")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [
+                "+ cargo nextest run --features parallel",
+                "+ cargo nextest run -p p3-featured --features backend-a,backend-b,parallel",
+            ],
+        )
+
+    def test_repository_metadata_explicitly_excludes_host_only_packages(self):
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--workspace-root",
+                str(REPO),
+                "--dry-run",
+                "embedded",
+            ],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("p3-examples", result.stdout)
+        self.assertNotIn("p3-field-testing", result.stdout)
+        self.assertIn("p3-binary-pcs", result.stdout)
+        for line in result.stdout.splitlines():
+            self.assertTrue(line.endswith(" --lib"), line)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check.py
+++ b/scripts/test_check.py
@@ -3,6 +3,7 @@
 import os
 from pathlib import Path
 import shlex
+import shutil
 import stat
 import subprocess
 import sys
@@ -252,6 +253,78 @@ class CargoMetadataTests(unittest.TestCase):
             [
                 "+ cargo nextest run --features parallel",
                 "+ cargo nextest run -p p3-featured --features backend-a,backend-b,parallel",
+            ],
+        )
+
+    def test_targeted_feature_package_runs_after_empty_baseline(self):
+        with tempfile.TemporaryDirectory() as temp:
+            self.make_workspace(temp)
+            root = Path(temp)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            capture = root / "commands.txt"
+            real_cargo = shutil.which("cargo")
+            self.assertIsNotNone(real_cargo)
+            fake = bin_dir / "cargo"
+            fake.write_text(
+                textwrap.dedent(
+                    """\
+                    #!/bin/sh
+                    if [ "$1" = metadata ]; then exec "$REAL_CARGO" "$@"; fi
+                    printf '%s\\n' "$*" >> "$CHECK_CAPTURE"
+                    case " $* " in
+                      *" --features "*) exit 0 ;;
+                      *" --no-tests warn "*) exit 0 ;;
+                      *) exit 4 ;;
+                    esac
+                    """
+                ),
+                encoding="utf-8",
+            )
+            fake.chmod(fake.stat().st_mode | stat.S_IXUSR)
+            (bin_dir / "cargo.bat").write_text(
+                textwrap.dedent(
+                    """\
+                    @echo off
+                    if "%1"=="metadata" (
+                      "%REAL_CARGO%" %*
+                      exit /b %errorlevel%
+                    )
+                    echo %*>>"%CHECK_CAPTURE%"
+                    echo %* | findstr /c:"--features" >nul && exit /b 0
+                    echo %* | findstr /c:"--no-tests warn" >nul && exit /b 0
+                    exit /b 4
+                    """
+                ),
+                encoding="utf-8",
+            )
+            env = os.environ.copy()
+            env["PATH"] = str(bin_dir) + os.pathsep + env.get("PATH", "")
+            env["REAL_CARGO"] = real_cargo
+            env["CHECK_CAPTURE"] = str(capture)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--workspace-root",
+                    str(root),
+                    "test",
+                    "--package",
+                    "p3-featured",
+                ],
+                env=env,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+            commands = capture.read_text(encoding="utf-8").splitlines()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            commands,
+            [
+                "nextest run -p p3-featured --no-tests warn",
+                "nextest run -p p3-featured --features backend-a,backend-b",
             ],
         )
 


### PR DESCRIPTION
Local checks currently require copying commands from CI, and embedded coverage relies on a manually maintained crate list that omits binary PCS. Add a Python standard-library command runner shared by local development and the existing workflows.

`scripts/check.py` provides focused/full host checks, tests, lint/docs, architecture builds, embedded builds, wasm checks, benchmark smoke, and heavy-test recipes. Discover embedded libraries from Cargo metadata with explicit host-only exclusions; support package metadata for tests that need multiple features enabled together. Preserve existing CI jobs, matrix entries, target flags, and runtime versus compile-only coverage. Add contributor instructions, a crate map, and a backend capability table.

Validation:

- 13 command tests passed, covering real temporary Cargo workspaces, process failure propagation, feature unions, and an empty targeted nextest baseline followed by feature-gated tests.
- Shared fast/lint/docs commands passed on the combined refactor checkout.
- Embedded runner built all 46 libraries selected in that checkout for `thumbv7em-none-eabi`, including binary PCS.
- Architecture/wasm/heavy/benchmark command dispatch and workflow mapping reviewed; those complete platform-specific suites were not rerun locally.
- Independent code review completed with no outstanding findings.
