### PR TITLE
fix(stir): reject the compact answer encoding in the default representation

### DIFF
--- a/stir/src/error.rs
+++ b/stir/src/error.rs
@@ -103,6 +103,14 @@ pub enum ProofShapeError {
     #[error("{round}: compact answers expect no transmitted ans coefficients, got {got}")]
     UnexpectedAnsPolynomial { round: RoundLabel, got: usize },
 
+    /// The default representation sends the answer polynomial itself.
+    ///
+    /// An interpolant through at least one node always carries a coefficient.
+    ///
+    /// An empty vector is the compact encoding, which is a different protocol.
+    #[error("{round}: ans polynomial is empty, expected at least one coefficient")]
+    MissingAnsPolynomial { round: RoundLabel, nodes: usize },
+
     /// A committed oracle is read through a Merkle multi-opening the proof must supply.
     #[error("{round}: missing query openings")]
     MissingQueryOpenings { round: RoundLabel },

--- a/stir/src/prover.rs
+++ b/stir/src/prover.rs
@@ -1475,7 +1475,15 @@ where
     Dft: TwoAdicSubgroupDft<F>,
 {
     let size = 1usize << log_size;
-    let log_len = log2_ceil_usize(coeffs.len().min(size).max(1));
+    // Floor the transform at two rows, then cap it at the coset.
+    //
+    // Why the floor: a constant is already exact over one variable.
+    //   The second row reads past the coefficients and contributes zero.
+    //   So the floor changes no result, and no backend is handed a single-row matrix.
+    //
+    // Why the cap: a single-point coset has no room for that floor.
+    //   The expansion measured below would otherwise wrap.
+    let log_len = log2_ceil_usize(coeffs.len().min(size).max(2)).min(log_size);
     // At low expansion ratios the full DFT avoids the cost of scaling a wide batch.
     if log_size - log_len >= 3 {
         return eval_low_degree_on_coset(dft, [&coeffs], shift, log_size, log_len);

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -130,10 +130,26 @@ fn single_matrix_opened_values<EF>(row_evals: &[Vec<EF>]) -> Vec<Vec<&[EF]>> {
         .collect()
 }
 
-/// Reject an `Ans` polynomial longer than the round's degree bound allows.
+/// Bound a transmitted answer polynomial at both ends.
 ///
-/// `Ans` interpolates `max_ans_len` points, so its degree is below that. A shorter polynomial
-/// is legitimate: the prover may strip trailing zeros.
+/// The polynomial interpolates the round's out-of-domain and query points.
+///
+/// Its degree therefore sits below the number of those nodes.
+///
+/// A shorter polynomial is legitimate.
+///
+/// A prover may strip trailing zero coefficients.
+///
+/// Stripping never reaches the empty vector while a node remains:
+///
+/// ```text
+///     one node    ->  the interpolant is a constant
+///     that zero   ->  a single zero coefficient, not an empty vector
+/// ```
+///
+/// So an empty vector is the compact encoding rather than a stripped one.
+///
+/// Accepting it here would leave the two encodings separated by the transcript alone.
 fn check_ans_length<EF, MmcsError, InputError>(
     round: RoundLabel,
     ans_polynomial: &[EF],
@@ -144,6 +160,13 @@ fn check_ans_length<EF, MmcsError, InputError>(
             round,
             maximum: max_ans_len,
             got: ans_polynomial.len(),
+        }
+        .into());
+    }
+    if ans_polynomial.is_empty() && max_ans_len > 0 {
+        return Err(ProofShapeError::MissingAnsPolynomial {
+            round,
+            nodes: max_ans_len,
         }
         .into());
     }
@@ -227,6 +250,58 @@ mod compact_answer_tests {
             .unwrap(),
             Cow::Borrowed([F::ZERO, F::ZERO])
         ));
+    }
+
+    #[test]
+    fn the_default_representation_rejects_the_compact_encoding() {
+        let round = RoundLabel::Round(2);
+
+        // Invariant: the default encoding always carries at least one coefficient.
+        //
+        //     default  ->  [c_0, c_1, ...]   the interpolant itself
+        //     compact  ->  []                rebuilt from the opened values
+        //
+        // Fixture state: two nodes to interpolate, so the interpolant is not empty.
+        //
+        // Mutation: send the compact encoding to a default-mode reader.
+        assert!(matches!(
+            resolve_ans_polynomial::<F, (), ()>(
+                round,
+                false,
+                &[],
+                &[F::ONE, F::TWO],
+                &[F::ZERO, F::ZERO]
+            ),
+            Err(StirError::InvalidProofShape(
+                ProofShapeError::MissingAnsPolynomial {
+                    round: RoundLabel::Round(2),
+                    nodes: 2
+                }
+            ))
+        ));
+
+        // Fixture state: one node holding zero, so the interpolant is the zero constant.
+        //
+        //     []        ->  the zero polynomial
+        //     [ZERO]    ->  the zero polynomial
+        //
+        // Both spell the same virtual oracle, so the shape is all that separates them.
+        assert!(matches!(
+            resolve_ans_polynomial::<F, (), ()>(round, false, &[], &[F::ONE], &[F::ZERO]),
+            Err(StirError::InvalidProofShape(
+                ProofShapeError::MissingAnsPolynomial {
+                    round: RoundLabel::Round(2),
+                    nodes: 1
+                }
+            ))
+        ));
+
+        // Fixture state: no nodes at all, so the empty vector is the only encoding there is.
+        assert!(
+            resolve_ans_polynomial::<F, (), ()>(round, false, &[], &[], &[])
+                .unwrap()
+                .is_empty()
+        );
     }
 }
 


