### PR TITLE
feat(security): integrate legacy conjectured regime

### DIFF
--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -433,26 +433,26 @@ where
 
 /// Report the security parameter of the proof.
 ///
-/// Prints the legacy conjectured, conjectured, and proven security levels.
+/// Prints proven and conjectured security, followed by the historical legacy estimate.
 #[inline]
 pub fn report_parameter_security<SC>(proof: &Proof<SC>, security_params: &StarkSecurityParams)
 where
     SC: StarkGenericConfig,
 {
-    println!(
-        "Legacy conjectured security: {} bits",
-        proof.legacy_security(security_params).security_bits
-    );
-    println!(
-        "Conjectured security: {} bits",
-        proof.conjectured_security(security_params).security_bits
-    );
     let proven = proof.proven_security(security_params);
     println!(
         "Proven security: {} bits (UDR: {}, LDR: {})",
         proven.security_bits(),
         proven.unique_decoding_bits,
         proven.list_decoding_bits
+    );
+    println!(
+        "Conjectured security: {} bits",
+        proof.conjectured_security(security_params).security_bits
+    );
+    println!(
+        "Legacy security (historical, not a bound): {} bits",
+        proof.legacy_security(security_params).security_bits
     );
 }
 

--- a/examples/src/proofs.rs
+++ b/examples/src/proofs.rs
@@ -433,12 +433,16 @@ where
 
 /// Report the security parameter of the proof.
 ///
