### PR TITLE
perf(binary-pcs): batch folds between Merkle commitments

### DIFF
--- a/binary-pcs/src/fold.rs
+++ b/binary-pcs/src/fold.rs
@@ -340,6 +340,108 @@ pub fn fold_codeword(codeword: &[BinaryField128], beta: BinaryField128) -> Vec<B
     folded
 }
 
+/// Fold one aligned coset, including its global offset in every virtual layer.
+pub(crate) fn fold_coset(
+    coset_index: usize,
+    values: &mut [BinaryField128],
+    challenges: &[BinaryField128],
+) -> BinaryField128 {
+    assert_eq!(values.len(), 1usize << challenges.len());
+    let mut len = values.len();
+    for &beta in challenges {
+        len /= 2;
+        for i in 0..len {
+            values[i] = fold_pair(
+                coset_index * len + i,
+                beta,
+                values[2 * i],
+                values[2 * i + 1],
+            );
+        }
+    }
+    values[0]
+}
+
+/// Fold several sequential challenges without materializing full intermediate codewords.
+///
+/// Each task reuses one coset-sized scratch buffer in the polynomial basis. Symbols cross
+/// bases only when loaded from the source or stored into the final output. The Cantor domain
+/// bases advance by XOR, just as in the single-fold path. `challenges` stays in sumcheck order.
+pub(crate) fn fold_codeword_batch(
+    codeword: &[BinaryField128],
+    challenges: &[BinaryField128],
+) -> Vec<BinaryField128> {
+    assert!(!challenges.is_empty());
+    assert!(codeword.len().is_power_of_two());
+    assert!(challenges.len() <= codeword.len().ilog2() as usize);
+    if challenges.len() == 1 {
+        return fold_codeword(codeword, challenges[0]);
+    }
+    let arity = challenges.len();
+    let size = 1 << arity;
+    let num_cosets = codeword.len() / size;
+    let betas: Vec<_> = challenges.iter().copied().map(Ghash128::from).collect();
+    let offsets: Vec<Ghash128> = (0..size / 2).map(|i| domain_point(i << 1)).collect();
+    let steps: Vec<Vec<Ghash128>> = (0..arity)
+        .map(|round| {
+            let mut step = Ghash128::ZERO;
+            (0..num_cosets.ilog2() as usize)
+                .map(|bit| {
+                    step += Ghash128::cantor_basis(arity - round + bit);
+                    step
+                })
+                .collect()
+        })
+        .collect();
+    let mut output = BinaryField128::zero_vec(num_cosets);
+    output
+        .par_chunks_mut(FOLD_GRAIN)
+        .zip(codeword.par_chunks(FOLD_GRAIN.saturating_mul(size)))
+        .enumerate()
+        .for_each(|(task, (out, input))| {
+            let start = task * FOLD_GRAIN;
+            let mut bases: Vec<Ghash128> = (0..arity)
+                .map(|r| domain_point(start << (arity - r)))
+                .collect();
+            let mut scratch = Ghash128::zero_vec(size);
+            for (offset, (slot, coset)) in out.iter_mut().zip(input.chunks_exact(size)).enumerate()
+            {
+                let index = start + offset;
+                if offset != 0 {
+                    for (base, steps) in bases.iter_mut().zip(&steps) {
+                        *base += steps[index.trailing_zeros() as usize];
+                    }
+                }
+                for (dst, &src) in scratch.iter_mut().zip(coset) {
+                    *dst = Ghash128::from(src);
+                }
+                let mut len = size;
+                for (r, &beta) in betas.iter().enumerate() {
+                    len /= 2;
+                    let packed_end = len / WIDTH * WIDTH;
+                    let beta_packed = Packed::broadcast(beta);
+                    for i in (0..packed_end).step_by(WIDTH) {
+                        let lo = Packed::from_fn(|lane| scratch[2 * (i + lane)]);
+                        let hi = Packed::from_fn(|lane| scratch[2 * (i + lane) + 1]);
+                        let x = Packed::from_fn(|lane| bases[r] + offsets[i + lane]);
+                        let f1 = lo + hi;
+                        let f0 = lo + x * f1;
+                        let folded = f0 + beta_packed * (f0 + f1);
+                        scratch[i..i + WIDTH].copy_from_slice(folded.as_slice());
+                    }
+                    for i in packed_end..len {
+                        let lo = scratch[2 * i];
+                        let f1 = lo + scratch[2 * i + 1];
+                        let f0 = lo + (bases[r] + offsets[i]) * f1;
+                        scratch[i] = f0 + beta * (f0 + f1);
+                    }
+                }
+                *slot = BinaryField128::from(scratch[0]);
+            }
+        });
+    output
+}
+
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
@@ -355,6 +457,28 @@ mod tests {
     use rand::{RngExt, SeedableRng};
 
     use super::{FOLD_GRAIN, WIDTH, fold_codeword, fold_pair, group_steps, lane_offsets};
+
+    #[test]
+    fn batched_folds_match_sequential_folds_at_every_coset_offset() {
+        let mut rng = SmallRng::seed_from_u64(0xBA7C);
+        for log_len in [4, 7, 12, 14] {
+            let word: Vec<BinaryField128> = (0..1 << log_len).map(|_| rng.random()).collect();
+            for arity in 1..=4.min(log_len) {
+                let challenges: Vec<BinaryField128> = (0..arity).map(|_| rng.random()).collect();
+                let mut expected = word.clone();
+                for &beta in &challenges {
+                    expected = fold_codeword(&expected, beta);
+                }
+                assert_eq!(super::fold_codeword_batch(&word, &challenges), expected);
+                for (index, coset) in word.chunks(1 << arity).enumerate() {
+                    assert_eq!(
+                        super::fold_coset(index, &mut coset.to_vec(), &challenges),
+                        expected[index]
+                    );
+                }
+            }
+        }
+    }
 
     /// Encode novel-basis coefficients over the additive domain, through the oracle.
     ///

--- a/binary-pcs/src/grouped_mmcs.rs
+++ b/binary-pcs/src/grouped_mmcs.rs
@@ -21,6 +21,7 @@ use thiserror::Error;
 pub struct GroupedCodewordMmcs<Inner> {
     inner: Inner,
     group_size: usize,
+    log_inv_rate: Option<usize>,
 }
 
 impl<Inner> GroupedCodewordMmcs<Inner> {
@@ -33,7 +34,26 @@ impl<Inner> GroupedCodewordMmcs<Inner> {
             group_size.is_power_of_two(),
             "group size must be a power of two"
         );
-        Self { inner, group_size }
+        Self {
+            inner,
+            group_size,
+            log_inv_rate: None,
+        }
+    }
+
+    /// Pack one full coset for the next fold batch, including a shorter final batch.
+    /// Prover and verifier must use the same validated PCS configuration.
+    pub const fn for_folding(inner: Inner, config: &crate::BinaryPcsConfig) -> Self {
+        Self {
+            inner,
+            group_size: 1 << config.log_folding_factor(),
+            log_inv_rate: Some(config.log_inv_rate()),
+        }
+    }
+
+    fn group_size_at(&self, height: usize) -> Option<usize> {
+        let message_len = height >> self.log_inv_rate.unwrap_or(0);
+        (message_len != 0).then(|| self.group_size.min(message_len))
     }
 }
 
@@ -114,7 +134,9 @@ impl<Inner: Mmcs<F>> Mmcs<F> for GroupedCodewordMmcs<Inner> {
             matrix.height().is_power_of_two(),
             "expected power-of-two length"
         );
-        let group_size = self.group_size.min(matrix.height());
+        let group_size = self
+            .group_size_at(matrix.height())
+            .expect("codeword shorter than rate expansion");
         self.inner
             .commit_matrix(GroupedCodeword { matrix, group_size })
     }
