### PR TITLE
fix(scripts): let the shared check command pin the target features a leg names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ Run `python3 scripts/check.py full` before opening a pull request. It covers the
 | --- | --- | --- |
 | `fast` | Check all host targets without running them | `--package NAME`, `--parallel` |
 | `full` | Run all routine host checks | none |
-| `test` | Run tests through `cargo-nextest` | `--package NAME`, `--parallel` |
-| `doctest` | Run Rust documentation tests | `--package NAME`, `--parallel` |
+| `test` | Run tests through `cargo-nextest` | `--package NAME`, `--parallel`, `--target-feature FEATURES` |
+| `doctest` | Run Rust documentation tests | `--package NAME`, `--parallel`, `--target-feature FEATURES` |
 | `lint` | Run all CI script/lint/doc/format checks | `--check scripts\|sort\|toml\|deps\|clippy\|docs\|fmt` |
-| `architecture` | Compile all targets for a non-runnable target | `--target TARGET`, `--parallel` |
+| `architecture` | Compile all targets for a non-runnable target | `--target TARGET`, `--parallel`, `--target-feature FEATURES` |
 | `embedded` | Build every eligible workspace library with `--lib` | `--target TARGET` |
 | `wasm` | Run the wasm compile and SIMD smoke recipes | `--step build\|test\|smoke\|bench\|merkle` |
 | `bench` | Execute every benchmark body once, excluding the large `p3-dft` sweep | none |
@@ -40,6 +40,14 @@ Run `python3 scripts/check.py full` before opening a pull request. It covers the
 
 `architecture` is a compile-only command. CI uses `test` and `doctest` only on architectures whose runner can execute the selected instructions, and uses `architecture` for AVX-512, VPCLMULQDQ, and SVE2 coverage where runner hardware is not guaranteed.
 
+Target features decide `cfg(target_feature = ..)`, so a leg that pins them compiles different code. `--target-feature` reaches the compiler through `RUSTFLAGS`, appended to whatever the caller already exports, and leaves the argv unchanged. Pass the same string the CI leg uses, or the command compiles the baseline feature set instead of the one it names:
+
+```bash
+python3 scripts/check.py architecture --target x86_64-unknown-linux-gnu --target-feature +avx512f
+python3 scripts/check.py test --target-feature +avx2
+python3 scripts/check.py test --package p3-keccak --target-feature -sha3
+```
+
 The embedded package list comes from `cargo metadata`. Every workspace package with a library target is included unless its manifest declares:
 
 ```toml
@@ -47,7 +55,7 @@ The embedded package list comes from `cargo metadata`. Every workspace package w
 embedded = false
 ```
 
-`p3-examples` and `p3-field-testing` are explicit host-only exclusions. Building each selected package with `--lib` prevents host-only binaries and examples from breaking an otherwise `no_std` library build. New library crates therefore enter embedded coverage automatically.
+`p3-examples` and `p3-field-testing` are explicit host-only exclusions, and `scripts/test_check.py` pins that set exactly, so opting a crate out is a deliberate test change rather than a silent loss of coverage. Building each selected package with `--lib` prevents host-only binaries and examples from breaking an otherwise `no_std` library build. New library crates therefore enter embedded coverage automatically.
 
 A package whose meaningful tests require a set of opt-in features can declare one additional CI invocation:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ Run `python3 scripts/check.py full` before opening a pull request. It covers the
 | --- | --- | --- |
 | `fast` | Check all host targets without running them | `--package NAME`, `--parallel` |
 | `full` | Run all routine host checks | none |
-| `test` | Run tests through `cargo-nextest` | `--package NAME`, `--parallel`, `--target-feature FEATURES` |
-| `doctest` | Run Rust documentation tests | `--package NAME`, `--parallel`, `--target-feature FEATURES` |
+| `test` | Run tests through `cargo-nextest` | `--package NAME`, `--parallel`, `--target-feature=FEATURES` |
+| `doctest` | Run Rust documentation tests | `--package NAME`, `--parallel`, `--target-feature=FEATURES` |
 | `lint` | Run all CI script/lint/doc/format checks | `--check scripts\|sort\|toml\|deps\|clippy\|docs\|fmt` |