-/// Prints the conjectured and proven security levels.
+/// Prints the legacy conjectured, conjectured, and proven security levels.
 #[inline]
 pub fn report_parameter_security<SC>(proof: &Proof<SC>, security_params: &StarkSecurityParams)
 where
     SC: StarkGenericConfig,
 {
+    println!(
+        "Legacy conjectured security: {} bits",
+        proof.legacy_security(security_params).security_bits
+    );
     println!(
         "Conjectured security: {} bits",
         proof.conjectured_security(security_params).security_bits

--- a/security/src/deep.rs
+++ b/security/src/deep.rs
@@ -25,9 +25,14 @@ use libm::log2;
 use crate::error::ErrorBits;
 use crate::shape::{InstanceShape, StarkAirParams};
 
-/// `-log2(ε_DEEP)` in bits. Returns 0 bits if inputs are degenerate.
+/// `-log2(ε_DEEP)` in bits. Returns 0 bits if inputs are degenerate or the trace size
+/// cannot be represented by `u64`.
 pub fn deep_ali_error(air: &StarkAirParams, shape: &InstanceShape, list_size: f64) -> ErrorBits {
-    if shape.modulus_bits == 0 || !list_size.is_finite() || list_size <= 0.0 {
+    if shape.modulus_bits == 0
+        || shape.log_trace_length >= u64::BITS as usize
+        || !list_size.is_finite()
+        || list_size <= 0.0
+    {
         return ErrorBits::from_log2(0.0);
     }
     let k = (1u64 << shape.log_trace_length) as f64;
@@ -39,4 +44,33 @@ pub fn deep_ali_error(air: &StarkAirParams, shape: &InstanceShape, list_size: f6
     let factor = ethstark.max(chunked).max(1.0);
     let bits = shape.modulus_bits as f64 - log2(list_size) - log2(factor);
     ErrorBits::from_log2(bits.max(0.0))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn trace_length_shift_boundary_is_conservative() {
+        let air = StarkAirParams {
+            num_constraints: 1,
+            max_constraint_degree: 2,
+            max_combo: 2,
+        };
+        let mut shape = InstanceShape {
+            log_trace_length: 63,
+            modulus_bits: 128,
+            collision_resistance: 128,
+            num_batched_functions: 1,
+        };
+        // 2^63 fits in u64; the DEEP factor is 3 * 2^63 + 1.
+        let expected = 128.0 - 63.0 - log2(3.0);
+        assert!((deep_ali_error(&air, &shape, 1.0).bits() - expected).abs() < 1e-12);
+
+        // These exponents must not panic or wrap back to a small trace.
+        for log_trace_length in [64, 65, usize::MAX] {
+            shape.log_trace_length = log_trace_length;
+            assert_eq!(deep_ali_error(&air, &shape, 1.0).bits(), 0.0);
+        }
+    }
 }

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -1,7 +1,7 @@
 //! FRI low-degree-test soundness.
 //!
 //! Conjectured regime: random-words bound, [2025/2010] §1.5.
-//! Legacy regime: pre-random-words ethSTARK query bound, [2021/582].
+//! Legacy regime: historical pre-random-words ethSTARK query estimate, [2021/582].
 //! Proven regime: round-by-round, [2024/1553] Theorems 2 & 3, with the
 //! BCHKS25 LDR commit bound ([2025/2055] Theorem 4.2). Cross-checked
 //! against Ethereum's `soundcalc`.
@@ -111,14 +111,18 @@ pub fn conjectured_error(regime: &FriRegime, shape: &InstanceShape) -> ErrorBits
     ErrorBits::from_log2(bits)
 }
 
-/// Legacy conjectured low-degree-test soundness (ethSTARK
-/// [2021/582](https://eprint.iacr.org/2021/582), pre-random-words).
+/// Historical FRI query-error estimate (ethSTARK
+/// [2021/582](https://eprint.iacr.org/2021/582) §5.10.1, pre-random-words).
 ///
-/// `b = num_queries · log_blowup + query_pow`. Predates the random-words
-/// correction in [`conjectured_error`] ([2025/2010] §1.5) and does not
-/// account for the commit-phase folding round covered by
-/// [`conjectured_commit_phase_error`]; kept for callers that specifically
-/// want the older, simpler heuristic bound.
+/// `b = num_queries · log_blowup + query_pow` is `-log2(2^-zeta * eps_1)`:
+/// the paper's FRI query error `eps_1 = rho^s`, boosted by grinding. It does
+/// not reproduce the paper's total-error `lambda`, whose Eq. (19) includes
+/// the one-bit union-bound loss from Eq. (18). The composite below instead
+/// takes the round-by-round minimum over its terms.
+///
+/// This omits the random-words correction in [`conjectured_error`] and the
+/// folding round in [`conjectured_commit_phase_error`]. It is for historical
+/// comparison, not a soundness bound or a guide to deployment parameters.
 /// Use [`crate::stark::legacy_security_report`] to compose it with the
 /// AIR, DEEP-ALI, batching, extra, and commitment-collision terms.
 pub const fn legacy_conjectured_error(regime: &FriRegime) -> ErrorBits {
@@ -500,17 +504,20 @@ mod tests {
         );
     }
 
-    /// `legacy_conjectured_error` reproduces the pre-random-words ethSTARK
-    /// formula exactly: `num_queries * log_blowup + query_pow`.
+    /// ethSTARK §5.10.1 uses R = 2, zeta = 20, and s = 31/41/55 for
+    /// lambda = 80/100/128. These are the boosted query terms, before the
+    /// paper's pre-query cap and one-bit union-bound loss.
     #[test]
-    fn legacy_conjectured_error_matches_ethstark_formula() {
-        let regime = benchmark_regime();
-        let bits = legacy_conjectured_error(&regime).bits();
-        assert_eq!(
-            bits,
-            (regime.num_queries * regime.log_blowup + regime.query_pow_bits) as f64
-        );
-        assert_eq!(bits, 116.0);
+    fn legacy_conjectured_error_matches_ethstark_query_vectors() {
+        for (num_queries, expected) in [(31, 82.0), (41, 102.0), (55, 130.0)] {
+            let regime = FriRegime {
+                log_blowup: 2,
+                num_queries,
+                query_pow_bits: 20,
+                ..benchmark_regime()
+            };
+            assert_eq!(legacy_conjectured_error(&regime).bits(), expected);
+        }
     }
 
     #[test]

--- a/security/src/fri.rs
+++ b/security/src/fri.rs
@@ -1,6 +1,7 @@
 //! FRI low-degree-test soundness.
 //!
 //! Conjectured regime: random-words bound, [2025/2010] §1.5.
+//! Legacy regime: pre-random-words ethSTARK query bound, [2021/582].
 //! Proven regime: round-by-round, [2024/1553] Theorems 2 & 3, with the
 //! BCHKS25 LDR commit bound ([2025/2055] Theorem 4.2). Cross-checked
 //! against Ethereum's `soundcalc`.
@@ -72,6 +73,10 @@ impl LowDegreeTest for FriRegime {
         conjectured_error(self, shape)
     }
 
+    fn legacy_conjectured_error(&self, _shape: &InstanceShape) -> Option<ErrorBits> {
+        Some(legacy_conjectured_error(self))
+    }
+
     fn conjectured_terms(&self, shape: &InstanceShape) -> Vec<SecurityTerm> {
         let mut terms = vec![SecurityTerm::new(
             LDT_QUERY_LABEL,
@@ -114,6 +119,8 @@ pub fn conjectured_error(regime: &FriRegime, shape: &InstanceShape) -> ErrorBits
 /// account for the commit-phase folding round covered by
 /// [`conjectured_commit_phase_error`]; kept for callers that specifically
 /// want the older, simpler heuristic bound.
+/// Use [`crate::stark::legacy_security_report`] to compose it with the
+/// AIR, DEEP-ALI, batching, extra, and commitment-collision terms.
 pub const fn legacy_conjectured_error(regime: &FriRegime) -> ErrorBits {
     ErrorBits::from_log2((regime.log_blowup * regime.num_queries + regime.query_pow_bits) as f64)
 }

--- a/security/src/grinding.rs
+++ b/security/src/grinding.rs
@@ -36,11 +36,13 @@ pub const fn boost(error: ErrorBits, pow_bits: usize) -> ErrorBits {
 /// Each site is consumed by the term whose round it opens:
 ///
 /// - [`Self::out_of_domain`] is applied to the DEEP-ALI term by
-///   [`crate::stark::proven_security_report`] and
-///   [`crate::stark::conjectured_security_report`].
+///   [`crate::stark::proven_security_report`],
+///   [`crate::stark::conjectured_security_report`], and
+///   [`crate::stark::legacy_security_report`].
 /// - [`Self::batch_combination`] is applied to the batched-openings term by
-///   [`crate::stark::proven_security_report`] and
-///   [`crate::stark::conjectured_security_report`].
+///   [`crate::stark::proven_security_report`],
+///   [`crate::stark::conjectured_security_report`], and
+///   [`crate::stark::legacy_security_report`].
 /// - [`Self::lookup_challenge`] is applied to the LogUp fingerprint term by
 ///   [`crate::logup::security_term`].
 ///
@@ -71,9 +73,9 @@ pub struct GrindingSites {
     /// with nothing to batch there is no such round and these bits buy
     /// nothing.
     ///
-    /// Both the proven and the conjectured composites model this round, so
-    /// grinding here moves either report — the two grade it in different
-    /// proximity regimes, but the prover pays the same work regardless.
+    /// The proven, conjectured, and legacy composites all model this round.
+    /// They grade it in different proximity regimes, but the prover pays the
+    /// same work regardless.
     pub batch_combination: usize,
     /// Bits ground before the lookup / permutation argument's challenges are
     /// sampled.

--- a/security/src/ldt.rs
+++ b/security/src/ldt.rs
@@ -18,8 +18,9 @@ use crate::shape::{InstanceShape, StarkAirParams};
 /// DEEP-ALI bounds at the protocol call site.
 ///
 /// The proximity regimes mirror [`crate::proximity`]: unique decoding (list
-/// size 1) and list decoding at an explicit proximity parameter `m`. An
-/// implementation reports only the **LDT-only** error for each regime; the
+/// size 1) and list decoding at an explicit proximity parameter `m`, plus
+/// conjectured and optionally legacy bounds. An implementation reports only
+/// the **LDT-only** error for each regime; the
 /// composite ([`crate::stark::proven_security_report`]) folds in the ALI,
 /// DEEP, extra, and commitment-collision terms.
 pub trait LowDegreeTest {
@@ -61,6 +62,17 @@ pub trait LowDegreeTest {
 
     /// Conjectured LDT error (random-words / heuristic regime).
     fn conjectured_error(&self, shape: &InstanceShape) -> ErrorBits;
+
+    /// Legacy conjectured LDT error, before the random-words correction.
+    ///
+    /// Returns `None` unless the implementation explicitly supports the
+    /// legacy regime. This keeps existing implementations compatible without
+    /// relabeling their modern conjectured bound as a legacy one.
+    /// [`crate::fri::FriRegime`] returns the ethSTARK query-only bound,
+    /// omitting its commit-phase folding round.
+    fn legacy_conjectured_error(&self, _shape: &InstanceShape) -> Option<ErrorBits> {
+        None
+    }
 
     /// The conjectured regime's LDT terms, labeled per phase.
     ///

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -19,6 +19,9 @@ pub const DEEP_LABEL: &str = "deep-ali";
 /// Label for the low-degree-test term, when an implementation reports its
 /// phases as one already-composed bound.
 ///
+/// Also used for the legacy FRI query-only estimate in
+/// [`crate::stark::legacy_security_report`], which omits the folding round.
+///
 /// # Asymmetry with the conjectured path
 ///
 /// The proven path reports this single label while the conjectured path
@@ -68,6 +71,11 @@ pub enum Regime {
     /// list-decoding capacity, at list size 1. See
     /// [`crate::proximity::list_size_conjectured`].
     Conjectured,
+    /// Legacy conjectured regime using the pre-random-words ethSTARK
+    /// query bound. For FRI this omits the folding round; see
+    /// [`crate::fri::legacy_conjectured_error`] and
+    /// [`crate::stark::legacy_security_report`].
+    Legacy,
 }
 
 /// Full soundness breakdown within a single proximity regime.
@@ -78,7 +86,8 @@ pub enum Regime {
 /// proof.
 ///
 /// This is also the top-level output of
-/// [`crate::stark::conjectured_security_report`], which has a single regime
+/// [`crate::stark::conjectured_security_report`] and
+/// [`crate::stark::legacy_security_report`], which each have a single regime
 /// and therefore no [`SecurityReport`] envelope to maximize over.
 #[derive(Clone, Debug, Serialize)]
 pub struct RegimeReport {

--- a/security/src/report.rs
+++ b/security/src/report.rs
@@ -19,9 +19,6 @@ pub const DEEP_LABEL: &str = "deep-ali";
 /// Label for the low-degree-test term, when an implementation reports its
 /// phases as one already-composed bound.
 ///
-/// Also used for the legacy FRI query-only estimate in
-/// [`crate::stark::legacy_security_report`], which omits the folding round.
-///
 /// # Asymmetry with the conjectured path
 ///
 /// The proven path reports this single label while the conjectured path

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -5,6 +5,8 @@
 //!
 //! The conjectured counterpart ([`conjectured_security_report`]) composes the
 //! same sources in the single random-words regime, where the list size is 1.
+//! [`legacy_security_report`] instead uses the LDT's legacy heuristic while
+//! retaining the same non-LDT terms.
 //!
 //! Extra protocol-specific error terms (lookup arguments, custom DEEP
 //! variants, batched openings, …) are passed through `extras: &[ErrorBits]`
@@ -421,6 +423,68 @@ pub fn conjectured_security_report<L: LowDegreeTest>(
         ErrorBits::from_log2(shape.collision_resistance as f64),
     ));
     RegimeReport::new(Regime::Conjectured, terms)
+}
+
+/// Composite legacy conjectured bits. Scalar mirror of
+/// [`legacy_security_report`], with the same terms and grinding sites.
+/// Returns `None` when the low-degree test does not support the legacy regime.
+pub fn legacy_security<L: LowDegreeTest>(
+    ldt: &L,
+    air: &StarkAirParams,
+    shape: &InstanceShape,
+    extras: &[ErrorBits],
+    grinding: &GrindingSites,
+) -> Option<ErrorBits> {
+    let ldt_error = ldt.legacy_conjectured_error(shape)?;
+    let list_size = list_size_conjectured();
+    let ali = air::composition_error(air.num_constraints, list_size, shape.modulus_bits);
+    let deep = boost(
+        deep::deep_ali_error(air, shape, list_size),
+        grinding.out_of_domain,
+    );
+    let batch = conjectured_batching_term(shape, ldt.log_blowup(), grinding.batch_combination);
+    let mut all = Vec::with_capacity(4 + extras.len());
+    all.push(ali);
+    all.push(deep);
+    all.push(ldt_error);
+    all.extend(batch.map(|t| t.bits));
+    all.extend_from_slice(extras);
+    let algebraic = ErrorBits::min(&all);
+    Some(ErrorBits::from_log2(
+        algebraic.bits().min(shape.collision_resistance as f64),
+    ))
+}
+
+/// Composite report using the legacy conjectured LDT bound.
+///
+/// Uses [`LowDegreeTest::legacy_conjectured_error`] under [`Regime::Legacy`].
+/// For FRI this is `num_queries * log_blowup + query_pow_bits`, without the
+/// random-words correction or the commit-phase folding term. This is an
+/// opt-in historical heuristic, not a proven soundness bound.
+///
+/// Only the LDT bound changes: ALI and DEEP-ALI still use list size 1, and
+/// batching, `extras`, grinding outside the LDT, and the commitment-collision
+/// cap are composed as in [`conjectured_security_report`]. Thus this is a
+/// STARK composite using the legacy LDT estimate, rather than the bare FRI
+/// formula. Returns `None` when the LDT does not support the legacy regime.
+pub fn legacy_security_report<L: LowDegreeTest>(
+    ldt: &L,
+    air: &StarkAirParams,
+    shape: &InstanceShape,
+    extras: &[SecurityTerm],
+    grinding: &GrindingSites,
+) -> Option<RegimeReport> {
+    let ldt_error = ldt.legacy_conjectured_error(shape)?;
+    Some(regime_report(
+        Regime::Legacy,
+        air,
+        shape,
+        list_size_conjectured(),
+        ldt_error,
+        conjectured_batching_term(shape, ldt.log_blowup(), grinding.batch_combination),
+        extras,
+        grinding,
+    ))
 }
 
 #[cfg(test)]
@@ -889,6 +953,106 @@ mod tests {
 
         assert!((b32.security_bits() - b0.security_bits()).abs() < 1e-12);
         assert!(b32.udr.terms().iter().all(|t| t.label != BATCH_LABEL));
+    }
+
+    /// Legacy reporting retains the ethSTARK query formula without adding
+    /// the random-words correction or the FRI folding round.
+    #[test]
+    fn legacy_report_uses_ethstark_query_bound() {
+        let regime = benchmark_regime();
+        let report =
+            legacy_security_report(&regime, &air(), &shape(), &[], &GrindingSites::NONE).unwrap();
+
+        assert_eq!(report.regime, Regime::Legacy);
+        assert_eq!(report.security_bits(), 116.0);
+        assert_eq!(report.binding().label, LDT_LABEL);
+        assert_eq!(report.terms().len(), 4);
+        assert_eq!(
+            legacy_security(&regime, &air(), &shape(), &[], &GrindingSites::NONE)
+                .unwrap()
+                .bits(),
+            116.0,
+        );
+
+        // Over this smaller field the modern folding term would bind below
+        // DEEP-ALI. Legacy omits it, leaving DEEP at 96 - log2(3 * 2^20 + 1).
+        let small_shape = InstanceShape {
+            modulus_bits: 96,
+            ..shape()
+        };
+        let small =
+            legacy_security_report(&regime, &air(), &small_shape, &[], &GrindingSites::NONE)
+                .unwrap();
+        assert_eq!(small.binding().label, DEEP_LABEL);
+        assert_eq!(small.security_bits() as usize, 74);
+        assert_eq!(
+            legacy_security(&regime, &air(), &small_shape, &[], &GrindingSites::NONE)
+                .unwrap()
+                .bits(),
+            small.security_bits(),
+        );
+    }
+
+    #[test]
+    fn legacy_report_preserves_composite_caps_and_grinding() {
+        let regime = benchmark_regime();
+        let air = air();
+        let shape = InstanceShape {
+            modulus_bits: 100,
+            num_batched_functions: 1025,
+            ..shape()
+        };
+        let cases = [
+            (GrindingSites::NONE, 128, None, BATCH_LABEL, 69),
+            (
+                GrindingSites {
+                    batch_combination: 8,
+                    ..GrindingSites::NONE
+                },
+                128,
+                None,
+                BATCH_LABEL,
+                77,
+            ),
+            (
+                GrindingSites {
+                    batch_combination: 20,
+                    out_of_domain: 8,
+                    ..GrindingSites::NONE
+                },
+                128,
+                None,
+                DEEP_LABEL,
+                86,
+            ),
+            (GrindingSites::NONE, 64, None, COLLISION_LABEL, 64),
+            (GrindingSites::NONE, 128, Some(40.0), "extra", 40),
+        ];
+        for (grinding, collision_resistance, extra, label, bits) in cases {
+            let shape = InstanceShape {
+                collision_resistance,
+                ..shape
+            };
+            let extras: Vec<_> = extra.into_iter().map(ErrorBits::from_log2).collect();
+            let terms: Vec<_> = extras
+                .iter()
+                .map(|&bits| SecurityTerm::new("extra", bits))
+                .collect();
+            let report = legacy_security_report(&regime, &air, &shape, &terms, &grinding).unwrap();
+            let scalar = legacy_security(&regime, &air, &shape, &extras, &grinding).unwrap();
+            assert_eq!(report.binding().label, label);
+            assert_eq!(report.security_bits() as usize, bits);
+            assert_eq!(scalar.bits(), report.security_bits());
+        }
+    }
+
+    #[test]
+    fn legacy_report_requires_explicit_ldt_support() {
+        let ldt = LdtOnlyChoice(benchmark_regime());
+        assert!(
+            legacy_security_report(&ldt, &air(), &shape(), &[], &GrindingSites::NONE).is_none()
+        );
+        assert!(legacy_security(&ldt, &air(), &shape(), &[], &GrindingSites::NONE).is_none());
     }
 
     /// The conjectured report's attained bits equal the scalar

--- a/security/src/stark.rs
+++ b/security/src/stark.rs
@@ -22,8 +22,8 @@ use crate::grinding::{GrindingSites, boost};
 use crate::ldt::LowDegreeTest;
 use crate::proximity::{list_size_conjectured, list_size_ldr_m, list_size_udr};
 use crate::report::{
-    ALI_LABEL, BATCH_LABEL, COLLISION_LABEL, DEEP_LABEL, LDT_LABEL, Regime, RegimeReport,
-    SecurityReport, SecurityTerm,
+    ALI_LABEL, BATCH_LABEL, COLLISION_LABEL, DEEP_LABEL, LDT_LABEL, LDT_QUERY_LABEL, Regime,
+    RegimeReport, SecurityReport, SecurityTerm,
 };
 use crate::shape::{InstanceShape, StarkAirParams};
 use crate::{air, deep};
@@ -191,13 +191,13 @@ fn conjectured_batching_term(
 /// `grinding.out_of_domain` boosts the DEEP term and
 /// `grinding.batch_combination` the batch term (applied by the caller, which
 /// builds `batch`); the low-degree test's own sites are already folded into
-/// `ldt_error` by the [`LowDegreeTest`] impl.
+/// `ldt_term` by the [`LowDegreeTest`] impl.
 fn regime_report(
     regime: Regime,
     air: &StarkAirParams,
     shape: &InstanceShape,
     list_size: f64,
-    ldt_error: ErrorBits,
+    ldt_term: SecurityTerm,
     batch: Option<SecurityTerm>,
     extras: &[SecurityTerm],
     grinding: &GrindingSites,
@@ -210,7 +210,7 @@ fn regime_report(
     let mut terms = Vec::with_capacity(5 + extras.len());
     terms.push(SecurityTerm::new(ALI_LABEL, ali));
     terms.push(SecurityTerm::new(DEEP_LABEL, deep));
-    terms.push(SecurityTerm::new(LDT_LABEL, ldt_error));
+    terms.push(ldt_term);
     terms.extend(batch);
     terms.extend_from_slice(extras);
     terms.push(SecurityTerm::new(
@@ -251,7 +251,7 @@ pub fn proven_security_report<L: LowDegreeTest>(
         air,
         shape,
         list_size_udr(),
-        udr_ldt,
+        SecurityTerm::new(LDT_LABEL, udr_ldt),
         batching_term(
             SecurityAssumption::UniqueDecoding,
             shape,
@@ -276,7 +276,7 @@ pub fn proven_security_report<L: LowDegreeTest>(
                 air,
                 shape,
                 list_size,
-                ldr_ldt,
+                SecurityTerm::new(LDT_LABEL, ldr_ldt),
                 batching_term(
                     SecurityAssumption::JohnsonBound,
                     shape,
@@ -455,18 +455,26 @@ pub fn legacy_security<L: LowDegreeTest>(
     ))
 }
 
-/// Composite report using the legacy conjectured LDT bound.
+/// Composite report using the historical legacy LDT estimate.
 ///
 /// Uses [`LowDegreeTest::legacy_conjectured_error`] under [`Regime::Legacy`].
 /// For FRI this is `num_queries * log_blowup + query_pow_bits`, without the
 /// random-words correction or the commit-phase folding term. This is an
-/// opt-in historical heuristic, not a proven soundness bound.
+/// opt-in historical heuristic, not a soundness bound or a guide to deployment
+/// parameters. It may exceed the conjectured report; shared caps can make them equal.
+///
+/// The FRI term reproduces ethSTARK §5.10.1's query error `eps_1`, boosted by
+/// grinding. This composite uses the round-by-round minimum convention of
+/// [2024/1553](https://eprint.iacr.org/2024/1553) §2, not ethSTARK's total-error
+/// `lambda`: Eq. (18) adds the pre-query and boosted query errors, and Eq. (19)
+/// includes the resulting union-bound loss of one bit. No such `-1` is applied here.
 ///
 /// Only the LDT bound changes: ALI and DEEP-ALI still use list size 1, and
 /// batching, `extras`, grinding outside the LDT, and the commitment-collision
-/// cap are composed as in [`conjectured_security_report`]. Thus this is a
-/// STARK composite using the legacy LDT estimate, rather than the bare FRI
-/// formula. Returns `None` when the LDT does not support the legacy regime.
+/// cap are composed as in [`conjectured_security_report`]. ALI and DEEP charge the
+/// actual constraint count and identity degree through [`air::composition_error`]
+/// and [`deep::deep_ali_error`], rather than ethSTARK's flat `log2|K|` pre-query cap.
+/// Returns `None` when the LDT does not support the legacy regime.
 pub fn legacy_security_report<L: LowDegreeTest>(
     ldt: &L,
     air: &StarkAirParams,
@@ -480,7 +488,7 @@ pub fn legacy_security_report<L: LowDegreeTest>(
         air,
         shape,
         list_size_conjectured(),
-        ldt_error,
+        SecurityTerm::new(LDT_QUERY_LABEL, ldt_error),
         conjectured_batching_term(shape, ldt.log_blowup(), grinding.batch_combination),
         extras,
         grinding,
@@ -489,8 +497,9 @@ pub fn legacy_security_report<L: LowDegreeTest>(
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
+
     use super::*;
-    use crate::report::LDT_QUERY_LABEL;
 
     fn shape() -> InstanceShape {
         InstanceShape {
@@ -558,7 +567,7 @@ mod tests {
             &air,
             &shape,
             list_size,
-            ldt,
+            SecurityTerm::new(LDT_LABEL, ldt),
             None,
             &[SecurityTerm::new("extra", extra)],
             &GrindingSites::NONE,
@@ -965,7 +974,7 @@ mod tests {
 
         assert_eq!(report.regime, Regime::Legacy);
         assert_eq!(report.security_bits(), 116.0);
-        assert_eq!(report.binding().label, LDT_LABEL);
+        assert_eq!(report.binding().label, LDT_QUERY_LABEL);
         assert_eq!(report.terms().len(), 4);
         assert_eq!(
             legacy_security(&regime, &air(), &shape(), &[], &GrindingSites::NONE)
@@ -1053,6 +1062,64 @@ mod tests {
             legacy_security_report(&ldt, &air(), &shape(), &[], &GrindingSites::NONE).is_none()
         );
         assert!(legacy_security(&ldt, &air(), &shape(), &[], &GrindingSites::NONE).is_none());
+    }
+
+    proptest! {
+        /// Legacy stays above both modern reports, including degenerate inputs.
+        /// The random-words estimate can be more conservative than the proven bound
+        /// over tiny fields, so the three-way order is asserted for fields of at least
+        /// 32 bits; every generated LDE fits within 28 bits.
+        #[test]
+        fn fri_legacy_report_stays_above_modern_reports(
+            fri in (0usize..=4, 0usize..=64, 0usize..=32, 0usize..=4, 0usize..=24, 0usize..=24),
+            instance in (0usize..=24, 0usize..=256, 0usize..=160, 0usize..=64),
+            air_shape in (0usize..=64, 0usize..=16, 0usize..=4),
+            grinding in (0usize..=24, 0usize..=24),
+            extra in proptest::option::of(0usize..=160),
+        ) {
+            let (log_blowup, num_queries, log_final_poly_len, max_log_arity, commit_pow_bits, query_pow_bits) = fri;
+            let regime = crate::fri::FriRegime {
+                log_blowup,
+                num_queries,
+                log_final_poly_len,
+                max_log_arity,
+                commit_pow_bits,
+                query_pow_bits,
+            };
+            let (log_trace_length, modulus_bits, collision_resistance, num_batched_functions) = instance;
+            let shape = InstanceShape {
+                log_trace_length,
+                modulus_bits,
+                collision_resistance,
+                num_batched_functions,
+            };
+            let (num_constraints, max_constraint_degree, max_combo) = air_shape;
+            let air = StarkAirParams {
+                num_constraints,
+                max_constraint_degree,
+                max_combo,
+            };
+            let grinding = GrindingSites {
+                out_of_domain: grinding.0,
+                batch_combination: grinding.1,
+                ..GrindingSites::NONE
+            };
+            let extras: Vec<_> = extra.into_iter()
+                .map(|bits| SecurityTerm::new("extra", ErrorBits::from_log2(bits as f64)))
+                .collect();
+
+            let legacy = legacy_security_report(&regime, &air, &shape, &extras, &grinding)
+                .unwrap().security_bits();
+            let conjectured = conjectured_security_report(&regime, &air, &shape, &extras, &grinding)
+                .security_bits();
+            let proven = proven_security_report(&regime, &air, &shape, &extras, &grinding)
+                .security_bits();
+            prop_assert!(legacy >= conjectured);
+            prop_assert!(legacy >= proven);
+            if modulus_bits >= 32 {
+                prop_assert!(conjectured >= proven);
+            }
+        }
     }
 
     /// The conjectured report's attained bits equal the scalar

--- a/uni-stark/src/proof.rs
+++ b/uni-stark/src/proof.rs
@@ -3,7 +3,7 @@ use alloc::vec::Vec;
 use p3_commit::Pcs;
 use serde::{Deserialize, Serialize};
 
-use crate::security::{ConjecturedSecurity, ProvenSecurity, StarkSecurityParams};
+use crate::security::{ConjecturedSecurity, LegacySecurity, ProvenSecurity, StarkSecurityParams};
 use crate::{Com, StarkGenericConfig, Val};
 
 type PcsProof<SC> = <<SC as StarkGenericConfig>::Pcs as Pcs<
@@ -26,6 +26,13 @@ pub struct Proof<SC: StarkGenericConfig> {
 }
 
 impl<SC: StarkGenericConfig> Proof<SC> {
+    /// Legacy conjectured security level (in bits).
+    ///
+    /// See [`LegacySecurity`].
+    pub fn legacy_security(&self, params: &StarkSecurityParams) -> LegacySecurity {
+        LegacySecurity::compute_from_params(params, self.degree_bits)
+    }
+
     /// Conjectured security level (in bits).
     ///
     /// See [`ConjecturedSecurity`].

--- a/uni-stark/src/proof.rs
+++ b/uni-stark/src/proof.rs
@@ -28,6 +28,9 @@ pub struct Proof<SC: StarkGenericConfig> {
 impl<SC: StarkGenericConfig> Proof<SC> {
     /// Legacy conjectured security level (in bits).
     ///
+    /// For historical comparison only: this may exceed [`ConjecturedSecurity`]
+    /// and is not a soundness bound. Do not use it to size deployment parameters.
+    ///
     /// See [`LegacySecurity`].
     pub fn legacy_security(&self, params: &StarkSecurityParams) -> LegacySecurity {
         LegacySecurity::compute_from_params(params, self.degree_bits)

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -480,13 +480,16 @@ impl ConjecturedSecurity {
     }
 }
 
-/// Legacy conjectured security level using the pre-random-words ethSTARK
-/// FRI bound: `num_queries * log_blowup + query_pow_bits`.
+/// Historical security estimate using the pre-random-words ethSTARK
+/// FRI query formula: `num_queries * log_blowup + query_pow_bits`.
 ///
 /// The STARK composite still includes AIR composition, DEEP-ALI, batched
 /// openings, and the commitment-collision cap. The FRI folding round and its
 /// commit-phase grinding are omitted by this historical heuristic. See
 /// [`legacy_security_report`].
+///
+/// For historical comparison only: this may exceed [`ConjecturedSecurity`]
+/// and is not a soundness bound. Do not use it to size deployment parameters.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LegacySecurity {
     pub security_bits: usize,
@@ -678,6 +681,16 @@ mod tests {
         assert_eq!(
             LegacySecurity::compute_from_params(&params, 20).security_bits,
             82
+        );
+    }
+
+    #[test]
+    fn legacy_security_rejects_an_unrepresentable_trace_length() {
+        let params = benchmark_high_arity_params(252);
+        // Proof::legacy_security passes the deserialized degree_bits through here.
+        assert_eq!(
+            LegacySecurity::compute_from_params(&params, 64).security_bits,
+            0
         );
     }
 

--- a/uni-stark/src/security.rs
+++ b/uni-stark/src/security.rs
@@ -15,7 +15,9 @@ use p3_security::fri::FriRegime;
 // dependency on `p3-security`.
 pub use p3_security::grinding::GrindingSites;
 use p3_security::shape::{InstanceShape, StarkAirParams as P3AirShape};
-use p3_security::stark::{conjectured_security_report, proven_security_report};
+use p3_security::stark::{
+    conjectured_security_report, legacy_security_report, proven_security_report,
+};
 use p3_util::{log2_ceil_usize, log2_floor_usize};
 
 /// What the polynomial commitment scheme commits beyond what the AIR itself
@@ -478,6 +480,37 @@ impl ConjecturedSecurity {
     }
 }
 
+/// Legacy conjectured security level using the pre-random-words ethSTARK
+/// FRI bound: `num_queries * log_blowup + query_pow_bits`.
+///
+/// The STARK composite still includes AIR composition, DEEP-ALI, batched
+/// openings, and the commitment-collision cap. The FRI folding round and its
+/// commit-phase grinding are omitted by this historical heuristic. See
+/// [`legacy_security_report`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LegacySecurity {
+    pub security_bits: usize,
+}
+
+impl LegacySecurity {
+    /// Compute legacy security at the proof's committed-polynomial size.
+    /// `degree_bits` includes zk padding, as in
+    /// [`ConjecturedSecurity::compute_from_params`].
+    pub fn compute_from_params(params: &StarkSecurityParams, degree_bits: usize) -> Self {
+        let report = legacy_security_report(
+            &params.fri_regime(),
+            &params.air_shape(),
+            &params.instance_shape(degree_bits),
+            &[],
+            &params.grinding,
+        )
+        .expect("FRI supports the legacy conjectured regime");
+        Self {
+            security_bits: report.security_bits() as usize,
+        }
+    }
+}
+
 /// Proven security level (in bits) of a STARK configuration.
 ///
 /// Follows Theorems 2 and 3 of [2024/1553](https://eprint.iacr.org/2024/1553)
@@ -621,6 +654,31 @@ mod tests {
     fn conjectured_security_log_blowup_zero_returns_zero_fri_bits() {
         let s = ConjecturedSecurity::compute_ldt_only(0, 100, 16, 128, 256);
         assert_eq!(s.security_bits, 16);
+    }
+
+    #[test]
+    fn legacy_security_from_params_preserves_the_legacy_bound() {
+        let params = benchmark_high_arity_params(252);
+        assert_eq!(
+            LegacySecurity::compute_from_params(&params, 20).security_bits,
+            116
+        );
+
+        let params = benchmark_high_arity_params(96);
+        let actual = [10, 16, 20, 24, 28]
+            .map(|degree_bits| LegacySecurity::compute_from_params(&params, degree_bits))
+            .map(|s| s.security_bits);
+        // DEEP-ALI binds at 96 - log2(3 * 2^degree_bits + 1).
+        assert_eq!(actual, [84, 78, 74, 70, 66]);
+
+        let params = params.with_grinding(GrindingSites {
+            out_of_domain: 8,
+            ..GrindingSites::NONE
+        });
+        assert_eq!(
+            LegacySecurity::compute_from_params(&params, 20).security_bits,
+            82
+        );
     }
 
     fn benchmark_high_arity_params(num_modulus_bits: usize) -> StarkSecurityParams {


### PR DESCRIPTION
The legacy ethSTARK FRI formula added in #2018 was only available as a standalone helper. Integrate it through `Regime::Legacy`, optional `LowDegreeTest` support, scalar/report APIs, and uni-STARK's `LegacySecurity` and `Proof::legacy_security`. Include the legacy level in example output.

Legacy reports use `num_queries * log_blowup + query_pow_bits` and omit the FRI folding term. They retain AIR/DEEP, batching, extras, grinding outside the LDT, and the commitment-collision cap. LDTs without explicit legacy support return `None`.

Validation:

- 168 tests passed with `cargo test -p p3-security -p p3-uni-stark --offline`, including legacy regression and composite-accounting coverage.
- Clippy passed for security, uni-STARK, and examples with `--all-targets -- -D warnings`.
- Workspace formatting and rustdoc checks with broken intra-doc links denied passed.