@@ -207,6 +229,7 @@ impl<Inner: Mmcs<F>> Mmcs<F> for GroupedCodewordMmcs<Inner> {
         if dim.width != 1 || !dim.height.is_power_of_two() {
             return Err(BadDimensions);
         }
+        let group_size = self.group_size_at(dim.height).ok_or(BadDimensions)?;
         if indices.len() != opened_values.len() {
             return Err(OpeningShape);
         }
@@ -223,7 +246,6 @@ impl<Inner: Mmcs<F>> Mmcs<F> for GroupedCodewordMmcs<Inner> {
                 return Err(ConflictingDuplicate);
             }
         }
-        let group_size = self.group_size.min(dim.height);
         let groups = group_indices(indices, group_size);
         // Check before allocating complete grouped rows. All groups are disjoint and inside
         // the validated codeword, so the product is bounded by dim.height.
@@ -321,6 +343,41 @@ mod tests {
                 proof.missing_symbols,
                 missing.into_iter().map(F::from_repr).collect::<Vec<_>>()
             );
+        }
+    }
+
+    #[test]
+    fn folding_schedule_sizes_leaves_for_the_next_actual_batch() {
+        use crate::{BinaryPcsConfig, BinaryPcsParams};
+        let config = BinaryPcsConfig::try_new(
+            6,
+            BinaryPcsParams {
+                log_inv_rate: 2,
+                security_level: 100,
+                pow_bits: 0,
+            },
+        )
+        .unwrap()
+        .try_with_folding(4)
+        .unwrap();
+        let grouped = GroupedCodewordMmcs::for_folding(mmcs(), &config);
+        for (len, width) in [(256, 16), (16, 4)] {
+            let values: Vec<_> = (0..len).map(|i| F::from_repr(i as u128)).collect();
+            let (root, data) = grouped.commit_matrix(RowMajorMatrix::new(values.clone(), 1));
+            let (expected, _) = mmcs().commit_matrix(RowMajorMatrix::new(values, width));
+            assert_eq!(root, expected);
+            let opening = grouped.open_batch(len - 1, &data);
+            grouped
+                .verify_batch(
+                    &root,
+                    &[Dimensions {
+                        height: len,
+                        width: 1,
+                    }],
+                    len - 1,
+                    (&opening).into(),
+                )
+                .unwrap();
         }
     }
 

--- a/binary-pcs/src/params.rs
+++ b/binary-pcs/src/params.rs
@@ -112,12 +112,19 @@ pub struct BinaryPcsConfig {
     params: BinaryPcsParams,
     num_variables: usize,
     num_queries: usize,
+    log_folding_factor: usize,
 }
 
 /// Why a [`BinaryPcsConfig`] could not be derived.
 #[derive(Clone, Debug, Error, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum BinaryPcsConfigError {
+    /// A batch must fold between one and all remaining message variables.
+    #[error("folding factor log {requested} must be in 1..={num_variables}")]
+    InvalidFoldingFactor {
+        requested: usize,
+        num_variables: usize,
+    },
     /// The codeword length does not fit in a `usize`.
     ///
     /// A codeword is indexed by `usize`, so `log_len` must stay below `max_bits`
@@ -161,9 +168,8 @@ impl BinaryPcsConfig {
     /// Derive the round schedule for a polynomial in `num_variables` variables.
     ///
     /// Every variable is folded: the commit phase lays the whole polynomial out as a single
-    /// codeword column, so there is no head of preprocessing rounds to configure. Binding a
-    /// prefix of the variables inside a committed row instead is the deferred head collapse,
-    /// which would reintroduce a folding parameter alongside the machinery to honour it.
+    /// codeword column. By default each variable fold commits its own word; use
+    /// [`Self::try_with_folding`] to batch several folds between commitments.
     ///
     /// # Errors
     ///
@@ -227,7 +233,75 @@ impl BinaryPcsConfig {
             params,
             num_variables,
             num_queries,
+            log_folding_factor: 1,
         })
+    }
+
+    /// Batch up to `log_folding_factor` sequential variable folds between commitments.
+    /// The last batch folds the remaining variables, even when shorter.
+    ///
+    /// For batching, charge every deterministic virtual fold, including those without roots.
+    /// The UDR mutual-agreement bound lifts agreement through each omitted fold: the input
+    /// word is fixed before its challenge, and the query authenticates the whole coset.
+    /// See Appendix A, Theorem 8 of <https://eprint.iacr.org/2024/1553>.
+    /// Sequential independent challenges are used, not powers of one sampled challenge.
+    ///
+    /// Sum `(N / 2^r + 1) / |F|` over every variable fold, plus `2 / |F|` per
+    /// sumcheck round. Reserve one bit each for that sum and the query error so their sum
+    /// meets the requested budget. Query PoW is credited only to the query error.
+    /// Factor log one retains the existing single-fold configuration and transcript.
+    ///
+    /// # Errors
+    /// Rejects an empty/oversized batch or a target exceeding the batched field budget.
+    pub fn try_with_folding(
+        mut self,
+        log_folding_factor: usize,
+    ) -> Result<Self, BinaryPcsConfigError> {
+        if log_folding_factor == 0 || log_folding_factor > self.num_variables {
+            return Err(BinaryPcsConfigError::InvalidFoldingFactor {
+                requested: log_folding_factor,
+                num_variables: self.num_variables,
+            });
+        }
+        // Re-derive from the original parameters, including when switching back to one fold.
+        self.log_folding_factor = log_folding_factor;
+        let reserve = usize::from(log_folding_factor > 1);
+        let max = self.field_security_bits().saturating_sub(reserve);
+        if self.params.security_level > max {
+            return Err(BinaryPcsConfigError::SecurityLevelExceedsFieldCapacity {
+                security_level: self.params.security_level,
+                max,
+            });
+        }
+        self.num_queries = REGIME.queries(
+            self.params.security_level + reserve - self.params.pow_bits,
+            self.params.log_inv_rate,
+        );
+        Ok(self)
+    }
+
+    /// Maximum number of sequential variable challenges per committed fold batch.
+    #[must_use]
+    pub const fn log_folding_factor(&self) -> usize {
+        self.log_folding_factor
+    }
+
+    /// Number of fold batches, including the final batch sent in the clear.
+    #[must_use]
+    pub const fn num_fold_batches(&self) -> usize {
+        self.num_variables.div_ceil(self.log_folding_factor)
+    }
+
+    /// Each batch's starting variable and number of challenges, in transcript order.
+    pub(crate) fn fold_batches(&self) -> impl Iterator<Item = (usize, usize)> + '_ {
+        (0..self.num_variables)
+            .step_by(self.log_folding_factor)
+            .map(|start| {
+                (
+                    start,
+                    self.log_folding_factor.min(self.num_variables - start),
+                )
+            })
     }
 
     /// Number of variables of the committed polynomial.
