### PR TITLE
fix(stir): reject missing non-compact answer coefficients

### DIFF
--- a/stir/src/error.rs
+++ b/stir/src/error.rs
@@ -99,6 +99,11 @@ pub enum ProofShapeError {
         got: usize,
     },
 
+    /// Non-compact answers require coefficients when interpolation points are present.
+    /// Even the zero polynomial must be transmitted as at least `[ZERO]`.
+    #[error("{round}: missing ans polynomial coefficients")]
+    MissingAnsPolynomial { round: RoundLabel },
+
     /// Compact answers require an empty transmitted coefficient vector.
     #[error("{round}: compact answers expect no transmitted ans coefficients, got {got}")]
     UnexpectedAnsPolynomial { round: RoundLabel, got: usize },

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -161,6 +161,9 @@ fn resolve_ans_polynomial<'a, EF: Field, MmcsError, InputError>(
     values: &[EF],
 ) -> Result<Cow<'a, [EF]>, StirError<MmcsError, InputError>> {
     if !compact {
+        if transmitted.is_empty() && !points.is_empty() {
+            return Err(ProofShapeError::MissingAnsPolynomial { round }.into());
+        }
         check_ans_length(round, transmitted, points.len())?;
         return Ok(Cow::Borrowed(transmitted));
     }
@@ -191,13 +194,33 @@ mod compact_answer_tests {
     use super::*;
 
     #[test]
+    fn full_answers_reject_missing_coefficients() {
+        let error = resolve_ans_polynomial::<F, (), ()>(
+            RoundLabel::Round(2),
+            false,
+            &[],
+            &[F::ONE],
+            &[F::ZERO],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            StirError::InvalidProofShape(ProofShapeError::MissingAnsPolynomial {
+                round: RoundLabel::Round(2)
+            })
+        ));
+    }
+
+    #[test]
     fn compact_answers_reconstruct_canonical_zero_and_reject_invalid_nodes() {
         let round = RoundLabel::Round(2);
-        assert!(
-            resolve_ans_polynomial::<F, (), ()>(round, true, &[], &[], &[])
-                .unwrap()
-                .is_empty()
-        );
+        for compact in [false, true] {
+            assert!(
+                resolve_ans_polynomial::<F, (), ()>(round, compact, &[], &[], &[])
+                    .unwrap()
+                    .is_empty()
+            );
+        }
         assert_eq!(
             resolve_ans_polynomial::<F, (), ()>(round, true, &[], &[F::ONE], &[F::ZERO])
                 .unwrap()

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -297,6 +297,13 @@ mod babybear_stir {
                 continue;
             }
             assert!(compact_bytes.len() < full_bytes.len());
+            let err = verify_stir(&full, &compact_proof, &mut challenger.clone()).unwrap_err();
+            assert_eq!(
+                shape_of(err),
+                ProofShapeError::MissingAnsPolynomial {
+                    round: RoundLabel::Round(0)
+                }
+            );
             for coefficients in [
                 full_proof.round_proofs[0].ans_polynomial.clone(),
                 vec![EF::ONE],
@@ -3770,6 +3777,18 @@ mod babybear_stir_multi {
                     postcard::to_allocvec(mixed_proof).unwrap()
                 );
             }
+            let err = verify(
+                &full_refs,
+                &mixed.iter().map(|(proof, _)| proof).collect::<Vec<_>>(),
+                &mut base.clone(),
+            )
+            .unwrap_err();
+            assert_eq!(
+                shape_of(err),
+                ProofShapeError::MissingAnsPolynomial {
+                    round: RoundLabel::Round(0)
+                }
+            );
             let mut bad: Vec<_> = mixed.into_iter().map(|(proof, _)| proof).collect();
             bad[0].round_proofs[1].ans_polynomial = vec![EF::ONE];
             let err = verify(&config_refs, &bad.iter().collect::<Vec<_>>(), &mut base).unwrap_err();

--- a/stir/tests/utils.rs
+++ b/stir/tests/utils.rs
@@ -1,7 +1,7 @@
 //! Unit tests for STIR polynomial arithmetic utilities.
 
 use p3_baby_bear::BabyBear;
-use p3_dft::Radix2DitParallel;
+use p3_dft::{Radix2DFTSmallBatch, Radix2DitParallel, TwoAdicSubgroupDft};
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_stir::prover::{codeword_from_coeffs, coeffs_from_codeword};
@@ -26,9 +26,17 @@ fn ef(n: u64) -> EF {
 
 #[test]
 fn test_codeword_from_coeffs_matches_horner_across_shapes() {
+    check_codeword_from_coeffs_matches_horner_across_shapes(&Radix2DitParallel::<F>::default());
+}
+
+#[test]
+fn test_codeword_from_coeffs_small_batch_matches_horner_across_shapes() {
+    check_codeword_from_coeffs_matches_horner_across_shapes(&Radix2DFTSmallBatch::<F>::default());
+}
+
+fn check_codeword_from_coeffs_matches_horner_across_shapes(dft: &impl TwoAdicSubgroupDft<F>) {
     use p3_field::TwoAdicField;
 
-    let dft = Radix2DitParallel::<F>::default();
     let mut rng = SmallRng::seed_from_u64(0xdecaf);
     for log_size in [0usize, 1, 4, 8] {
         let size = 1usize << log_size;
@@ -47,7 +55,7 @@ fn test_codeword_from_coeffs_matches_horner_across_shapes() {
         ] {
             let coeffs: Vec<EF> = (0..len).map(|_| rng.random()).collect();
             for shift in [F::ZERO, F::ONE, F::GENERATOR, f(7)] {
-                let actual = codeword_from_coeffs(&dft, coeffs.clone(), shift, log_size);
+                let actual = codeword_from_coeffs(dft, coeffs.clone(), shift, log_size);
                 assert_eq!(actual.len(), size);
                 let mut point = shift;
                 let generator = F::two_adic_generator(log_size);


### PR DESCRIPTION
Reject an empty transmitted answer polynomial in non-compact STIR verification when interpolation points are present. This returns `MissingAnsPolynomial` before absorbing the answer and applies to both standalone and batched verification.

Follow-up to [the review request on #2056](https://github.com/Plonky3/Plonky3/pull/2056#discussion_r3958415237). Add reverse-mode regressions covering all-zero witnesses and batched proofs with committed or external initial oracles. Extend the codeword/Horner tests to `Radix2DFTSmallBatch`, including size-one domains, to cover the DFT concern raised in the same comment.

Validation: 3,996 workspace tests pass in each of the default and `parallel` configurations, plus doctests. All remaining checks from `python3 scripts/check.py full` pass; the TOML check was rerun outside the macOS sandbox after a Taplo startup panic, and subsequent lints were run individually. STIR Clippy also passes with `parallel` enabled.