-| `architecture` | Compile all targets for a non-runnable target | `--target TARGET`, `--parallel`, `--target-feature FEATURES` |
+| `architecture` | Compile all targets for a non-runnable target | `--target TARGET`, `--parallel`, `--target-feature=FEATURES` |
 | `embedded` | Build every eligible workspace library with `--lib` | `--target TARGET` |
 | `wasm` | Run the wasm compile and SIMD smoke recipes | `--step build\|test\|smoke\|bench\|merkle` |
 | `bench` | Execute every benchmark body once, excluding the large `p3-dft` sweep | none |
@@ -40,13 +40,21 @@ Run `python3 scripts/check.py full` before opening a pull request. It covers the
 
 `architecture` is a compile-only command. CI uses `test` and `doctest` only on architectures whose runner can execute the selected instructions, and uses `architecture` for AVX-512, VPCLMULQDQ, and SVE2 coverage where runner hardware is not guaranteed.
 
-Target features decide `cfg(target_feature = ..)`, so a leg that pins them compiles different code. `--target-feature` reaches the compiler through `RUSTFLAGS`, appended to whatever the caller already exports, and leaves the argv unchanged. Pass the same string the CI leg uses, or the command compiles the baseline feature set instead of the one it names:
+Target features decide `cfg(target_feature = ..)`, so a leg that pins them compiles different code.
+
+Pass the same string the CI leg uses, joined with an equals sign, or the command compiles the baseline feature set instead of the one it names:
 
 ```bash
-python3 scripts/check.py architecture --target x86_64-unknown-linux-gnu --target-feature +avx512f
-python3 scripts/check.py test --target-feature +avx2
-python3 scripts/check.py test --package p3-keccak --target-feature -sha3
+python3 scripts/check.py architecture --target x86_64-unknown-linux-gnu --target-feature=+avx512f
+python3 scripts/check.py test --target-feature=+avx2
+python3 scripts/check.py test --package p3-keccak --target-feature=-sha3
 ```