@@ -280,12 +354,11 @@ impl BinaryPcsConfig {
 
     /// Bits of security the sampled queries deliver.
     ///
-    /// The query phase runs one test per distinct fold pair.
-    /// It therefore executes at most half the domain's worth of tests, however many
-    /// the derivation asked for.
+    /// The query phase runs one test per distinct first-batch coset, capped at the
+    /// number of such cosets in the domain.
     ///
     /// Where the derived count exceeds that, this figure is a lower bound.
-    /// Opening every pair checks every fold at every position of every round, and the
+    /// Opening every base coset checks every composed fold at every position, and the
     /// query-phase error of that is zero rather than a power of the proximity gap.
     #[must_use]
     pub fn query_security_bits(&self) -> f64 {
@@ -294,11 +367,19 @@ impl BinaryPcsConfig {
 
     /// Bits of security the fold and sumcheck rounds leave, rounded down.
     ///
-    /// This is the ceiling on the target: [`Self::try_new`] rejects a `security_level` above
-    /// it, because no query count buys those bits back.
+    /// No query count buys these bits back. Batched configurations reserve one additional
+    /// bit to add this error to the query error; see [`Self::try_with_folding`].
     #[must_use]
     pub const fn field_security_bits(&self) -> usize {
-        field_security_bits_at(self.log_domain_size(), self.num_fold_rounds())
+        if self.log_folding_factor == 1 {
+            field_security_bits_at(self.log_domain_size(), self.num_fold_rounds())
+        } else {
+            // Sum the geometric series of all virtual codeword lengths and every
+            // fold/sumcheck error. log_domain_size < usize::BITS leaves room in u128.
+            let numerator = (2u128 << self.log_domain_size()) - (2u128 << self.log_final_len())
+                + 3 * self.num_variables as u128;
+            ALPHABET_BITS.saturating_sub(log2_ceil_u128(numerator))
+        }
     }
 }
 
@@ -333,6 +414,55 @@ mod tests {
         // Folding stops when the message is a constant, leaving the rate expansion.
         assert_eq!(config.log_final_len(), 2);
         assert!(config.num_queries() > 0);
+    }
+
+    #[test]
+    fn batched_schedule_keeps_all_variables_and_a_short_final_batch() {
+        let config = BinaryPcsConfig::try_new(7, params())
+            .unwrap()
+            .try_with_folding(3)
+            .unwrap();
+        assert_eq!(
+            config.fold_batches().collect::<alloc::vec::Vec<_>>(),
+            [(0, 3), (3, 3), (6, 1)]
+        );
+        assert_eq!(config.num_fold_rounds(), 7);
+        assert_eq!(config.num_fold_batches(), 3);
+        assert_eq!(config.log_final_len(), 2);
+        assert!(config.query_security_bits() >= 85.0);
+        assert!(
+            BinaryPcsConfig::try_new(7, params())
+                .unwrap()
+                .try_with_folding(0)
+                .is_err()
+        );
+        assert!(
+            BinaryPcsConfig::try_new(7, params())
+                .unwrap()
+                .try_with_folding(8)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn batching_prices_every_virtual_fold_and_reserves_error_budget() {
+        let config = BinaryPcsConfig::try_new(19, params())
+            .unwrap()
+            .try_with_folding(3)
+            .unwrap();
+        // Sum (2^(21-r)+1), r=0..18, plus 2*19 = 4_194_353; ceil(log2)=23.
+        assert_eq!(config.field_security_bits(), 105);
+        let mut p = params();
+        p.security_level = 105;
+        let old = BinaryPcsConfig::try_new(19, p).unwrap();
+        assert!(old.try_with_folding(3).is_err());
+        p.security_level = 104;
+        assert!(
+            BinaryPcsConfig::try_new(19, p)
+                .unwrap()
+                .try_with_folding(3)
+                .is_ok()
+        );
     }
 
     /// `query_security_bits` reports the achieved security the sampled queries buy back after

--- a/binary-pcs/src/pcs.rs
+++ b/binary-pcs/src/pcs.rs
@@ -195,21 +195,26 @@ where
         let mut claimed_sum = BinaryField128::ZERO;
         constraint.combine_evals(&mut claimed_sum);
 
-        // One `verify_rounds` call per fold round: a single call spanning every round would
-        // read all of the proof's polynomial messages before any intermediate commitment is
-        // observed, which is not the order the prover produced them in.
+        // Replay each polynomial before its own challenge, observing roots only at the
+        // batch boundaries chosen by the verifier's configuration.
         let mut betas = Vec::with_capacity(num_fold_rounds);
-        for r in 0..num_fold_rounds {
-            let round_data = SumcheckData {
-                polynomial_evaluations: vec![proof.sumcheck.polynomial_evaluations()[r]],
-                pow_witnesses: Vec::new(),
-            };
-            let round_point =
-                round_data.verify_rounds(challenger, &mut claimed_sum, 1, 0, Basis::Evaluation)?;
-            betas.push(round_point.as_slice()[0]);
-
-            if r + 1 < num_fold_rounds {
-                challenger.observe(proof.rounds[r].commitment.clone());
+        for (batch, (start, arity)) in self.config.fold_batches().enumerate() {
+            for r in start..start + arity {
+                let round_data = SumcheckData {
+                    polynomial_evaluations: vec![proof.sumcheck.polynomial_evaluations()[r]],
+                    pow_witnesses: Vec::new(),
+                };
+                let round_point = round_data.verify_rounds(
+                    challenger,
+                    &mut claimed_sum,
+                    1,
+                    0,
+                    Basis::Evaluation,
+                )?;
+                betas.push(round_point.as_slice()[0]);
+            }
+            if batch + 1 < self.config.num_fold_batches() {
+                challenger.observe(proof.rounds[batch].commitment.clone());
             }
         }
 
@@ -429,6 +434,7 @@ mod tests {
     #[allow(clippy::type_complexity)]
     fn open_at_fixture(
         seed: u64,
+        log_folding_factor: usize,
     ) -> (
         BinaryPcs<MyMmcs>,
         <MyMmcs as Mmcs<F>>::Commitment,
@@ -445,7 +451,10 @@ mod tests {
             vec![OpeningBatch::new(vec![0], Vec::new())],
         )]);
 
-        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params()).unwrap();
+        let config = BinaryPcsConfig::try_new(NUM_VARIABLES, params())
+            .unwrap()
+            .try_with_folding(log_folding_factor)
+            .unwrap();
         let pcs = BinaryPcs::new(config, mmcs());
 
         let mut prover_challenger = challenger();
@@ -470,7 +479,7 @@ mod tests {
     /// than assumed.
     #[test]
     fn verify_at_round_trips_with_transcript_derived_points() {
-        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED);
+        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED, 1);
 
         // `verify_at` does not absorb the commitment; the caller does, exactly once, before
         // deriving the point it then hands to `verify_at`.
@@ -493,6 +502,24 @@ mod tests {
         .unwrap();
     }
 
+    #[test]
+    fn batched_verify_at_round_trips_with_transcript_derived_points() {
+        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED, 3);
+        let mut verifier_challenger = challenger();
+        verifier_challenger.observe(commitment.clone());
+        let sample: F = verifier_challenger.sample_algebra_element();
+        let verifier_point = Point::expand_from_univariate(sample, NUM_VARIABLES);
+        assert_eq!(verifier_point, point);
+        pcs.verify_at(
+            &commitment,
+            &proof,
+            &protocol,
+            core::slice::from_ref(&verifier_point),
+            &mut verifier_challenger,
+        )
+        .unwrap();
+    }
+
     /// A verifier that skips absorbing the commitment before calling `verify_at` — the one
     /// responsibility `verify_at` leaves to its caller — must reject the proof, even though the
     /// point it supplies is the genuine one the proof was opened at. This is what would catch a
@@ -502,7 +529,7 @@ mod tests {
     /// verify anyway, since the point supplied here needs no repair — only the challenger does.
     #[test]
     fn verify_at_rejects_a_proof_when_the_caller_skips_absorbing_the_commitment() {
-        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED);
+        let (pcs, commitment, proof, protocol, point) = open_at_fixture(0xFEED, 1);
 
         let mut verifier_challenger = challenger();
         let err = pcs

--- a/binary-pcs/src/proof.rs
+++ b/binary-pcs/src/proof.rs
@@ -8,7 +8,7 @@ use p3_multilinear_util::poly::Poly;
 use p3_sumcheck::{OpeningEvals, SumcheckData};
 use serde::{Deserialize, Serialize};
 
-/// One intermediate folding round: the commitment to that round's folded codeword, and its
+/// One intermediate fold batch: the commitment to that round's folded codeword, and its
 /// query openings.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(
@@ -18,8 +18,9 @@ use serde::{Deserialize, Serialize};
 pub struct RoundProof<MT: Mmcs<BinaryField128>> {
     /// Merkle root of this round's folded codeword.
     pub commitment: MT::Commitment,
-    /// Opened rows, two per query — the low- then high-indexed symbol of that query's fold
-    /// pair at this round — in the order the query indices were sampled.
+    /// Every symbol of each queried coset, one width-1 row per symbol. Coset width is
+    /// `2^arity` for the next fold batch, derived from the verifier's configuration.
+    /// Cosets follow sampled query order; symbols inside a coset are ascending.
     pub opened_values: Vec<Vec<BinaryField128>>,
     /// One multiproof authenticating every opened row of this round together.
     pub multi_proof: MT::MultiProof,
@@ -27,10 +28,10 @@ pub struct RoundProof<MT: Mmcs<BinaryField128>> {
 
 /// A full opening proof.
 ///
-/// The last folding round has no [`RoundProof`]: its codeword has already shrunk to
+/// The last fold batch has no [`RoundProof`]: its codeword has already shrunk to
 /// `2^log_inv_rate` symbols, so it is sent in full as `final_codeword` instead of committed —
 /// a Merkle path over it would only repeat what the verifier can already read directly. Every
-/// earlier round appears in `rounds`, committed and opened at the paired positions each query
+/// earlier batch appears in `rounds`, committed and opened at every coset position each query
 /// needs.
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(bound(
@@ -40,10 +41,10 @@ pub struct RoundProof<MT: Mmcs<BinaryField128>> {
 pub struct BinaryPcsProof<MT: Mmcs<BinaryField128>> {
     /// Every sumcheck round message, in round order.
     pub sumcheck: SumcheckData<BinaryField128, BinaryField128>,
-    /// One entry per intermediate folding round, i.e. every folding round except the last.
+    /// One entry per intermediate fold batch, excluding the final batch.
     pub rounds: Vec<RoundProof<MT>>,
-    /// Openings of the base commitment: two width-1 rows per query — the pair's low- then
-    /// high-indexed symbol — in the order query indices were sampled.
+    /// All symbols of the sampled base cosets, in query order with ascending coset offsets.
+    /// The first batch's arity determines the number of width-1 rows per query.
     pub base_opened_values: Vec<Vec<BinaryField128>>,
     /// Multiproof for the base commitment's queried rows.
     pub base_multi_proof: MT::MultiProof,

--- a/binary-pcs/src/prover.rs
+++ b/binary-pcs/src/prover.rs
@@ -6,7 +6,7 @@
 //! `Layout::into_sumcheck` consumes zero preprocessing rounds, leaving every one of the
 //! `num_variables` residual sumcheck rounds a folding round. Each round's challenge is used
 //! twice: it binds one multilinear variable, through [`PcsLayout`]'s evaluation-basis suffix
-//! binding, and it folds the codeword, through [`fold_codeword`], a Reed-Solomon codeword fold
+//! binding, and it folds the codeword, through [`fold_codeword_batch`], a Reed-Solomon codeword fold
 //! in the same basis (see `fold.rs`). The two stay in correspondence throughout: see
 //! `the_codeword_and_the_sumcheck_stay_in_lockstep` below, which drives the real `Layout`
 //! machinery and checks it, and `prefix_layout_does_not_stay_in_lockstep`, which checks that
@@ -24,10 +24,10 @@ use p3_sumcheck::SumcheckData;
 use p3_sumcheck::layout::{Layout, Table, Witness};
 
 use crate::PcsLayout;
-use crate::fold::fold_codeword;
+use crate::fold::fold_codeword_batch;
 use crate::params::BinaryPcsConfig;
 use crate::proof::RoundProof;
-use crate::verifier::{flat_pair_indices, sample_query_indices};
+use crate::verifier::{flat_coset_indices, sample_query_cosets};
 
 /// Preprocessing depth the commit phase lays out inside a committed row.
 ///
@@ -109,17 +109,16 @@ where
     )
 }
 
-/// Runs the residual sumcheck in lockstep with the codeword fold: one sumcheck round, one
-/// 2-to-1 fold, per iteration, with one Merkle commitment for every fold except the last —
-/// that fold's codeword is returned directly as the final codeword rather than committed, since
-/// its whole content already travels in the clear.
+/// Runs each residual sumcheck round before consuming its challenge in a codeword fold.
+/// Consecutive folds are fused into configured batches, with one commitment per batch except
+/// the last, whose entire codeword travels in the clear.
 ///
 /// The single grinding budget is spent once before the query phase, not here, so every round
 /// runs with `pow_bits = 0`.
 ///
 /// Returns the base commitment's Merkle prover data (handed back so the caller can still open
 /// base-round queries against it), the sumcheck transcript, one [`RoundCommitment`] per fold
-/// round except the last, the folding randomness in round order — `randomness.as_slice()[r]` is
+/// batch except the last, the folding randomness in round order — `randomness.as_slice()[r]` is
 /// round `r`'s challenge, matching what [`Layout::into_sumcheck`] returns — and the final
 /// folded codeword.
 #[must_use]
@@ -162,36 +161,29 @@ where
         "zero preprocessing depth commits a width-1 codeword"
     );
 
-    // One sumcheck round, one codeword fold, per iteration.
-    //
-    //     round r < last:  challenge beta_r -> fold 2-to-1 -> commit -> observe root
-    //     round r = last:  challenge beta_r -> fold 2-to-1 -> return in the clear
-    //
-    // The last fold's codeword is never committed.
-    // It travels in the proof as the final codeword instead.
-    let num_fold_rounds = config.num_fold_rounds();
-    let mut rounds: Vec<RoundCommitment<MT>> = Vec::with_capacity(num_fold_rounds - 1);
+    // Sumcheck messages/challenges remain sequential. Only batch boundaries materialize
+    // codewords and observe roots; the final batch is returned in the clear.
+    let num_batches = config.num_fold_batches();
+    let mut rounds: Vec<RoundCommitment<MT>> = Vec::with_capacity(num_batches - 1);
     let mut final_codeword = Vec::new();
-    for round in 0..num_fold_rounds {
-        let _round_span = tracing::info_span!("fold round", round).entered();
-        let challenge = tracing::info_span!("sumcheck round").in_scope(|| {
-            sumcheck.compute_sumcheck_polynomials(&mut sumcheck_data, challenger, 1, 0, None)
-        });
-        let beta = challenge.as_slice()[0];
-        randomness.extend(&challenge);
-
-        // Fold out of the previous round's Merkle leaves, never out of a copy of them.
-        // The commitment scheme already owns every codeword it committed.
-        // The fold allocates its own output, so this borrow ends before the push below.
-        let source = if round == 0 {
+    for (batch, (start, arity)) in config.fold_batches().enumerate() {
+        let _batch_span = tracing::info_span!("fold batch", batch, start, arity).entered();
+        let mut challenges = Vec::with_capacity(arity);
+        for round in start..start + arity {
+            let challenge = tracing::info_span!("sumcheck round", round).in_scope(|| {
+                sumcheck.compute_sumcheck_polynomials(&mut sumcheck_data, challenger, 1, 0, None)
+            });
+            challenges.push(challenge.as_slice()[0]);
+            randomness.extend(&challenge);
+        }
+        let source = if batch == 0 {
             &merkle_data
         } else {
-            &rounds[round - 1].merkle_data
+            &rounds[batch - 1].merkle_data
         };
         let folded = tracing::info_span!("fold codeword")
-            .in_scope(|| fold_codeword(&mmcs.get_matrices(source)[0].values, beta));
-
-        if round + 1 < num_fold_rounds {
+            .in_scope(|| fold_codeword_batch(&mmcs.get_matrices(source)[0].values, &challenges));
+        if batch + 1 < num_batches {
             let (commitment, round_data) = tracing::info_span!("commit folded codeword")
                 .in_scope(|| mmcs.commit_matrix(RowMajorMatrix::new(folded, 1)));
             challenger.observe(commitment.clone());
@@ -216,12 +208,12 @@ where
 /// The query phase's prover-side output: every opening `verifier::verify_query_paths` needs,
 /// plus the grinding witness.
 pub(crate) struct QueryProofs<MT: Mmcs<BinaryField128>> {
-    /// Openings of the base commitment: two width-1 rows per query — the pair's low- then
-    /// high-indexed symbol — in the order query indices were sampled.
+    /// Every symbol of each queried base coset, one width-1 row per symbol.
+    /// Cosets follow sampled query order; symbols inside a coset are ascending.
     pub base_opened_values: Vec<Vec<BinaryField128>>,
     /// Multiproof for the base commitment's queried rows.
     pub base_multi_proof: MT::MultiProof,
-    /// One [`RoundProof`] per intermediate folding round, i.e. every round except the last.
+    /// One [`RoundProof`] per intermediate fold batch, excluding the final batch.
     pub rounds: Vec<RoundProof<MT>>,
     /// Witness for the single grind before the query phase.
     pub pow_witness: BinaryField128,
@@ -229,9 +221,9 @@ pub(crate) struct QueryProofs<MT: Mmcs<BinaryField128>> {
 
 /// Runs the query phase: grinds the single proof-of-work witness, samples query indices from
 /// the base codeword's domain, then opens the base commitment and every intermediate
-/// folding-round commitment at the paired indices each sampled query needs.
+/// fold-batch commitment at all coset indices each sampled query needs.
 ///
-/// `rounds` is every [`RoundCommitment`] `fold_rounds` produced: one per fold round except the
+/// `rounds` is every [`RoundCommitment`] `fold_rounds` produced: one per fold batch except the
 /// last, whose codeword is never committed — it travels in the clear as the proof's
 /// `final_codeword` instead, so a Merkle path for it would only repeat what the verifier can
 /// already read directly.
@@ -251,25 +243,22 @@ where
 {
     assert_eq!(
         rounds.len(),
-        config.num_fold_rounds() - 1,
+        config.num_fold_batches() - 1,
         "rounds is the caller's own fold_rounds output, never proof-supplied data"
     );
 
     let pow_witness = challenger.grind(config.pow_bits());
 
-    let domain_size = config.domain_size();
-    let indices =
-        sample_query_indices::<_, BinaryField128>(domain_size, config.num_queries(), challenger);
-
-    let base_indices = flat_pair_indices(&indices, 0);
+    let indices = sample_query_cosets(config, challenger);
+    let base_indices = flat_coset_indices(&indices, 0, config.log_folding_factor());
     let (base_values, base_multi_proof) = mmcs.open_multi_batch(&base_indices, base_merkle_data);
     let base_opened_values = single_matrix_rows(base_values);
 
     let opened_rounds = rounds
         .iter()
-        .enumerate()
-        .map(|(r, round)| {
-            let round_indices = flat_pair_indices(&indices, r + 1);
+        .zip(config.fold_batches().skip(1))
+        .map(|(round, (start, arity))| {
+            let round_indices = flat_coset_indices(&indices, start, arity);
             let (values, multi_proof) = mmcs.open_multi_batch(&round_indices, &round.merkle_data);
             RoundProof {
                 commitment: round.commitment.clone(),
@@ -313,7 +302,8 @@ mod tests {
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
-    use super::{commit, fold_codeword, fold_rounds};
+    use super::{commit, fold_rounds};
+    use crate::fold::fold_codeword;
     use crate::params::{BinaryPcsConfig, BinaryPcsParams};
     use crate::test_util::{challenger, mmcs};
 

--- a/binary-pcs/src/verifier.rs
+++ b/binary-pcs/src/verifier.rs
@@ -1,21 +1,10 @@
-//! Query sampling and the per-query fold-consistency check.
+//! Full-coset queries tying consecutive committed fold batches together.
 //!
-//! Every round's codeword is a flat vector; round 0 is the base commitment, round `r` for
-//! `1 <= r < num_fold_rounds` is `proof.rounds[r - 1]`, and round `num_fold_rounds` is
-//! `proof.final_codeword`, sent in full rather than committed. A query index `i`, drawn from
-//! the base codeword's domain, addresses position `i >> r` at round `r`; folding that
-//! position's pair with round `r`'s challenge must reproduce the value read at position
-//! `i >> (r + 1)` of round `r + 1`.
-//!
-//! Every one of those reads goes through `i >> 1`:
-//!
-//! - Round 0 opens the pair `[i & !1, (i & !1) + 1]`.
-//! - Round 0 folds that pair at the domain point of the pair's low position.
-//! - Round `r >= 1` sees only `i >> r`.
-//!
-//! So bit 0 of `i` selects nothing, and a query is a pair index.
-//! Sampling draws that pair index directly.
-//! That is what makes one distinct draw mean one distinct fold-chain test.
+//! Base query indices are aligned to the first batch's coset size. A batch starting at
+//! variable `start` with `arity` challenges opens the coset containing `index >> start`,
+//! folds all its symbols, then checks the coordinate `index >> (start + arity)` in the next
+//! committed word (or the final word sent in full). Only base cosets are sampled distinctly;
+//! repeated projected cosets in later rounds remain the same base-query paths.
 
 use alloc::collections::BTreeSet;
 use alloc::vec;
@@ -29,7 +18,7 @@ use p3_matrix::Dimensions;
 use p3_util::log2_strict_usize;
 
 use crate::error::BinaryPcsError;
-use crate::fold::fold_pair;
+use crate::fold::{fold_coset, fold_pair};
 use crate::params::BinaryPcsConfig;
 use crate::proof::BinaryPcsProof;
 
@@ -101,19 +90,32 @@ where
     pairs.into_iter().map(|pair| pair << 1).collect()
 }
 
-/// The pair of positions round `round`'s codeword must supply to carry query `index` onward:
-/// the position `index` addresses at that round, and its fold sibling — low bit clear first.
-const fn fold_pair_positions(index: usize, round: usize) -> [usize; 2] {
-    let position = index >> round;
-    let even = position & !1;
-    [even, even + 1]
+/// Sample distinct base cosets. Reusing the pair sampler on a shorter index domain keeps
+/// the single-fold transcript unchanged; lifting its indices clears all first-batch low bits.
+pub(crate) fn sample_query_cosets<Ch>(config: &BinaryPcsConfig, challenger: &mut Ch) -> Vec<usize>
+where
+    Ch: FieldChallenger<BinaryField128> + CanSampleUniformBits<BinaryField128>,
+{
+    let shift = config.log_folding_factor() - 1;
+    sample_query_indices::<_, BinaryField128>(
+        config.domain_size() >> shift,
+        config.num_queries(),
+        challenger,
+    )
+    .into_iter()
+    .map(|index| index << shift)
+    .collect()
 }
 
-/// Every position round `round` must open: one pair per sampled query index, in query order.
-pub(crate) fn flat_pair_indices(indices: &[usize], round: usize) -> Vec<usize> {
+/// All symbols of every queried coset, in query order, with ascending offsets within a coset.
+pub(crate) fn flat_coset_indices(indices: &[usize], start: usize, arity: usize) -> Vec<usize> {
+    let size = 1usize << arity;
     indices
         .iter()
-        .flat_map(|&index| fold_pair_positions(index, round))
+        .flat_map(|&index| {
+            let first = (index >> start) & !(size - 1);
+            first..first + size
+        })
         .collect()
 }
 
@@ -167,7 +169,7 @@ pub(crate) fn check_round_and_final_lengths<MT>(
 where
     MT: Mmcs<BinaryField128>,
 {
-    let expected_intermediate_rounds = config.num_fold_rounds() - 1;
+    let expected_intermediate_rounds = config.num_fold_batches() - 1;
     if proof.rounds.len() != expected_intermediate_rounds {
         return Err(BinaryPcsError::RoundCountMismatch {
             expected: expected_intermediate_rounds,
@@ -223,89 +225,84 @@ where
     check_round_and_final_lengths(config, proof)?;
 
     let domain_size = config.domain_size();
-    let target_queries = num_distinct_queries(domain_size, config.num_queries());
-    let expected_opens = 2 * target_queries;
-
-    check_round_shape(0, &proof.base_opened_values, expected_opens)?;
-    for (r, round) in proof.rounds.iter().enumerate() {
-        check_round_shape(r + 1, &round.opened_values, expected_opens)?;
+    let target_queries = config
+        .num_queries()
+        .min(domain_size >> config.log_folding_factor());
+    let batches: Vec<_> = config.fold_batches().collect();
+    let round_values = |batch: usize| -> &[Vec<BinaryField128>] {
+        if batch == 0 {
+            &proof.base_opened_values
+        } else {
+            &proof.rounds[batch - 1].opened_values
+        }
+    };
+    for (batch, &(_, arity)) in batches.iter().enumerate() {
+        check_round_shape(batch, round_values(batch), target_queries << arity)?;
     }
 
-    // The transcript is touched from here on: grind, then sample.
     if !challenger.check_witness(config.pow_bits(), proof.pow_witness) {
         return Err(BinaryPcsError::InvalidPowWitness);
     }
-
-    let indices =
-        sample_query_indices::<_, BinaryField128>(domain_size, config.num_queries(), challenger);
+    let indices = sample_query_cosets(config, challenger);
     debug_assert_eq!(indices.len(), target_queries);
 
-    // One Merkle multiproof per round.
-    let base_indices = flat_pair_indices(&indices, 0);
-    let base_dims = [Dimensions {
-        width: 1,
-        height: domain_size,
-    }];
-    mmcs.verify_multi_batch(
-        base_commitment,
-        &base_dims,
-        &base_indices,
-        &wrap_rows(&proof.base_opened_values),
-        &proof.base_multi_proof,
-    )
-    .map_err(|source| BinaryPcsError::MerkleFailed { round: 0, source })?;
-
-    for (r, round) in proof.rounds.iter().enumerate() {
-        let round_number = r + 1;
-        let round_indices = flat_pair_indices(&indices, round_number);
+    for (batch, &(start, arity)) in batches.iter().enumerate() {
+        let (commitment, multi_proof) = if batch == 0 {
+            (base_commitment, &proof.base_multi_proof)
+        } else {
+            (
+                &proof.rounds[batch - 1].commitment,
+                &proof.rounds[batch - 1].multi_proof,
+            )
+        };
         let dims = [Dimensions {
             width: 1,
-            height: domain_size >> round_number,
+            height: domain_size >> start,
         }];
+        let coset_indices = flat_coset_indices(&indices, start, arity);
         mmcs.verify_multi_batch(
-            &round.commitment,
+            commitment,
             &dims,
-            &round_indices,
-            &wrap_rows(&round.opened_values),
-            &round.multi_proof,
+            &coset_indices,
+            &wrap_rows(round_values(batch)),
+            multi_proof,
         )
         .map_err(|source| BinaryPcsError::MerkleFailed {
-            round: round_number,
+            round: batch,
             source,
         })?;
     }
 
-    // Fold-chain consistency, one query at a time.
-    let round_values = |round: usize| -> &[Vec<BinaryField128>] {
-        if round == 0 {
-            &proof.base_opened_values
-        } else {
-            &proof.rounds[round - 1].opened_values
-        }
-    };
-
+    let mut coset = Vec::new();
     for (q, &index) in indices.iter().enumerate() {
-        // The bound is `num_fold_rounds`, checked against `betas.len()` above, rather than
-        // `betas.len()` itself, so an inconsistent `betas` cannot silently shrink or grow this
-        // loop; `r` also indexes `index >> r` and both `round_values` calls, not just `betas`.
-        #[allow(clippy::needless_range_loop)]
-        for r in 0..num_fold_rounds {
-            let beta = betas[r];
-            let position = index >> r;
-            let lo = round_values(r)[2 * q][0];
-            let hi = round_values(r)[2 * q + 1][0];
-            let folded = fold_pair(position >> 1, beta, lo, hi);
-
-            let expected = if r + 1 < num_fold_rounds {
-                let parity = (position >> 1) & 1;
-                round_values(r + 1)[2 * q + parity][0]
+        for (batch, &(start, arity)) in batches.iter().enumerate() {
+            let size = 1 << arity;
+            let next_position = index >> (start + arity);
+            let folded = if arity == 1 {
+                fold_pair(
+                    next_position,
+                    betas[start],
+                    round_values(batch)[2 * q][0],
+                    round_values(batch)[2 * q + 1][0],
+                )
             } else {
-                proof.final_codeword.as_slice()[position >> 1]
+                coset.clear();
+                coset.extend(
+                    round_values(batch)[q * size..(q + 1) * size]
+                        .iter()
+                        .map(|row| row[0]),
+                );
+                fold_coset(next_position, &mut coset, &betas[start..start + arity])
             };
-
+            let expected = if let Some(&(_, next_arity)) = batches.get(batch + 1) {
+                let next_size = 1 << next_arity;
+                round_values(batch + 1)[q * next_size + (next_position & (next_size - 1))][0]
+            } else {
+                proof.final_codeword.as_slice()[next_position]
+            };
             if folded != expected {
                 return Err(BinaryPcsError::FoldMismatch {
-                    round: r + 1,
+                    round: batch + 1,
                     query: q,
                 });
             }
@@ -332,7 +329,7 @@ mod tests {
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
-    use super::{BinaryPcsError, sample_query_indices, verify_query_paths};
+    use super::{BinaryPcsError, sample_query_cosets, sample_query_indices, verify_query_paths};
     use crate::params::{BinaryPcsConfig, BinaryPcsParams};
     use crate::proof::BinaryPcsProof;
     use crate::prover::{RoundCommitment, commit, fold_rounds, open_queries};
@@ -377,6 +374,28 @@ mod tests {
         let mut c = challenger();
         let indices = sample_query_indices::<_, BinaryField128>(8, 100, &mut c);
         assert_eq!(indices, alloc::vec![0, 2, 4, 6]);
+    }
+
+    #[test]
+    fn batched_queries_sample_distinct_full_cosets_and_cap_at_the_coset_count() {
+        for (num_variables, arity) in [(8, 3), (3, 3)] {
+            let config = BinaryPcsConfig::try_new(num_variables, params())
+                .unwrap()
+                .try_with_folding(arity)
+                .unwrap();
+            let indices = sample_query_cosets(&config, &mut challenger());
+            let cosets = config.domain_size() >> arity;
+            assert_eq!(indices.len(), config.num_queries().min(cosets));
+            assert!(indices.windows(2).all(|w| w[0] < w[1]));
+            assert!(
+                indices
+                    .iter()
+                    .all(|&i| i < config.domain_size() && i % (1 << arity) == 0)
+            );
+            if config.num_queries() >= cosets {
+                assert_eq!(indices, (0..cosets).map(|i| i << arity).collect::<Vec<_>>());
+            }
+        }
     }
 
     #[test]

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -10,7 +10,10 @@
 //! actually produced.
 
 use p3_binary_field::{BinaryChallenger, BinaryField128};
-use p3_binary_pcs::{BinaryPcs, BinaryPcsConfig, BinaryPcsError, BinaryPcsParams, BinaryPcsProof};
+use p3_binary_pcs::{
+    BinaryPcs, BinaryPcsConfig, BinaryPcsError, BinaryPcsParams, BinaryPcsProof,
+    GroupedCodewordMmcs,
+};
 use p3_challenger::{FieldChallenger, HashChallenger};
 use p3_commit::{Mmcs, MultilinearPcs};
 use p3_field::PrimeCharacteristicRing;
@@ -32,6 +35,59 @@ type MyCompress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
 type MyMmcs = MerkleTreeMmcs<F, u8, MyHash, MyCompress, 2, 32>;
 type MyChallenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
 type MyPcs = BinaryPcs<MyMmcs>;
+
+#[test]
+fn batched_folding_commits_only_batch_boundaries_and_verifies() {
+    for (num_variables, arity, expected_roots) in [(8, 3, 2), (7, 2, 3), (4, 4, 0)] {
+        let config = BinaryPcsConfig::try_new(num_variables, params(2, 0, 100))
+            .unwrap()
+            .try_with_folding(arity)
+            .unwrap();
+        let pcs = BinaryPcs::new(config, GroupedCodewordMmcs::for_folding(mmcs(), &config));
+        let mut rng = SmallRng::seed_from_u64(0xBA7C);
+        let table = Table::rand(&mut rng, 1, num_variables);
+        let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+        let protocol = OpeningProtocol::new(vec![TableSpec::new(
+            TableShape::new(num_variables, 1),
+            vec![OpeningBatch::new(vec![0], vec![0])],
+        )]);
+        let mut ch = challenger();
+        let (root, data) = pcs.commit(witness, &mut ch);
+        let proof = pcs.open(data, protocol.clone(), &mut ch);
+        assert_eq!(proof.rounds.len(), expected_roots);
+        assert_eq!(proof.sumcheck.num_rounds(), num_variables);
+        let bytes = postcard::to_allocvec(&proof).unwrap();
+        let decoded: BinaryPcsProof<GroupedCodewordMmcs<MyMmcs>> =
+            postcard::from_bytes(&bytes).unwrap();
+        pcs.verify(&root, &decoded, &mut challenger(), protocol.clone())
+            .unwrap();
+
+        // Authenticate every symbol in the coset, including those beyond the first pair.
+        let mut tampered = decoded.clone();
+        tampered.base_opened_values[(1 << arity) - 1][0] += F::ONE;
+        assert!(matches!(
+            pcs.verify(&root, &tampered, &mut challenger(), protocol.clone()),
+            Err(BinaryPcsError::MerkleFailed { round: 0, .. })
+        ));
+
+        let mut short_coset = decoded.clone();
+        short_coset.base_opened_values.pop();
+        assert!(matches!(
+            pcs.verify(&root, &short_coset, &mut challenger(), protocol.clone()),
+            Err(BinaryPcsError::OpeningCountMismatch { round: 0, .. })
+        ));
+
+        if !decoded.rounds.is_empty() {
+            let mut tampered = decoded;
+            // The final committed layer precedes a potentially shorter batch.
+            tampered.rounds.last_mut().unwrap().opened_values[0][0] += F::ONE;
+            assert!(matches!(
+                pcs.verify(&root, &tampered, &mut challenger(), protocol),
+                Err(BinaryPcsError::MerkleFailed { round, .. }) if round == expected_roots
+            ));
+        }
+    }
+}
 
 /// Default shape shared by every negative test: enough intermediate rounds
 /// (`num_fold_rounds - 1 == 7`) to truncate or permute, and `pow_bits > 0` so the grinding
@@ -436,6 +492,7 @@ fn permuted_round_commitments_are_rejected() {
 fn zero_claim_lifecycle(
     num_variables: usize,
     seed: u64,
+    log_folding_factor: usize,
 ) -> (
     MyPcs,
     <MyMmcs as Mmcs<F>>::Commitment,
@@ -455,6 +512,8 @@ fn zero_claim_lifecycle(
         num_variables,
         params(LOG_INV_RATE, POW_BITS, SECURITY_LEVEL),
     )
+    .unwrap()
+    .try_with_folding(log_folding_factor)
     .unwrap();
     let pcs = BinaryPcs::new(config, mmcs());
 
@@ -474,7 +533,7 @@ fn zero_claim_lifecycle(
 /// that ties the final codeword to the rounds committed before it, and it is what catches this.
 #[test]
 fn a_zero_claim_proof_with_a_uniformly_shifted_final_codeword_is_rejected_by_the_fold_chain() {
-    let (pcs, commitment, proof, protocol) = zero_claim_lifecycle(NUM_VARIABLES, 11);
+    let (pcs, commitment, proof, protocol) = zero_claim_lifecycle(NUM_VARIABLES, 11, 1);
 
     let mut honest_challenger = challenger();
     pcs.verify(
@@ -518,6 +577,26 @@ fn a_zero_claim_proof_with_a_uniformly_shifted_final_codeword_is_rejected_by_the
         matches!(err, BinaryPcsError::FoldMismatch { round, query: 0 } if round == NUM_VARIABLES),
         "expected FoldMismatch at round {NUM_VARIABLES} query 0, got {err:?}"
     );
+}
+
+/// With no opening claims, the sumcheck's final product check is vacuous. Batched query
+/// verification must still tie the uniform final word to the authenticated base cosets.
+#[test]
+fn batched_zero_claim_proofs_reject_a_shifted_final_codeword() {
+    for arity in [2, 3, NUM_VARIABLES] {
+        let (pcs, commitment, mut proof, protocol) =
+            zero_claim_lifecycle(NUM_VARIABLES, 0xBA7C, arity);
+        pcs.verify(&commitment, &proof, &mut challenger(), protocol.clone())
+            .unwrap();
+        for symbol in proof.final_codeword.as_mut_slice() {
+            *symbol += F::ONE;
+        }
+        let expected_round = NUM_VARIABLES.div_ceil(arity);
+        assert!(matches!(
+            pcs.verify(&commitment, &proof, &mut challenger(), protocol),
+            Err(BinaryPcsError::FoldMismatch { round, query: 0 }) if round == expected_round
+        ));
+    }
 }
 
 /// The different-commitment test desyncs the whole transcript, so `FinalCheck` fires long

--- a/multi-stark/examples/bench_binary_grouping.rs
+++ b/multi-stark/examples/bench_binary_grouping.rs
@@ -1,7 +1,8 @@
 //! Benchmark adjacent-symbol Merkle grouping on the binary recurrence AIR.
-//! Run with `-- [repetitions=9] [log_height=18] [vary]`; CSV goes to stdout.
+//! Run with `-- [repetitions=9] [log_height=18] [vary] [batched]`; CSV goes to stdout.
 //! Group 0 is the unwrapped baseline; group 1 measures adapter overhead.
 //! `vary` uses a different public transcript separator in each iteration to sample proof sizes.
+//! `batched` compares the original PCS, fixed groups 4/8, and batches of 2/3/4 folds.
 
 use std::time::Instant;
 
@@ -67,16 +68,22 @@ impl<M: MmcsTrait<F, Commitment = <Mmcs as MmcsTrait<F>>::Commitment>> MultiStar
     }
 }
 
-fn config<M>(log_height: usize, mmcs: M) -> Config<M> {
+fn pcs_config(log_height: usize, log_folding_factor: usize) -> BinaryPcsConfig {
     // Two trace columns add one variable to the stacked polynomial.
     let params = BinaryPcsParams {
         log_inv_rate: 2,
         pow_bits: 0,
         security_level: 100,
     };
-    let pcs_config = BinaryPcsConfig::try_new(log_height + 1, params).unwrap();
+    BinaryPcsConfig::try_new(log_height + 1, params)
+        .unwrap()
+        .try_with_folding(log_folding_factor)
+        .unwrap()
+}
+
+fn config<M>(log_height: usize, mmcs: M, log_folding_factor: usize) -> Config<M> {
     Config {
-        pcs: BinaryPcs::new(pcs_config, mmcs),
+        pcs: BinaryPcs::new(pcs_config(log_height, log_folding_factor), mmcs),
     }
 }
 
@@ -143,11 +150,12 @@ fn run<M: MmcsTrait<F, Commitment = <Mmcs as MmcsTrait<F>>::Commitment>>(
     log_height: usize,
     mmcs: M,
     seed: u64,
+    log_folding_factor: usize,
 ) -> (f64, f64, usize)
 where
     M::ProverData<RowMajorMatrix<F>>: Clone,
 {
-    let config = config(log_height, mmcs);
+    let config = config(log_height, mmcs, log_folding_factor);
     let (table, public) = trace(log_height);
     let (pk, vk) = setup(&config, &[&RecurrenceAir], &mut challenger(seed));
     let start = Instant::now();
@@ -199,25 +207,39 @@ fn main() {
         Some("vary") => true,
         _ => panic!("usage: bench_binary_grouping [repetitions] [log_height] [vary]"),
     };
-    println!("iteration,group_size,seed,prove_ms,verify_ms,proof_bytes");
+    let batched = match args.get(3).map(String::as_str) {
+        None => false,
+        Some("batched") => true,
+        _ => panic!("expected batched as the fourth argument"),
+    };
+    println!("iteration,group_size,log_folding_factor,seed,prove_ms,verify_ms,proof_bytes");
     // Warm every configuration, then rotate and reverse order to spread drift across groups.
     // Iteration zero is warm-up and must be excluded from summary statistics.
     for iteration in 0..=repetitions {
-        let mut groups = [0, 1, 2, 4, 8, 16];
+        let mut groups = if batched {
+            [(0, 1), (4, 1), (8, 1), (4, 2), (8, 3), (16, 4)]
+        } else {
+            [(0, 1), (1, 1), (2, 1), (4, 1), (8, 1), (16, 1)]
+        };
         let order = iteration.saturating_sub(1);
         groups.rotate_left(order % 6);
         if (order / groups.len()) % 2 == 1 {
             groups.reverse();
         }
         let seed = if vary_transcript { iteration as u64 } else { 0 };
-        for group in groups {
+        for (group, arity) in groups {
             let mmcs = Mmcs::new(Hash::new(Keccak256Hash), Compress::new(Keccak256Hash), 0);
             let (prove_ms, verify_ms, bytes) = if group == 0 {
-                run(log_height, mmcs, seed)
+                run(log_height, mmcs, seed, arity)
             } else {
-                run(log_height, GroupedCodewordMmcs::new(mmcs, group), seed)
+                let grouped = if arity > 1 {
+                    GroupedCodewordMmcs::for_folding(mmcs, &pcs_config(log_height, arity))
+                } else {
+                    GroupedCodewordMmcs::new(mmcs, group)
+                };
+                run(log_height, grouped, seed, arity)
             };
-            println!("{iteration},{group},{seed},{prove_ms:.6},{verify_ms:.6},{bytes}");
+            println!("{iteration},{group},{arity},{seed},{prove_ms:.6},{verify_ms:.6},{bytes}");
         }
     }
 }

--- a/multi-stark/examples/prove_binary_field.rs
+++ b/multi-stark/examples/prove_binary_field.rs
@@ -5,7 +5,9 @@
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_binary_field::{BinaryChallenger, BinaryField128, TowerLevel};
-use p3_binary_pcs::{BinaryPcs, BinaryPcsConfig, BinaryPcsParams, BinaryPcsProverData};
+use p3_binary_pcs::{
+    BinaryPcs, BinaryPcsConfig, BinaryPcsParams, BinaryPcsProverData, GroupedCodewordMmcs,
+};
 use p3_challenger::HashChallenger;
 use p3_keccak::Keccak256Hash;
 use p3_matrix::dense::RowMajorMatrix;
@@ -25,7 +27,8 @@ use tracing_subscriber::{EnvFilter, Registry};
 type F = BinaryField128;
 type Hash = SerializingHasher<Keccak256Hash>;
 type Compress = CompressionFunctionFromHasher<Keccak256Hash, 2, 32>;
-type Mmcs = p3_merkle_tree::MerkleTreeMmcs<F, u8, Hash, Compress, 2, 32>;
+type MerkleMmcs = p3_merkle_tree::MerkleTreeMmcs<F, u8, Hash, Compress, 2, 32>;
+type Mmcs = GroupedCodewordMmcs<MerkleMmcs>;
 type Challenger = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
 
 struct Config {
@@ -67,8 +70,14 @@ fn config(log_height: usize) -> Config {
         pow_bits: 0,
         security_level: 100,
     };
-    let pcs_config = BinaryPcsConfig::try_new(log_height + 1, params).unwrap();
-    let mmcs = Mmcs::new(Hash::new(Keccak256Hash), Compress::new(Keccak256Hash), 0);
+    // Commit after up to three variable folds, with one coset per leaf.
+    // The final batch and its leaves shrink to the number of remaining variables.
+    let pcs_config = BinaryPcsConfig::try_new(log_height + 1, params)
+        .unwrap()
+        .try_with_folding(3.min(log_height + 1))
+        .unwrap();
+    let merkle = MerkleMmcs::new(Hash::new(Keccak256Hash), Compress::new(Keccak256Hash), 0);
+    let mmcs = Mmcs::for_folding(merkle, &pcs_config);
     Config {
         pcs: BinaryPcs::new(pcs_config, mmcs),
     }


### PR DESCRIPTION
Grouped Merkle leaves still build a separate tree for every intermediate fold. This change commits only at configured batch boundaries and authenticates each entire fold coset, following [Binius64's buffered-challenge FRI schedule](https://github.com/binius-zk/binius64/blob/37e9cd64e82243cde0e79c7d8ac0dc319f1cbeb4/crates/iop-prover/src/fri/fold.rs).

Stacked on #2095 (`robin/binary-pcs-grouped-leaves`, latest tip `d56454e6`).

- Add opt-in `BinaryPcsConfig::try_with_folding(k)`. Every sumcheck message still precedes its independent challenge; roots appear only at batch boundaries. The default single-fold configuration retains its transcript and query count.
- Fuse each coset's folds using scratch in the polynomial basis, avoiding full intermediate words and repeated basis conversions. Preserve the existing packed single-fold path.
- Size leaves for the next actual batch, including shorter tails. Verify all authenticated coset symbols and their global domain offsets through to the final word.
- Switch `prove_binary_field` to three-fold batches with matching leaves, retaining tracing and small-fixture support. Extend the existing benchmark to compare folding schedules.

For the example's 19-variable stacked polynomial, three-fold batching builds 7 trees instead of 19. The sum of committed codeword payloads falls from 64 MiB to 36.57 MiB (43% less; excludes internal digests). Initial encoding length and rate remain the same.

The batched security budget sums `(N/2^r + 1)/|F|` over every virtual fold and `2/|F|` per sumcheck round, using the UDR mutual-agreement argument in [Appendix A, Theorem 8](https://eprint.iacr.org/2024/1553). One bit is reserved for each of the field and query errors before adding them. At this 100-bit target, batching uses 149 queries versus 148 for the existing single-fold configuration. PoW is credited only to the query term.

Measured on Apple M4 Pro, native optimized build with parallelism: 2^18 rows, two GF(2^128) columns, Keccak, rate 1/4, 100-bit target, zero PoW. Medians of 18 measured trials per configuration, after warming every configuration; transcripts vary and execution order rotates/reverses. Every proof is serialized, decoded, and verified. Timings are complete AIR proving/verification, excluding trace generation, setup, and serialization.

| Configuration | Prove ms | Verify ms | Proof KiB |
|---|---:|---:|---:|
| ARM-optimized, ungrouped | 151.90 | 4.744 | 475.65 |
| 4-symbol leaves, one fold | 85.49 | 3.723 | 485.59 |
| 8-symbol leaves, one fold | 73.49 | 3.442 | 552.93 |
| 2-fold batches | 73.42 | 2.307 | 280.78 |
| 3-fold batches (example) | 63.29 | 1.959 | 248.88 |
| 4-fold batches | 58.19 | 2.133 | 279.69 |

Against eight-symbol grouping alone, three-fold batching saves 13.9% proving time, 43.1% verification time, and 55.0% proof bytes. Against four-symbol grouping, the proving saving is 26.0%. Four-fold batching reaches 58.2 ms, with larger proofs and slower verification than three-fold batching. These are ARM measurements; x86 was compile-checked only.

Reproduce:

```sh
RUST_LOG=off RUSTFLAGS='-C target-cpu=native -C opt-level=3' cargo run --profile optimized --features parallel -p p3-multi-stark --example bench_binary_grouping -- 18 18 vary batched
```

Validation:

- Native optimized parallel PCS suite: 74 passed, including the normally ignored large test. Portable debug suite: 73 passed, one ignored.
- Binary AIR example: all 8 tests passed, including mixed heights, preprocessed data, and malformed proofs; full 2^18 example also verified with tracing.
- Added oracle comparisons against repeated single folds on arbitrary codewords, including nonzero parallel-task offsets; partial tails, single-batch proofs, prescribed points, distinct/full-enumeration queries, tampered coset symbols, truncated openings, and zero-claim fold-chain attacks.
- Clippy with warnings denied for PCS/all targets and both examples; formatting and rustdoc links passed.
- x86 AVX2/PCLMUL and wasm library checks passed.