### PR DESCRIPTION
Follow-up to #2056, from my review of it. Two small fixes, neither of them a live break in that PR.

## The compact encoding was not shape-rejected by a default-mode verifier

`check_ans_length` bounded the transmitted `Ans` polynomial only from above:

```rust
if ans_polynomial.len() > max_ans_len { /* AnsPolynomialTooLong */ }
```

so an empty vector passed. A compact-mode proof carries no coefficients, so it reached
`challenger.observe_algebra_slice(&[])` in a default-mode verifier and was rejected only
downstream, once the diverged transcript reached a later challenge. The opposite direction was
already a loud `UnexpectedAnsPolynomial`, so the guard was one-sided.

That divergence is unconditional, so this was never exploitable: `interpolate_poly` returns at
least `[ZERO]` whenever `points` is non-empty, and `num_ood_samples` in `{1,2}` plus
`num_queries >= 1` makes the node set non-empty in every reachable round, so the honest prover
never absorbs an empty slice. The point is that the separation between the two representations
rested on sponge divergence rather than on a shape check, and the rest of the crate prefers to
fail loudly.

The reasoning that makes the new check safe:

```text
    one node   ->  the interpolant is a constant
    zero const ->  interpolate_poly returns [ZERO], not []
    so         ->  a stripped default Ans is never empty while a node remains
```

The case that motivates it is the zero interpolant, where `[]` and `[ZERO]` describe the
*same* virtual oracle. There nothing but the diverged `final_gamma` told the two encodings
apart, which is exactly the situation a shape check should not be left out of.

New `ProofShapeError::MissingAnsPolynomial { round, nodes }`, and
`the_default_representation_rejects_the_compact_encoding` covers all three shapes: several
nodes, the single-node zero interpolant, and no nodes at all — where the empty vector is the
only representation there is and stays accepted.

## `codeword_from_coeffs` could hand a `Dft` a height-1 matrix

The degree-aware fast path sized its transform as `log2_ceil_usize(len.min(size).max(1))`, so
one coefficient or none gave `log_len == 0` and `eval_low_degree_on_coset` built a
`RowMajorMatrix` of height 1. No in-crate caller produces that — every path feeds at least four
coefficients — but the function is `pub`, and `Radix2DFTSmallBatch::dft_batch` computes
`log2_strict_usize(estimate_num_rows_in_l1::<F>(1, w))` before it looks at `log_h`, so it is not
a shape I would want a caller to reach.

Floored at two rows, then capped at the coset. A constant is exact at one variable, because row
1 reads past the coefficients and contributes zero, so the floor costs nothing and changes no
result. The cap matters on its own: without it a single-point coset (`log_size == 0`) would ask
for more variables than the coset has and wrap `log_size - log_len`.

## Test plan

- [x] `cargo nextest run -p p3-stir` — 203 passed
- [x] `cargo nextest run -p p3-whir` — 131 passed, 1 skipped (STIR feeds it)
- [x] `cargo test --doc -p p3-stir`
- [x] `cargo clippy -p p3-stir --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — no diff