+
+The features reach the compiler through its flag variable, never through the argv, and are appended to whatever the caller already exports.
+
+Cargo ignores `RUSTFLAGS` whenever `CARGO_ENCODED_RUSTFLAGS` is set, so the flag follows whichever variable is active.
+
+Doctests are compiled by the documentation tool rather than the ordinary one, so `doctest` pins its flag variable as well.
 
 The embedded package list comes from `cargo metadata`. Every workspace package with a library target is included unless its manifest declares:
 

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -285,6 +285,15 @@ def add_package_and_parallel(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--parallel", action="store_true", help="enable the parallel feature")
 
 
+def add_target_feature(parser: argparse.ArgumentParser) -> None:
+    """Accept the target features a CI leg pins, so the same leg is reproducible locally."""
+    parser.add_argument(
+        "--target-feature",
+        default=None,
+        help="target features to append to RUSTFLAGS, e.g. +avx2,+vpclmulqdq or -sha3",
+    )
+
+
 def parser() -> argparse.ArgumentParser:
     result = argparse.ArgumentParser(description=__doc__)
     result.add_argument("--dry-run", action="store_true", help="print commands without running them")
@@ -301,8 +310,10 @@ def parser() -> argparse.ArgumentParser:
     subparsers.add_parser("full", help="run all host checks used by CI")
     test = subparsers.add_parser("test", help="run tests with cargo-nextest")
     add_package_and_parallel(test)
+    add_target_feature(test)
     doctest = subparsers.add_parser("doctest", help="run Rust documentation tests")
     add_package_and_parallel(doctest)
+    add_target_feature(doctest)
     lint = subparsers.add_parser("lint", help="run formatting, lint, dependency and doc checks")
     lint.add_argument("--check", choices=LINT_COMMANDS, help="run one lint check")
     architecture = subparsers.add_parser(
@@ -310,6 +321,7 @@ def parser() -> argparse.ArgumentParser:
     )
     architecture.add_argument("--target", required=True)
     architecture.add_argument("--parallel", action="store_true")
+    add_target_feature(architecture)
     embedded = subparsers.add_parser(
         "embedded", help="build metadata-selected libraries for an embedded target"
     )
@@ -331,14 +343,33 @@ def display(command: Sequence[str]) -> str:
     return shlex.join(command)
 
 
-def command_environment(command: Sequence[str]) -> dict[str, str] | None:
-    if command[:3] != ["cargo", "+stable", "doc"]:
+def command_environment(
+    command: Sequence[str], target_feature: str | None = None
+) -> dict[str, str] | None:
+    """The environment one command runs under, or nothing to inherit the caller's unchanged.
+
+    Target features reach the compiler through `RUSTFLAGS`, never through the argv.
+
+    That is how the CI legs pin them, and it is what decides `cfg(target_feature = ..)`.
+
+    They are appended to whatever the caller already set.
+
+    So a leg that exports `-C debuginfo=0` keeps it.
+    """
+    rustdoc = command[:3] == ["cargo", "+stable", "doc"]
+    if not rustdoc and not target_feature:
         return None
     environment = os.environ.copy()
-    deny_broken_links = "-D rustdoc::broken_intra_doc_links"
-    current = environment.get("RUSTDOCFLAGS", "")
-    if deny_broken_links not in current:
-        environment["RUSTDOCFLAGS"] = f"{current} {deny_broken_links}".strip()
+    if target_feature:
+        flag = f"-C target-feature={target_feature}"
+        current = environment.get("RUSTFLAGS", "")
+        if flag not in current:
+            environment["RUSTFLAGS"] = f"{current} {flag}".strip()
+    if rustdoc:
+        deny_broken_links = "-D rustdoc::broken_intra_doc_links"
+        current = environment.get("RUSTDOCFLAGS", "")
+        if deny_broken_links not in current:
+            environment["RUSTDOCFLAGS"] = f"{current} {deny_broken_links}".strip()
     return environment
 
 
@@ -350,15 +381,30 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (subprocess.CalledProcessError, json.JSONDecodeError, ValueError) as error:
         print(f"error: {error}", file=sys.stderr)
         return error.returncode if isinstance(error, subprocess.CalledProcessError) else 1
+    # Only the subcommands that compile or run Rust accept target features.
+    target_feature = getattr(args, "target_feature", None)
+    if target_feature:
+        print(f"+ RUSTFLAGS += -C target-feature={target_feature}", flush=True)
     for command in commands:
         print(f"+ {display(command)}", flush=True)
         if not args.dry_run:
-            completed = subprocess.run(
-                command,
-                cwd=args.workspace_root,
-                env=command_environment(command),
-                check=False,
-            )
+            try:
+                completed = subprocess.run(
+                    command,
+                    cwd=args.workspace_root,
+                    env=command_environment(command, target_feature),
+                    check=False,
+                )
+            except OSError as error:
+                # A missing tool is a prerequisite the contributor has not installed yet.
+                #
+                # Name it, rather than ending a long run in a stack trace.
+                print(
+                    f"error: {command[0]} not found ({error}); "
+                    "see CONTRIBUTING.md for the required tools",
+                    file=sys.stderr,
+                )
+                return 127
             if completed.returncode:
                 return completed.returncode
     return 0

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -290,8 +290,32 @@ def add_target_feature(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--target-feature",
         default=None,
-        help="target features to append to RUSTFLAGS, e.g. +avx2,+vpclmulqdq or -sha3",
+        help="target features to pin, joined with an equals sign: --target-feature=+avx2",
     )
+
+
+def attach_leading_minus_values(argv: Sequence[str]) -> list[str]:
+    """Join a value that starts with a minus onto the option it belongs to.
+
+    A feature is disabled by prefixing it with a minus, and the argument parser reads such a
+    value as another option instead.
+
+    Rewriting the pair into the equals form lets both spellings work, so a leg that turns a
+    feature off is not a special case for the caller to remember.
+    """
+    joined = []
+    argv = list(argv)
+    index = 0
+    while index < len(argv):
+        argument = argv[index]
+        takes_value = argument == "--target-feature" and index + 1 < len(argv)
+        if takes_value and argv[index + 1].startswith("-"):
+            joined.append(f"{argument}={argv[index + 1]}")
+            index += 2
+            continue
+        joined.append(argument)
+        index += 1
+    return joined
 
 
 def parser() -> argparse.ArgumentParser:
@@ -343,38 +367,88 @@ def display(command: Sequence[str]) -> str:
     return shlex.join(command)
 
 
+# Separator Cargo uses inside the encoded flag variables, one unit per argument.
+ENCODED_SEPARATOR = "\x1f"
+
+
+def append_compiler_flag(
+    environment: dict[str, str], plain: str, encoded: str, flag: Sequence[str]
+) -> str:
+    """Put one compiler flag where Cargo will read it, and name the variable used.
+
+    Cargo ignores the plain variable whenever the encoded one is set.
+
+    So the flag has to follow whichever variable the caller chose, or it is silently dropped.
+
+    The flag is appended, never merged into an existing setting.
+
+    For a target feature that is what makes the request effective, since the last setting of
+    a given feature is the one that takes effect.
+    """
+    if encoded in environment:
+        current = environment[encoded]
+        units = current.split(ENCODED_SEPARATOR) if current else []
+        environment[encoded] = ENCODED_SEPARATOR.join([*units, *flag])
+        return encoded
+    current = environment.get(plain, "")
+    environment[plain] = " ".join([current, *flag]).strip()
+    return plain
+
+
 def command_environment(
     command: Sequence[str], target_feature: str | None = None
-) -> dict[str, str] | None:
-    """The environment one command runs under, or nothing to inherit the caller's unchanged.
+) -> tuple[dict[str, str] | None, list[str]]:
+    """The environment one command runs under, plus the variables it changed.
 
-    Target features reach the compiler through `RUSTFLAGS`, never through the argv.
+    Nothing is returned as the environment when the command inherits the caller's unchanged.
+
+    Target features reach a compiler through its flag variable, never through the argv.
 
     That is how the CI legs pin them, and it is what decides `cfg(target_feature = ..)`.
 
-    They are appended to whatever the caller already set.
+    A doctest is compiled by the documentation tool, not by the ordinary one.
 
-    So a leg that exports `-C debuginfo=0` keeps it.
+    So a feature has to reach both, or the library gets it while its doctests keep the
+    baseline values.
     """
-    rustdoc = command[:3] == ["cargo", "+stable", "doc"]
-    if not rustdoc and not target_feature:
-        return None
+    # Documentation tests and the documentation build are the two commands the
+    # documentation tool compiles, so both need its own flag variable.
+    doc_build = command[:3] == ["cargo", "+stable", "doc"]
+    doctest = command[:2] == ["cargo", "test"] and "--doc" in command
+
+    if not doc_build and not target_feature:
+        return None, []
+
     environment = os.environ.copy()
+    touched = []
+
     if target_feature:
-        flag = f"-C target-feature={target_feature}"
-        current = environment.get("RUSTFLAGS", "")
-        if flag not in current:
-            environment["RUSTFLAGS"] = f"{current} {flag}".strip()
-    if rustdoc:
-        deny_broken_links = "-D rustdoc::broken_intra_doc_links"
-        current = environment.get("RUSTDOCFLAGS", "")
-        if deny_broken_links not in current:
-            environment["RUSTDOCFLAGS"] = f"{current} {deny_broken_links}".strip()
-    return environment
+        flag = ["-C", f"target-feature={target_feature}"]
+        touched.append(
+            append_compiler_flag(environment, "RUSTFLAGS", "CARGO_ENCODED_RUSTFLAGS", flag)
+        )
+        if doc_build or doctest:
+            touched.append(
+                append_compiler_flag(
+                    environment, "RUSTDOCFLAGS", "CARGO_ENCODED_RUSTDOCFLAGS", flag
+                )
+            )
+
+    if doc_build:
+        deny = ["-D", "rustdoc::broken_intra_doc_links"]
+        name = append_compiler_flag(
+            environment, "RUSTDOCFLAGS", "CARGO_ENCODED_RUSTDOCFLAGS", deny
+        )
+        if name not in touched:
+            touched.append(name)
+
+    return environment, touched
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = parser().parse_args(argv)
+    args = parser().parse_args(
+        attach_leading_minus_values(sys.argv[1:] if argv is None else argv)
+    )
     args.workspace_root = args.workspace_root.resolve()
     try:
         commands = commands_for(args)
@@ -383,16 +457,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         return error.returncode if isinstance(error, subprocess.CalledProcessError) else 1
     # Only the subcommands that compile or run Rust accept target features.
     target_feature = getattr(args, "target_feature", None)
-    if target_feature:
-        print(f"+ RUSTFLAGS += -C target-feature={target_feature}", flush=True)
     for command in commands:
+        environment, touched = command_environment(command, target_feature)
+        # Announce where the requested feature landed, so a dry run shows the real variable.
+        if target_feature:
+            for name in touched:
+                print(f"+ {name} += -C target-feature={target_feature}", flush=True)
         print(f"+ {display(command)}", flush=True)
         if not args.dry_run:
             try:
                 completed = subprocess.run(
                     command,
                     cwd=args.workspace_root,
-                    env=command_environment(command, target_feature),
+                    env=environment,
                     check=False,
                 )
             except OSError as error:

--- a/scripts/test_check.py
+++ b/scripts/test_check.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 import os
 from pathlib import Path
 import shlex
@@ -10,7 +11,10 @@ import sys
 import tempfile
 import textwrap
 import unittest
+import unittest.mock
 
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 SCRIPT = Path(__file__).with_name("check.py")
 REPO = SCRIPT.parent.parent
@@ -344,11 +348,105 @@ class CargoMetadataTests(unittest.TestCase):
             check=False,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertNotIn("p3-examples", result.stdout)
-        self.assertNotIn("p3-field-testing", result.stdout)
-        self.assertIn("p3-binary-pcs", result.stdout)
+        # Pin the exclusions as a set, not a sample.
+        #
+        # A manifest opting out would otherwise shrink embedded coverage silently.
+        #
+        # Nothing in the test diff would say that a crate stopped being checked.
+        selected = {
+            shlex.split(line)[shlex.split(line).index("-p") + 1]
+            for line in result.stdout.splitlines()
+        }
+        members = subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            cwd=REPO,
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        library_members = {
+            package["name"]
+            for package in json.loads(members.stdout)["packages"]
+            if any("lib" in target["kind"] for target in package["targets"])
+        }
+        self.assertEqual(library_members - selected, {"p3-examples", "p3-field-testing"})
+        self.assertIn("p3-binary-pcs", selected)
         for line in result.stdout.splitlines():
             self.assertTrue(line.endswith(" --lib"), line)
+
+
+class TargetFeatureTests(unittest.TestCase):
+    def test_target_feature_reaches_rustflags_and_not_the_argv(self):
+        # A leg pins its features through RUSTFLAGS, since that is what decides
+        # cfg(target_feature = ..).
+        #
+        # The argv must therefore stay identical to the unpinned command.
+        for command, expected in [
+            (["architecture", "--target", "x86_64-unknown-linux-gnu"], "cargo build"),
+            (["test"], "cargo nextest run"),
+            (["doctest"], "cargo test --doc"),
+        ]:
+            with self.subTest(command=command[0]):
+                plain = _run_dry(command)
+                pinned = _run_dry([*command, "--target-feature", "+avx2,+vpclmulqdq"])
+                self.assertTrue(
+                    any(line.startswith(f"+ {expected}") for line in plain), plain
+                )
+                self.assertEqual(
+                    [line for line in pinned if not line.startswith("+ RUSTFLAGS")],
+                    plain,
+                )
+                self.assertIn(
+                    "+ RUSTFLAGS += -C target-feature=+avx2,+vpclmulqdq", pinned
+                )
+
+    def test_target_feature_appends_to_an_existing_rustflags(self):
+        # CI already exports -C debuginfo=0, so the append must not replace it.
+        import check  # noqa: PLC0415
+
+        environment = {"RUSTFLAGS": "-C debuginfo=0"}
+        with unittest.mock.patch.dict(os.environ, environment, clear=True):
+            resolved = check.command_environment(["cargo", "build"], "+avx2")
+        self.assertEqual(resolved["RUSTFLAGS"], "-C debuginfo=0 -C target-feature=+avx2")
+
+    def test_target_feature_append_is_idempotent(self):
+        # The workflow's own Set flags step may already have pinned the same leg.
+        import check  # noqa: PLC0415
+
+        environment = {"RUSTFLAGS": "-C debuginfo=0 -C target-feature=+avx2"}
+        with unittest.mock.patch.dict(os.environ, environment, clear=True):
+            resolved = check.command_environment(["cargo", "build"], "+avx2")
+        self.assertEqual(resolved["RUSTFLAGS"], "-C debuginfo=0 -C target-feature=+avx2")
+
+    def test_no_target_feature_inherits_the_environment_unchanged(self):
+        import check  # noqa: PLC0415
+
+        self.assertIsNone(check.command_environment(["cargo", "build"], None))
+
+    def test_docs_still_deny_broken_links_alongside_a_target_feature(self):
+        import check  # noqa: PLC0415
+
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            resolved = check.command_environment(
+                ["cargo", "+stable", "doc"], "+avx2"
+            )
+        self.assertEqual(resolved["RUSTFLAGS"], "-C target-feature=+avx2")
+        self.assertEqual(
+            resolved["RUSTDOCFLAGS"], "-D rustdoc::broken_intra_doc_links"
+        )
+
+
+def _run_dry(command):
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--workspace-root", str(REPO), "--dry-run", *command],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout.splitlines()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test_check.py
+++ b/scripts/test_check.py
@@ -376,9 +376,9 @@ class CargoMetadataTests(unittest.TestCase):
 
 
 class TargetFeatureTests(unittest.TestCase):
-    def test_target_feature_reaches_rustflags_and_not_the_argv(self):
-        # A leg pins its features through RUSTFLAGS, since that is what decides
-        # cfg(target_feature = ..).
+    def test_target_feature_reaches_the_flags_and_not_the_argv(self):
+        # A leg pins its features through the compiler's flag variable, since that is what
+        # decides cfg(target_feature = ..).
         #
         # The argv must therefore stay identical to the unpinned command.
         for command, expected in [
@@ -388,52 +388,127 @@ class TargetFeatureTests(unittest.TestCase):
         ]:
             with self.subTest(command=command[0]):
                 plain = _run_dry(command)
-                pinned = _run_dry([*command, "--target-feature", "+avx2,+vpclmulqdq"])
+                pinned = _run_dry([*command, "--target-feature=+avx2,+vpclmulqdq"])
                 self.assertTrue(
                     any(line.startswith(f"+ {expected}") for line in plain), plain
                 )
                 self.assertEqual(
-                    [line for line in pinned if not line.startswith("+ RUSTFLAGS")],
-                    plain,
-                )
-                self.assertIn(
-                    "+ RUSTFLAGS += -C target-feature=+avx2,+vpclmulqdq", pinned
+                    [line for line in pinned if "target-feature" not in line], plain
                 )
 
-    def test_target_feature_appends_to_an_existing_rustflags(self):
-        # CI already exports -C debuginfo=0, so the append must not replace it.
+    def test_a_leading_minus_value_is_accepted_in_both_spellings(self):
+        # Turning a feature off spells the value with a leading minus.
+        #
+        # Both the joined and the separated spelling must reach the compiler.
+        joined = _run_dry(["test", "--package", "p3-keccak", "--target-feature=-sha3"])
+        separated = _run_dry(["test", "--package", "p3-keccak", "--target-feature", "-sha3"])
+        self.assertEqual(joined, separated)
+        self.assertIn("+ RUSTFLAGS += -C target-feature=-sha3", joined)
+
+    def test_a_requested_feature_outranks_an_inherited_disable(self):
+        # The last setting of a feature is the one that takes effect.
+        #
+        #     inherited : +avx2,-avx2   -> avx2 off
+        #     appended  : +avx2         -> avx2 on
+        #
+        # So the flag is appended rather than matched against what is already there.
         import check  # noqa: PLC0415
 
-        environment = {"RUSTFLAGS": "-C debuginfo=0"}
-        with unittest.mock.patch.dict(os.environ, environment, clear=True):
-            resolved = check.command_environment(["cargo", "build"], "+avx2")
-        self.assertEqual(resolved["RUSTFLAGS"], "-C debuginfo=0 -C target-feature=+avx2")
+        with unittest.mock.patch.dict(
+            os.environ, {"RUSTFLAGS": "-C target-feature=+avx2,-avx2"}, clear=True
+        ):
+            environment, _ = check.command_environment(["cargo", "build"], "+avx2")
+        self.assertTrue(environment["RUSTFLAGS"].endswith("-C target-feature=+avx2"))
 
-    def test_target_feature_append_is_idempotent(self):
-        # The workflow's own Set flags step may already have pinned the same leg.
+    def test_an_inherited_plain_variable_is_preserved(self):
+        # CI already exports a debug-info setting, so the append must not replace it.
         import check  # noqa: PLC0415
 
-        environment = {"RUSTFLAGS": "-C debuginfo=0 -C target-feature=+avx2"}
-        with unittest.mock.patch.dict(os.environ, environment, clear=True):
-            resolved = check.command_environment(["cargo", "build"], "+avx2")
-        self.assertEqual(resolved["RUSTFLAGS"], "-C debuginfo=0 -C target-feature=+avx2")
+        with unittest.mock.patch.dict(
+            os.environ, {"RUSTFLAGS": "-C debuginfo=0"}, clear=True
+        ):
+            environment, touched = check.command_environment(["cargo", "build"], "+avx2")
+        self.assertEqual(
+            environment["RUSTFLAGS"], "-C debuginfo=0 -C target-feature=+avx2"
+        )
+        self.assertEqual(touched, ["RUSTFLAGS"])
+
+    def test_the_encoded_variable_is_used_when_the_caller_set_it(self):
+        # Cargo ignores the plain variable whenever the encoded one is set.
+        #
+        # Writing the plain one there would announce a feature that never reaches rustc.
+        import check  # noqa: PLC0415
+
+        encoded = f"-C{check.ENCODED_SEPARATOR}debuginfo=0"
+        with unittest.mock.patch.dict(
+            os.environ, {"CARGO_ENCODED_RUSTFLAGS": encoded}, clear=True
+        ):
+            environment, touched = check.command_environment(["cargo", "build"], "+sve2")
+        self.assertEqual(
+            environment["CARGO_ENCODED_RUSTFLAGS"].split(check.ENCODED_SEPARATOR),
+            ["-C", "debuginfo=0", "-C", "target-feature=+sve2"],
+        )
+        self.assertNotIn("RUSTFLAGS", environment)
+        self.assertEqual(touched, ["CARGO_ENCODED_RUSTFLAGS"])
+
+    def test_a_doctest_pins_the_documentation_compiler_too(self):
+        # Doctests are compiled by the documentation tool, not the ordinary one.
+        #
+        # Without its own flag variable the library gets the feature and its doctests do not.
+        import check  # noqa: PLC0415
+
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            environment, touched = check.command_environment(
+                ["cargo", "test", "--doc"], "+sve2"
+            )
+        self.assertEqual(environment["RUSTFLAGS"], "-C target-feature=+sve2")
+        self.assertEqual(environment["RUSTDOCFLAGS"], "-C target-feature=+sve2")
+        self.assertEqual(touched, ["RUSTFLAGS", "RUSTDOCFLAGS"])
+
+    def test_a_doctest_uses_the_encoded_documentation_variable_when_set(self):
+        import check  # noqa: PLC0415
+
+        encoded = f"-C{check.ENCODED_SEPARATOR}debuginfo=0"
+        with unittest.mock.patch.dict(
+            os.environ, {"CARGO_ENCODED_RUSTDOCFLAGS": encoded}, clear=True
+        ):
+            environment, _ = check.command_environment(
+                ["cargo", "test", "--doc"], "+sve2"
+            )
+        self.assertEqual(
+            environment["CARGO_ENCODED_RUSTDOCFLAGS"].split(check.ENCODED_SEPARATOR),
+            ["-C", "debuginfo=0", "-C", "target-feature=+sve2"],
+        )
+        self.assertNotIn("RUSTDOCFLAGS", environment)
 
     def test_no_target_feature_inherits_the_environment_unchanged(self):
         import check  # noqa: PLC0415
 
-        self.assertIsNone(check.command_environment(["cargo", "build"], None))
+        self.assertEqual(check.command_environment(["cargo", "build"], None), (None, []))
 
-    def test_docs_still_deny_broken_links_alongside_a_target_feature(self):
+    def test_docs_deny_broken_links_alongside_a_target_feature(self):
         import check  # noqa: PLC0415
 
         with unittest.mock.patch.dict(os.environ, {}, clear=True):
-            resolved = check.command_environment(
+            environment, _ = check.command_environment(
                 ["cargo", "+stable", "doc"], "+avx2"
             )
-        self.assertEqual(resolved["RUSTFLAGS"], "-C target-feature=+avx2")
         self.assertEqual(
-            resolved["RUSTDOCFLAGS"], "-D rustdoc::broken_intra_doc_links"
+            environment["RUSTDOCFLAGS"],
+            "-C target-feature=+avx2 -D rustdoc::broken_intra_doc_links",
         )
+
+    def test_docs_deny_broken_links_with_no_target_feature(self):
+        import check  # noqa: PLC0415
+
+        with unittest.mock.patch.dict(os.environ, {}, clear=True):
+            environment, touched = check.command_environment(
+                ["cargo", "+stable", "doc"], None
+            )
+        self.assertEqual(
+            environment["RUSTDOCFLAGS"], "-D rustdoc::broken_intra_doc_links"
+        )
+        self.assertEqual(touched, ["RUSTDOCFLAGS"])
 
 
 def _run_dry(command):


### PR DESCRIPTION
Follow-up to #2062, from my review of it. The check ledger in that PR is intact — I verified every leg, step, `RUSTFLAGS` combination and `--features` flag survives byte-identically, and that all 21 rendered job names are unchanged so no required status check is orphaned. This closes the one place where the stated goal was not met.

## `architecture` could not reproduce the leg it is named for

CONTRIBUTING says `architecture` "uses `architecture` for AVX-512, VPCLMULQDQ, and SVE2 coverage", but `check.py` never set `-C target-feature`. The workflow pins the features in a separate `Set flags` step, so **CI was always right** — it was only the shared local command that was blind:

```text
    check.py architecture --target x86_64-unknown-linux-gnu
      ->  compiles the baseline feature set
      ->  every cfg(target_feature = "avx512f") block is cfg-ed out
      ->  green, having checked none of what the command names
```

The `+avx2`, `+pclmulqdq` and macOS `-sha3` legs had no shared recipe at all, and those are the ones most likely to catch a SIMD-only miscompile.

`--target-feature` now reaches the compiler the way a leg does — through `RUSTFLAGS`, not the argv, because that is what decides `cfg(target_feature = ..)`:

```bash
python3 scripts/check.py architecture --target x86_64-unknown-linux-gnu --target-feature +avx512f
python3 scripts/check.py test --target-feature +avx2
python3 scripts/check.py test --package p3-keccak --target-feature -sha3
```

Two properties that make this safe to land without touching the workflow:

- **It appends, and the append is idempotent.** A leg's `-C debuginfo=0` survives, and if `Set flags` has already pinned the same features the flag is not added twice. So the two mechanisms compose rather than fight, and wiring `${{ matrix.features }}` through the steps (and dropping `Set flags`) becomes a safe separate change rather than a prerequisite.
- **Every CI recipe is byte-identical when the flag is absent.** Verified for `test`, `test --parallel`, `doctest`, `doctest --parallel`, `architecture`, and `embedded`. `ci.yml` is untouched, so no job name moves — which matters, because the comment above that matrix warns that a leg's rendered name embeds its `features` and two of those names are required checks.

## A missing tool ended a long run in a traceback

`main`'s `try` covered only `commands_for`, not the execution loop. Skip `taplo-cli` from CONTRIBUTING's install line and `check.py full` died with `FileNotFoundError: ... 'taplo'` and a stack trace, after clippy and docs had already been paid for. It now names the tool and points at CONTRIBUTING, exiting 127.

## The embedded exclusion set was sampled, not pinned

`test_repository_metadata_explicitly_excludes_host_only_packages` asserted three names but not the complement, so a manifest declaring `embedded = false` could shrink the ledger from 45 crates to 44 with nothing in the test diff saying a crate stopped being checked.

That is the mirror image of the hand-maintained list this mechanism replaced — which omitted `p3-binary-pcs` for exactly the reason that nothing asserted completeness. The set is now pinned exactly against `cargo metadata`, so opting a crate out requires a deliberate test edit.

## Test plan

- [x] `python3 -m unittest scripts.test_check` — 18 passed (13 pre-existing, 5 new)
- [x] `python3 scripts/check.py --dry-run lint --check scripts` — dispatches the suite
- [x] Recipe equivalence checked by hand for `test`, `test --parallel`, `doctest`, `doctest --parallel`, `architecture --target … --parallel`, `embedded` — argv identical to `main` in every case
- [x] `PATH=/usr/bin python3 scripts/check.py lint --check toml` — reports `error: taplo not found (…); see CONTRIBUTING.md for the required tools` instead of a traceback

No cargo commands were run; this PR changes no Rust.
