### PR TITLE
perf(goldilocks): optimize scalar and packed arithmetic across backends

### DIFF
--- a/field/src/extension/cubic_extension.rs
+++ b/field/src/extension/cubic_extension.rs
@@ -73,9 +73,9 @@ impl<F: CubicTrinomialExtendable> HasFrobenius<F> for CubicTrinomialExtensionFie
     fn frobenius(&self) -> Self {
         let a = &self.value;
         let m = F::FROBENIUS_MATRIX;
-        let c0 = a[0] + m[0][1] * a[1] + m[0][2] * a[2];
-        let c1 = m[1][1] * a[1] + m[1][2] * a[2];
-        let c2 = m[2][1] * a[1] + m[2][2] * a[2];
+        let c0 = a[0] + F::dot_product::<2>(&[a[1], a[2]], &[m[0][1], m[0][2]]);
+        let c1 = F::dot_product::<2>(&[a[1], a[2]], &[m[1][1], m[1][2]]);
+        let c2 = F::dot_product::<2>(&[a[1], a[2]], &[m[2][1], m[2][2]]);
         Self::new([c0, c1, c2])
     }
 

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -3,7 +3,7 @@ use core::hint::black_box;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
 use p3_field::integers::QuotientMap;
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::{Algebra, Field, PackedValue, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_chunked_linear_combination,
     benchmark_div_2exp, benchmark_double_latency, benchmark_double_throughput, benchmark_halve,
@@ -193,6 +193,25 @@ where
     });
 }
 
+fn benchmark_packed_batched_linear_combination(c: &mut Criterion, name: &str) {
+    type PF = <F as Field>::Packing;
+    let mut rng = SmallRng::seed_from_u64(0x5E2_51CE);
+    for len in [0, 1, 2, 3, 4, 5, 6, 16, 32, 63, 64, 65, 100, 129, 1024] {
+        let values = (0..len)
+            .map(|_| PF::from_fn(|_| F::new(rng.random())))
+            .collect::<Vec<_>>();
+        let coeffs = (0..len).map(|_| F::new(rng.random())).collect::<Vec<_>>();
+        c.bench_function(&format!("{name} batched_linear_combination/{len}"), |b| {
+            b.iter(|| {
+                black_box(PF::batched_linear_combination(
+                    black_box(values.as_slice()),
+                    black_box(coeffs.as_slice()),
+                ))
+            });
+        });
+    }
+}
+
 fn bench_packedfield(c: &mut Criterion) {
     let name = type_name::<<F as Field>::Packing>().to_string();
     type PF = <F as Field>::Packing;
@@ -234,6 +253,7 @@ fn bench_packedfield(c: &mut Criterion) {
     benchmark_sum_array::<PF, 129, 100>(c, &name);
 
     benchmark_chunked_linear_combination::<F, PF, 100>(c, &name);
+    benchmark_packed_batched_linear_combination(c, &name);
 
     benchmark_mixed_dot_array::<PF, F, 1>(c, &name);
     benchmark_mixed_dot_array::<PF, F, 2>(c, &name);

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -1,6 +1,8 @@
 use core::any::type_name;
+use core::hint::black_box;
 
 use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use p3_field::integers::QuotientMap;
 use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_add_latency, benchmark_add_throughput, benchmark_chunked_linear_combination,
@@ -79,6 +81,32 @@ fn bench_field(c: &mut Criterion) {
     });
 }
 
+fn bench_large_integer_conversion(c: &mut Criterion) {
+    const INPUT_COUNT: usize = 1024;
+
+    let mut rng = SmallRng::seed_from_u64(0x128_C0DE);
+    let unsigned_inputs: [u128; INPUT_COUNT] = core::array::from_fn(|_| rng.random());
+    let signed_inputs: [i128; INPUT_COUNT] = core::array::from_fn(|_| rng.random());
+
+    c.bench_function("from_u128", |b| {
+        let mut index = 0;
+        b.iter(|| {
+            let input = black_box(unsigned_inputs[index]);
+            index = (index + 1) % INPUT_COUNT;
+            black_box(F::from_int(input))
+        });
+    });
+
+    c.bench_function("from_i128", |b| {
+        let mut index = 0;
+        b.iter(|| {
+            let input = black_box(signed_inputs[index]);
+            index = (index + 1) % INPUT_COUNT;
+            black_box(F::from_int(input))
+        });
+    });
+}
+
 fn bench_packedfield(c: &mut Criterion) {
     let name = type_name::<<F as Field>::Packing>().to_string();
     // Note that each round of throughput has 10 operations
@@ -111,5 +139,10 @@ fn bench_packedfield(c: &mut Criterion) {
     benchmark_mixed_dot_array::<PF, F, 6>(c, &name);
 }
 
-criterion_group!(goldilocks_arithmetic, bench_field, bench_packedfield);
+criterion_group!(
+    goldilocks_arithmetic,
+    bench_field,
+    bench_large_integer_conversion,
+    bench_packedfield
+);
 criterion_main!(goldilocks_arithmetic);

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -135,6 +135,7 @@ fn bench_large_integer_conversion(c: &mut Criterion) {
 
 fn bench_packedfield(c: &mut Criterion) {
     let name = type_name::<<F as Field>::Packing>().to_string();
+    type PF = <F as Field>::Packing;
     // Note that each round of throughput has 10 operations
     // So we should have 10 * more repetitions for latency tests.
     const REPS: usize = 100;
@@ -154,7 +155,18 @@ fn bench_packedfield(c: &mut Criterion) {
     benchmark_dot_array::<<F as Field>::Packing, 5>(c, &name);
     benchmark_dot_array::<<F as Field>::Packing, 6>(c, &name);
 
-    type PF = <F as Field>::Packing;
+    benchmark_sum_array::<PF, 3, 100>(c, &name);
+    benchmark_sum_array::<PF, 4, 100>(c, &name);
+    benchmark_sum_array::<PF, 5, 100>(c, &name);
+    benchmark_sum_array::<PF, 6, 100>(c, &name);
+    benchmark_sum_array::<PF, 7, 100>(c, &name);
+    benchmark_sum_array::<PF, 8, 100>(c, &name);
+    benchmark_sum_array::<PF, 12, 100>(c, &name);
+    benchmark_sum_array::<PF, 16, 100>(c, &name);
+    benchmark_sum_array::<PF, 32, 100>(c, &name);
+    benchmark_sum_array::<PF, 64, 100>(c, &name);
+    benchmark_sum_array::<PF, 129, 100>(c, &name);
+
     benchmark_chunked_linear_combination::<F, PF, 100>(c, &name);
 
     benchmark_mixed_dot_array::<PF, F, 1>(c, &name);

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -21,6 +21,30 @@ use rand::{RngExt, SeedableRng};
 
 type F = Goldilocks;
 
+fn benchmark_sqrt_varied<const N: usize>(c: &mut Criterion) {
+    let mut rng = SmallRng::seed_from_u64(0x5A7_C0DE + N as u64);
+    let residues: [F; N] = core::array::from_fn(|_| rng.random::<F>().square());
+    let raw_inputs: [F; N] = core::array::from_fn(|_| F::new(rng.random()));
+
+    c.bench_function(&format!("Goldilocks sqrt varied residues/{N}"), |b| {
+        let mut index = 0;
+        b.iter(|| {
+            let input = black_box(residues[index]);
+            index = (index + 1) % N;
+            black_box(input.try_sqrt())
+        });
+    });
+
+    c.bench_function(&format!("Goldilocks sqrt varied raw/{N}"), |b| {
+        let mut index = 0;
+        b.iter(|| {
+            let input = black_box(raw_inputs[index]);
+            index = (index + 1) % N;
+            black_box(input.try_sqrt())
+        });
+    });
+}
+
 fn bench_field(c: &mut Criterion) {
     let name = "Goldilocks";
     const REPS: usize = 200;
@@ -29,6 +53,8 @@ fn bench_field(c: &mut Criterion) {
     benchmark_square::<F>(c, name);
     benchmark_inv::<F>(c, name);
     benchmark_sqrt::<F>(c, name);
+    benchmark_sqrt_varied::<256>(c);
+    benchmark_sqrt_varied::<1024>(c);
     benchmark_iter_sum::<F, 4, REPS>(c, name);
 
     benchmark_sum_array::<F, 4, REPS>(c, name);

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -16,6 +16,7 @@ use p3_field_testing::{
     benchmark_mul_throughput, benchmark_sum_array,
 };
 use p3_goldilocks::Goldilocks;
+use rand::distr::{Distribution, StandardUniform};
 use rand::rngs::SmallRng;
 use rand::{RngExt, SeedableRng};
 
@@ -133,6 +134,65 @@ fn bench_large_integer_conversion(c: &mut Criterion) {
     });
 }
 
+fn benchmark_packed_fixed_power<R, const REPS: usize, const EXP: u64>(c: &mut Criterion, name: &str)
+where
+    R: PrimeCharacteristicRing + Copy,
+    StandardUniform: Distribution<R>,
+{
+    let mut rng = SmallRng::seed_from_u64(0x2E80_2E80 + EXP);
+    let input = (0..REPS).map(|_| rng.random::<R>()).collect::<Vec<_>>();
+    let mut mul_input = input.clone();
+    let mut div_input = input;
+
+    c.bench_function(&format!("{name} mul_2exp_u64 fixed {EXP}"), |b| {
+        b.iter(|| {
+            mul_input
+                .iter_mut()
+                .for_each(|value| *value = value.mul_2exp_u64(EXP));
+            black_box(mul_input.as_slice());
+        });
+    });
+    c.bench_function(&format!("{name} div_2exp_u64 fixed {EXP}"), |b| {
+        b.iter(|| {
+            div_input
+                .iter_mut()
+                .for_each(|value| *value = value.div_2exp_u64(EXP));
+            black_box(div_input.as_slice());
+        });
+    });
+}
+
+fn benchmark_packed_runtime_powers<R, const REPS: usize>(c: &mut Criterion, name: &str)
+where
+    R: PrimeCharacteristicRing + Copy,
+    StandardUniform: Distribution<R>,
+{
+    let mut rng = SmallRng::seed_from_u64(0x2E80_2E80_5EED);
+    let input = (0..REPS).map(|_| rng.random::<R>()).collect::<Vec<_>>();
+    let exponents = (0..REPS).map(|_| rng.random::<u64>()).collect::<Vec<_>>();
+    let mut mul_input = input.clone();
+    let mut div_input = input;
+
+    c.bench_function(&format!("{name} mul_2exp_u64 runtime"), |b| {
+        b.iter(|| {
+            mul_input
+                .iter_mut()
+                .zip(&exponents)
+                .for_each(|(value, &exp)| *value = value.mul_2exp_u64(black_box(exp)));
+            black_box(mul_input.as_slice());
+        });
+    });
+    c.bench_function(&format!("{name} div_2exp_u64 runtime"), |b| {
+        b.iter(|| {
+            div_input
+                .iter_mut()
+                .zip(&exponents)
+                .for_each(|(value, &exp)| *value = value.div_2exp_u64(black_box(exp)));
+            black_box(div_input.as_slice());
+        });
+    });
+}
+
 fn bench_packedfield(c: &mut Criterion) {
     let name = type_name::<<F as Field>::Packing>().to_string();
     type PF = <F as Field>::Packing;
@@ -147,6 +207,12 @@ fn bench_packedfield(c: &mut Criterion) {
     benchmark_sub_throughput::<<F as Field>::Packing, REPS>(c, &name);
     benchmark_mul_latency::<<F as Field>::Packing, L_REPS>(c, &name);
     benchmark_mul_throughput::<<F as Field>::Packing, REPS>(c, &name);
+
+    benchmark_packed_fixed_power::<PF, REPS, 1>(c, &name);
+    benchmark_packed_fixed_power::<PF, REPS, 5>(c, &name);
+    benchmark_packed_fixed_power::<PF, REPS, 32>(c, &name);
+    benchmark_packed_fixed_power::<PF, REPS, 63>(c, &name);
+    benchmark_packed_runtime_powers::<PF, REPS>(c, &name);
 
     benchmark_dot_array::<<F as Field>::Packing, 1>(c, &name);
     benchmark_dot_array::<<F as Field>::Packing, 2>(c, &name);

--- a/goldilocks/benches/bench_field.rs
+++ b/goldilocks/benches/bench_field.rs
@@ -57,7 +57,10 @@ fn bench_field(c: &mut Criterion) {
     benchmark_mul_2exp::<F, REPS>(c, name, 63);
 
     benchmark_div_2exp::<F, REPS>(c, name, 1);
+    benchmark_div_2exp::<F, REPS>(c, name, 3);
+    benchmark_div_2exp::<F, REPS>(c, name, 5);
     benchmark_div_2exp::<F, REPS>(c, name, 10);
+    benchmark_div_2exp::<F, REPS>(c, name, 32);
 
     benchmark_neg_latency::<F, L_REPS>(c, name);
     benchmark_neg_throughput::<F, REPS>(c, name);

--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -51,7 +51,7 @@ fn bench_quintic_extension(c: &mut Criterion) {
 }
 
 fn bench_cubic_frobenius(c: &mut Criterion) {
-    let mut rng = SmallRng::seed_from_u64(0xF0B3_1A5);
+    let mut rng = SmallRng::seed_from_u64(0x0F0B_31A5);
     let inputs: [EF3; 64] = core::array::from_fn(|_| rng.random());
     c.bench_function(
         "CubicTrinomialExtensionField<Goldilocks> frobenius (varying inputs)",
@@ -68,7 +68,7 @@ fn bench_cubic_frobenius(c: &mut Criterion) {
 }
 
 fn bench_cubic_inverse(c: &mut Criterion) {
-    let mut rng = SmallRng::seed_from_u64(0x1A2B_125);
+    let mut rng = SmallRng::seed_from_u64(0x01A2_B125);
     let inputs: [EF3; 64] = core::array::from_fn(|_| rng.random());
     c.bench_function(
         "CubicTrinomialExtensionField<Goldilocks> inverse (varying inputs)",

--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -16,6 +16,7 @@ type EF3 = CubicTrinomialExtensionField<Goldilocks>;
 type EF5 = BinomialExtensionField<Goldilocks, 5>;
 type PEF2 = <EF2 as ExtensionField<Goldilocks>>::ExtensionPacking;
 type PEF3 = <EF3 as ExtensionField<Goldilocks>>::ExtensionPacking;
+type PEF5 = <EF5 as ExtensionField<Goldilocks>>::ExtensionPacking;
 
 // Note that each round of throughput has 10 operations
 // So we should have 10 * more repetitions for latency tests.
@@ -48,6 +49,10 @@ fn bench_quintic_extension(c: &mut Criterion) {
     benchmark_mul::<EF5>(c, name);
     benchmark_mul_throughput::<EF5, REPS>(c, name);
     benchmark_mul_latency::<EF5, L_REPS>(c, name);
+
+    let packed_name = "Packed BinomialExtensionField<Goldilocks, 5>";
+    benchmark_mul_throughput::<PEF5, REPS>(c, packed_name);
+    benchmark_mul_latency::<PEF5, L_REPS>(c, packed_name);
 }
 
 fn bench_cubic_frobenius(c: &mut Criterion) {

--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -2,7 +2,7 @@ use core::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use p3_field::extension::{BinomialExtensionField, CubicTrinomialExtensionField, HasFrobenius};
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::{ExtensionField, Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
 };
@@ -14,6 +14,8 @@ use rand::{RngExt, SeedableRng};
 type EF2 = BinomialExtensionField<Goldilocks, 2>;
 type EF3 = CubicTrinomialExtensionField<Goldilocks>;
 type EF5 = BinomialExtensionField<Goldilocks, 5>;
+type PEF2 = <EF2 as ExtensionField<Goldilocks>>::ExtensionPacking;
+type PEF3 = <EF3 as ExtensionField<Goldilocks>>::ExtensionPacking;
 
 // Note that each round of throughput has 10 operations
 // So we should have 10 * more repetitions for latency tests.
@@ -27,6 +29,16 @@ fn bench_quadratic_extension(c: &mut Criterion) {
     benchmark_mul::<EF2>(c, name);
     benchmark_mul_throughput::<EF2, REPS>(c, name);
     benchmark_mul_latency::<EF2, L_REPS>(c, name);
+
+    let packed_name = "Packed BinomialExtensionField<Goldilocks, 2>";
+    benchmark_mul_throughput::<PEF2, REPS>(c, packed_name);
+    benchmark_mul_latency::<PEF2, L_REPS>(c, packed_name);
+}
+
+fn bench_packed_cubic_extension(c: &mut Criterion) {
+    let name = "Packed CubicTrinomialExtensionField<Goldilocks>";
+    benchmark_mul_throughput::<PEF3, REPS>(c, name);
+    benchmark_mul_latency::<PEF3, L_REPS>(c, name);
 }
 
 fn bench_quintic_extension(c: &mut Criterion) {
@@ -75,6 +87,7 @@ fn bench_cubic_inverse(c: &mut Criterion) {
 criterion_group!(
     bench_goldilocks_ef,
     bench_quadratic_extension,
+    bench_packed_cubic_extension,
     bench_quintic_extension,
     bench_cubic_frobenius,
     bench_cubic_inverse

--- a/goldilocks/benches/extension.rs
+++ b/goldilocks/benches/extension.rs
@@ -1,12 +1,18 @@
+use core::hint::black_box;
+
 use criterion::{Criterion, criterion_group, criterion_main};
-use p3_field::extension::BinomialExtensionField;
+use p3_field::extension::{BinomialExtensionField, CubicTrinomialExtensionField, HasFrobenius};
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_field_testing::bench_func::{
     benchmark_inv, benchmark_mul_latency, benchmark_mul_throughput, benchmark_square,
 };
 use p3_field_testing::benchmark_mul;
 use p3_goldilocks::Goldilocks;
+use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 type EF2 = BinomialExtensionField<Goldilocks, 2>;
+type EF3 = CubicTrinomialExtensionField<Goldilocks>;
 type EF5 = BinomialExtensionField<Goldilocks, 5>;
 
 // Note that each round of throughput has 10 operations
@@ -32,9 +38,45 @@ fn bench_quintic_extension(c: &mut Criterion) {
     benchmark_mul_latency::<EF5, L_REPS>(c, name);
 }
 
+fn bench_cubic_frobenius(c: &mut Criterion) {
+    let mut rng = SmallRng::seed_from_u64(0xF0B3_1A5);
+    let inputs: [EF3; 64] = core::array::from_fn(|_| rng.random());
+    c.bench_function(
+        "CubicTrinomialExtensionField<Goldilocks> frobenius (varying inputs)",
+        |b| {
+            b.iter(|| {
+                let mut result = EF3::ZERO;
+                for &input in &inputs {
+                    result += black_box(input).frobenius();
+                }
+                black_box(result)
+            });
+        },
+    );
+}
+
+fn bench_cubic_inverse(c: &mut Criterion) {
+    let mut rng = SmallRng::seed_from_u64(0x1A2B_125);
+    let inputs: [EF3; 64] = core::array::from_fn(|_| rng.random());
+    c.bench_function(
+        "CubicTrinomialExtensionField<Goldilocks> inverse (varying inputs)",
+        |b| {
+            b.iter(|| {
+                let mut result = EF3::ZERO;
+                for &input in &inputs {
+                    result += black_box(input).inverse();
+                }
+                black_box(result)
+            });
+        },
+    );
+}
+
 criterion_group!(
     bench_goldilocks_ef,
     bench_quadratic_extension,
-    bench_quintic_extension
+    bench_quintic_extension,
+    bench_cubic_frobenius,
+    bench_cubic_inverse
 );
 criterion_main!(bench_goldilocks_ef);

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -119,6 +119,50 @@ impl PrimeCharacteristicRing for PackedGoldilocksNeon {
     }
 
     #[inline]
+    fn sum_array<const N: usize>(input: &[Self]) -> Self {
+        assert_eq!(N, input.len());
+        match N {
+            0 => Self::ZERO,
+            1 => input[0],
+            2 => input[0] + input[1],
+            3 => input[0] + input[1] + input[2],
+            4 => (input[0] + input[1]) + (input[2] + input[3]),
+            5 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<1>(&input[4..]),
+            6 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<2>(&input[4..]),
+            7 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<3>(&input[4..]),
+            8 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<4>(&input[4..]),
+            9..=63 => {
+                // Keep the existing eight-term trees for short sums: carry bookkeeping
+                // adds latency until enough independent work amortizes the final fold.
+                let mut acc = Self::sum_array::<8>(&input[..8]);
+                for i in (16..=N).step_by(8) {
+                    acc += Self::sum_array::<8>(&input[(i - 8)..i]);
+                }
+                let tail = &input[(8 * (N / 8))..];
+                match N & 7 {
+                    0 => acc,
+                    1 => acc + Self::sum_array::<1>(tail),
+                    2 => acc + Self::sum_array::<2>(tail),
+                    3 => acc + Self::sum_array::<3>(tail),
+                    4 => acc + Self::sum_array::<4>(tail),
+                    5 => acc + Self::sum_array::<5>(tail),
+                    6 => acc + Self::sum_array::<6>(tail),
+                    7 => acc + Self::sum_array::<7>(tail),
+                    _ => unreachable!(),
+                }
+            }
+            _ => {
+                let mut chunks = input.chunks(64);
+                let mut sum = sum_chunk(chunks.next().expect("N is nonzero"));
+                for chunk in chunks {
+                    sum += sum_chunk(chunk);
+                }
+                sum
+            }
+        }
+    }
+
+    #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
         Self::from_fn(|lane| {
             let lhs_lane: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].as_slice()[lane]);
@@ -152,6 +196,95 @@ impl_mul_base_field!(PackedGoldilocksNeon, Goldilocks);
 impl_div_methods!(PackedGoldilocksNeon, Goldilocks);
 impl_packed_field_div!(PackedGoldilocksNeon);
 impl_sum_prod_base_field!(PackedGoldilocksNeon, Goldilocks);
+
+/// Sum at most 64 raw u64 values per lane, delaying the Goldilocks fold.
+#[inline]
+fn sum_chunk(input: &[PackedGoldilocksNeon]) -> PackedGoldilocksNeon {
+    debug_assert!((1..=64).contains(&input.len()));
+    unsafe {
+        use core::arch::aarch64::{vcgtq_u64, vshlq_n_u64, vsraq_n_u64};
+
+        let zero = vdupq_n_u64(0);
+        let (lo, carries) = if input.len() < 4 {
+            // A short final chunk only needs one dependency chain.
+            let mut lo = input[0].to_vector();
+            let mut carries = zero;
+            for term in &input[1..] {
+                let next = vaddq_u64(lo, term.to_vector());
+                carries = vsubq_u64(carries, vcgtq_u64(lo, next));
+                lo = next;
+            }
+            (lo, carries)
+        } else {
+            let (groups, remainder) = input.as_chunks::<4>();
+            let (first, groups) = groups.split_first().unwrap();
+            let mut lo0 = first[0].to_vector();
+            let mut lo1 = first[1].to_vector();
+            let mut lo2 = first[2].to_vector();
+            let mut lo3 = first[3].to_vector();
+            let mut carries0 = zero;
+            let mut carries1 = zero;
+            let mut carries2 = zero;
+            let mut carries3 = zero;
+
+            // Keep four independent chains explicit, without an indexed accumulator array.
+            // Subtracting each all-ones overflow mask increments its exact wrap count.
+            for values in groups {
+                let next0 = vaddq_u64(lo0, values[0].to_vector());
+                carries0 = vsubq_u64(carries0, vcgtq_u64(lo0, next0));
+                lo0 = next0;
+
+                let next1 = vaddq_u64(lo1, values[1].to_vector());
+                carries1 = vsubq_u64(carries1, vcgtq_u64(lo1, next1));
+                lo1 = next1;
+
+                let next2 = vaddq_u64(lo2, values[2].to_vector());
+                carries2 = vsubq_u64(carries2, vcgtq_u64(lo2, next2));
+                lo2 = next2;
+
+                let next3 = vaddq_u64(lo3, values[3].to_vector());
+                carries3 = vsubq_u64(carries3, vcgtq_u64(lo3, next3));
+                lo3 = next3;
+            }
+
+            // Distribute the one-to-three remainder terms across distinct chains.
+            if let Some(value) = remainder.first() {
+                let next = vaddq_u64(lo0, value.to_vector());
+                carries0 = vsubq_u64(carries0, vcgtq_u64(lo0, next));
+                lo0 = next;
+            }
+            if let Some(value) = remainder.get(1) {
+                let next = vaddq_u64(lo1, value.to_vector());
+                carries1 = vsubq_u64(carries1, vcgtq_u64(lo1, next));
+                lo1 = next;
+            }
+            if let Some(value) = remainder.get(2) {
+                let next = vaddq_u64(lo2, value.to_vector());
+                carries2 = vsubq_u64(carries2, vcgtq_u64(lo2, next));
+                lo2 = next;
+            }
+
+            // Merge the exact states in a balanced tree. Include each low-word overflow
+            // alongside both input carry counts, so the final count is at most len - 1.
+            let lo01 = vaddq_u64(lo0, lo1);
+            let carries01 = vsubq_u64(vaddq_u64(carries0, carries1), vcgtq_u64(lo0, lo01));
+            let lo23 = vaddq_u64(lo2, lo3);
+            let carries23 = vsubq_u64(vaddq_u64(carries2, carries3), vcgtq_u64(lo2, lo23));
+            let lo = vaddq_u64(lo01, lo23);
+            let carries = vsubq_u64(vaddq_u64(carries01, carries23), vcgtq_u64(lo01, lo));
+            (lo, carries)
+        };
+
+        // The exact sum is lo + carries * 2^64, including noncanonical inputs.
+        // There are at most 63 carries, so correction = carries * EPSILON < P.
+        let correction = vsubq_u64(vshlq_n_u64::<32>(carries), carries);
+        let sum = vaddq_u64(lo, correction);
+        let overflow = vcgtq_u64(lo, sum);
+        // On overflow, sum <= correction - 1, so sum + EPSILON <= 64 * EPSILON - 1 < P.
+        // The all-ones overflow mask shifted right by 32 is exactly EPSILON.
+        PackedGoldilocksNeon::from_vector(vsraq_n_u64::<32>(sum, overflow))
+    }
+}
 
 impl Algebra<Goldilocks> for PackedGoldilocksNeon {
     // With the delayed-reduction dot product below, one 192-bit reduction is
@@ -597,6 +730,33 @@ mod tests {
                 "square residue lane {lane}: a={:#x}",
                 a[lane]
             );
+        }
+    }
+
+    #[test]
+    fn sum_chunk_carry_boundaries() {
+        for len in [1, 2, 3, 4, 9, 10, 11, 15, 16, 31, 32, 63, 64] {
+            for full_terms in 0..=len {
+                let input = (0..len)
+                    .map(|i| {
+                        PackedGoldilocksNeon(Goldilocks::new_array([
+                            if i < full_terms { u64::MAX } else { 0 },
+                            if i < full_terms { 1 } else { u64::MAX },
+                        ]))
+                    })
+                    .collect::<alloc::vec::Vec<_>>();
+                let actual = super::sum_chunk(&input);
+                for lane in 0..WIDTH {
+                    let expected = input.iter().fold(0u128, |sum, term| {
+                        (sum + u128::from(term.0[lane].value)) % u128::from(super::P)
+                    }) as u64;
+                    assert_eq!(
+                        actual.0[lane].value % super::P,
+                        expected,
+                        "len={len}, full_terms={full_terms}, lane={lane}"
+                    );
+                }
+            }
         }
     }
 

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use core::arch::aarch64::{
-    uint64x2_t, vaddq_u64, vandq_u64, vdupq_n_u64, vgetq_lane_u64, vsetq_lane_u64, vshrq_n_u64,
-    vsubq_u64,
+    uint64x2_t, vaddq_u64, vandq_u64, vcltq_u64, vdupq_n_s64, vdupq_n_u64, vgetq_lane_u64,
+    vsetq_lane_u64, vshlq_u64, vshrq_n_u64, vsubq_u64,
 };
 use core::fmt::Debug;
 use core::iter::{Product, Sum};
@@ -22,7 +22,6 @@ use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
 
-#[cfg(any(target_feature = "sve2", test))]
 use super::utils::EPSILON;
 use crate::{Goldilocks, P};
 
@@ -134,6 +133,18 @@ impl PrimeCharacteristicRing for PackedGoldilocksNeon {
         match exp {
             0 => *self,
             1 => self.halve(),
+            2..=32 => unsafe {
+                let x = self.to_vector();
+                let lo = vandq_u64(x, vdupq_n_u64((1u64 << exp) - 1));
+                let hi = vshlq_u64(x, vdupq_n_s64(-(exp as i64)));
+                let a = vaddq_u64(hi, vshlq_u64(lo, vdupq_n_s64((32 - exp) as i64)));
+                let b = vshlq_u64(lo, vdupq_n_s64((64 - exp) as i64));
+                // 2^-exp = 2^(32-exp) - 2^(64-exp) mod P. Both a and b are
+                // below P, so a - b > -P and one borrow correction suffices.
+                let borrow = vcltq_u64(a, b);
+                let correction = vandq_u64(borrow, vdupq_n_u64(EPSILON));
+                Self::from_vector(vsubq_u64(vsubq_u64(a, b), correction))
+            },
             _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
         }
     }

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -326,6 +326,17 @@ impl Algebra<Goldilocks> for PackedGoldilocksNeon {
     #[cfg(not(target_feature = "sve2"))]
     const BATCHED_LC_CHUNK: usize = 2;
 
+    #[cfg(target_feature = "sve2")]
+    #[inline]
+    fn batched_linear_combination(values: &[Self], coeffs: &[Goldilocks]) -> Self {
+        if values.len() <= 3 {
+            return p3_field::chunked_linear_combination::<64, Self, Goldilocks>(values, coeffs);
+        }
+        // Accumulate the whole slice, avoiding fixed-size reductions and a
+        // serial multiply-add tail. The driver validates matching lengths.
+        sve2_mixed_dot_delayed_with_chunk_limit(values, coeffs, u32::MAX as usize)
+    }
+
     #[inline]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
         #[cfg(target_feature = "sve2")]
@@ -364,24 +375,25 @@ fn sve2_mixed_dot_delayed<const N: usize>(
 
 #[cfg(target_feature = "sve2")]
 #[inline]
-fn sve2_mixed_dot_delayed_with_chunk_limit<const N: usize>(
-    a: &[PackedGoldilocksNeon; N],
-    f: &[Goldilocks; N],
+fn sve2_mixed_dot_delayed_with_chunk_limit(
+    a: &[PackedGoldilocksNeon],
+    f: &[Goldilocks],
     chunk_limit: usize,
 ) -> PackedGoldilocksNeon {
-    if N == 0 {
+    assert_eq!(a.len(), f.len());
+    if a.is_empty() {
         return PackedGoldilocksNeon::ZERO;
     }
     assert!((1..=u32::MAX as usize).contains(&chunk_limit));
 
-    if N <= chunk_limit {
-        // SAFETY: Both arrays contain N readable elements and N is nonzero and
-        // bounded by u32::MAX.
+    if a.len() <= chunk_limit {
+        // SAFETY: Both slices have the same nonzero length, bounded by
+        // chunk_limit <= u32::MAX.
         return unsafe { sve2_mixed_dot_chunk(a, f) };
     }
 
     let mut chunks = a.chunks(chunk_limit).zip(f.chunks(chunk_limit));
-    let (first_a, first_f) = chunks.next().expect("N is nonzero");
+    let (first_a, first_f) = chunks.next().expect("a is nonempty");
     // SAFETY: `chunks` produces equally sized, nonempty chunks no longer than
     // `chunk_limit`, which is bounded by u32::MAX above.
     let mut sum = unsafe { sve2_mixed_dot_chunk(first_a, first_f) };
@@ -818,6 +830,8 @@ mod tests {
 
 #[cfg(test)]
 mod mixed_dot_tests {
+    extern crate std;
+
     use p3_field::PrimeField64;
     use proptest::prelude::*;
     use rand::rngs::SmallRng;
@@ -826,19 +840,67 @@ mod mixed_dot_tests {
     use super::super::utils::tests::EDGE;
     use super::*;
 
-    /// Reference: canonicalize inputs, accumulate mod P in u128.
-    fn dot_ref<const N: usize>(
-        a: &[PackedGoldilocksNeon; N],
-        f: &[Goldilocks; N],
-        lane: usize,
-    ) -> u64 {
+    /// Independent raw-u64 reference; reduce each product before adding so
+    /// the u128 sum cannot overflow even for noncanonical inputs.
+    fn dot_ref(a: &[PackedGoldilocksNeon], f: &[Goldilocks], lane: usize) -> u64 {
         let mut acc: u128 = 0;
-        for i in 0..N {
-            let ai = a[i].as_slice()[lane].as_canonical_u64() as u128;
-            let fi = f[i].as_canonical_u64() as u128;
-            acc = (acc + ai * fi) % (P as u128);
+        for i in 0..a.len() {
+            let ai = a[i].as_slice()[lane].value as u128;
+            let fi = f[i].value as u128;
+            acc = (acc + ai * fi % (P as u128)) % (P as u128);
         }
         acc as u64
+    }
+
+    #[test]
+    fn batched_linear_combination_lengths_match_raw_reference() {
+        let mut rng = SmallRng::seed_from_u64(0x5E2_51CE);
+        for len in [0, 1, 2, 3, 4, 5, 6, 31, 32, 33, 63, 64, 65, 100, 129, 1024] {
+            for pattern in 0..3 {
+                let a = (0..len)
+                    .map(|i| {
+                        PackedGoldilocksNeon::from_fn(|lane| {
+                            Goldilocks::new(match pattern {
+                                0 => rng.random(),
+                                1 => EDGE[(i + 3 * lane) % EDGE.len()],
+                                _ => u64::MAX,
+                            })
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let f = (0..len)
+                    .map(|i| {
+                        Goldilocks::new(match pattern {
+                            0 => rng.random(),
+                            1 => EDGE[(i / EDGE.len()) % EDGE.len()],
+                            _ => u64::MAX,
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                let got = PackedGoldilocksNeon::batched_linear_combination(&a, &f);
+                for lane in 0..WIDTH {
+                    assert_eq!(
+                        got.as_slice()[lane].as_canonical_u64(),
+                        dot_ref(&a, &f, lane),
+                        "lane {lane}, len={len}, pattern={pattern}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn batched_linear_combination_rejects_mismatched_lengths() {
+        let a = [PackedGoldilocksNeon::ONE; 4];
+        let f = [Goldilocks::ONE; 4];
+        for (a_len, f_len) in [(0, 1), (1, 0), (2, 3), (3, 2)] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    PackedGoldilocksNeon::batched_linear_combination(&a[..a_len], &f[..f_len])
+                })
+                .is_err()
+            );
+        }
     }
 
     fn check_mixed_dot<const N: usize>(
@@ -980,11 +1042,13 @@ mod mixed_dot_tests {
     fn sve2_mixed_dot_forced_small_chunks_match_reference() {
         fn case<const N: usize>(seed: u64) {
             let mut rng = SmallRng::seed_from_u64(seed);
-            let a: [PackedGoldilocksNeon; N] = core::array::from_fn(|_| {
-                PackedGoldilocksNeon(Goldilocks::new_array([rng.random(), rng.random()]))
-            });
-            let f: [Goldilocks; N] = core::array::from_fn(|_| Goldilocks::new(rng.random()));
-            let got = sve2_mixed_dot_delayed_with_chunk_limit(&a, &f, 3);
+            let a = (0..N)
+                .map(|_| PackedGoldilocksNeon(Goldilocks::new_array([rng.random(), rng.random()])))
+                .collect::<Vec<_>>();
+            let f = (0..N)
+                .map(|_| Goldilocks::new(rng.random()))
+                .collect::<Vec<_>>();
+            let got = sve2_mixed_dot_delayed_with_chunk_limit(a.as_slice(), f.as_slice(), 3);
             for lane in 0..WIDTH {
                 assert_eq!(
                     got.as_slice()[lane].as_canonical_u64(),
@@ -1000,6 +1064,22 @@ mod mixed_dot_tests {
         case::<3>(3);
         case::<4>(4);
         case::<7>(7);
+        case::<100>(100);
+    }
+
+    #[cfg(target_feature = "sve2")]
+    #[test]
+    fn sve2_mixed_dot_slice_driver_rejects_mismatched_lengths() {
+        let a = [PackedGoldilocksNeon::ONE; 4];
+        let f = [Goldilocks::ONE; 4];
+        for (a_len, f_len) in [(0, 1), (1, 0), (2, 3), (3, 2), (3, 4), (4, 3)] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    sve2_mixed_dot_delayed_with_chunk_limit(&a[..a_len], &f[..f_len], 3)
+                })
+                .is_err()
+            );
+        }
     }
 
     proptest! {

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -22,6 +22,7 @@ use p3_util::reconstitute_from_base;
 use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
 
+#[cfg(any(target_feature = "sve2", test))]
 use super::utils::EPSILON;
 use crate::{Goldilocks, P};
 
@@ -401,59 +402,42 @@ unsafe fn mul_reduce_dual_asm(a0: u64, b0: u64, a1: u64, b1: u64) -> (u64, u64) 
             "umulh {hi0}, {a0}, {b0}",
             "umulh {hi1}, {a1}, {b1}",
 
-            // hi_hi = hi >> 32
-            "lsr   {hi_hi0}, {hi0}, #32",
-            "lsr   {hi_hi1}, {hi1}, #32",
-
-            // tmp = lo - hi_hi (with borrow handling)
-            "subs  {tmp0}, {lo0}, {hi_hi0}",
+            // lo -= hi >> 32, minus EPSILON on borrow.
+            "subs  {lo0}, {lo0}, {hi0}, lsr #32",
             "csetm {adj0:w}, cc",
-            "subs  {tmp1}, {lo1}, {hi_hi1}",
+            "subs  {lo1}, {lo1}, {hi1}, lsr #32",
             "csetm {adj1:w}, cc",
-            "sub   {tmp0}, {tmp0}, {adj0}",
-            "sub   {tmp1}, {tmp1}, {adj1}",
+            "sub   {lo0}, {lo0}, {adj0}",
+            "sub   {lo1}, {lo1}, {adj1}",
 
-            // hi_lo = hi & EPSILON
-            "and   {hi_lo0}, {hi0}, {epsilon}",
-            "and   {hi_lo1}, {hi1}, {epsilon}",
+            // Zero-extend hi_lo without another input register for EPSILON.
+            "mov   {hi0:w}, {hi0:w}",
+            "mov   {hi1:w}, {hi1:w}",
 
             // hi_lo_eps = (hi_lo << 32) - hi_lo (avoids multiply)
-            "lsl   {t0}, {hi_lo0}, #32",
-            "lsl   {t1}, {hi_lo1}, #32",
-            "sub   {hi_lo_eps0}, {t0}, {hi_lo0}",
-            "sub   {hi_lo_eps1}, {t1}, {hi_lo1}",
+            "lsl   {adj0}, {hi0}, #32",
+            "lsl   {adj1}, {hi1}, #32",
+            "sub   {hi0}, {adj0}, {hi0}",
+            "sub   {hi1}, {adj1}, {hi1}",
 
-            // result = tmp + hi_lo_eps (with overflow handling)
-            "adds  {result0}, {tmp0}, {hi_lo_eps0}",
+            // result = lo + hi_lo_eps (with overflow handling)
+            "adds  {lo0}, {lo0}, {hi0}",
             "csetm {adj0:w}, cs",
-            "adds  {result1}, {tmp1}, {hi_lo_eps1}",
+            "adds  {lo1}, {lo1}, {hi1}",
             "csetm {adj1:w}, cs",
-            "add   {result0}, {result0}, {adj0}",
-            "add   {result1}, {result1}, {adj1}",
+            "add   {lo0}, {lo0}, {adj0}",
+            "add   {lo1}, {lo1}, {adj1}",
 
             a0 = in(reg) a0,
             b0 = in(reg) b0,
             a1 = in(reg) a1,
             b1 = in(reg) b1,
-            epsilon = in(reg) EPSILON,
-            lo0 = out(reg) _,
-            lo1 = out(reg) _,
+            lo0 = out(reg) result0,
+            lo1 = out(reg) result1,
             hi0 = out(reg) _,
             hi1 = out(reg) _,
-            hi_hi0 = out(reg) _,
-            hi_hi1 = out(reg) _,
-            tmp0 = out(reg) _,
-            tmp1 = out(reg) _,
-            hi_lo0 = out(reg) _,
-            hi_lo1 = out(reg) _,
-            t0 = out(reg) _,
-            t1 = out(reg) _,
-            hi_lo_eps0 = out(reg) _,
-            hi_lo_eps1 = out(reg) _,
             adj0 = out(reg) _,
             adj1 = out(reg) _,
-            result0 = out(reg) result0,
-            result1 = out(reg) result1,
             options(pure, nomem, nostack),
         );
     }
@@ -484,9 +468,26 @@ fn square(x: uint64x2_t) -> uint64x2_t {
 
 #[cfg(test)]
 mod tests {
+    use p3_field::PrimeCharacteristicRing;
     use p3_field_testing::test_packed_field;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::{Goldilocks, PackedGoldilocksNeon, WIDTH};
+
+    const MUL_EDGE: [u64; 11] = [
+        0,
+        1,
+        2,
+        0xFFFF_FFFE,
+        0xFFFF_FFFF,
+        0x1_0000_0000,
+        0x8000_0000_0000_0000,
+        super::P - 1,
+        super::P,
+        super::P + 1,
+        u64::MAX,
+    ];
 
     const SPECIAL_VALS: [Goldilocks; WIDTH] =
         Goldilocks::new_array([0xFFFF_FFFF_0000_0000, 0xFFFF_FFFF_FFFF_FFFF]);
@@ -507,6 +508,80 @@ mod tests {
         &[super::ONES],
         crate::PackedGoldilocksNeon(super::SPECIAL_VALS)
     );
+
+    fn mul_reduce_reference(a: u64, b: u64) -> u64 {
+        let product = (a as u128) * (b as u128);
+        let lo = product as u64;
+        let hi = (product >> 64) as u64;
+
+        let (lo, borrow) = lo.overflowing_sub(hi >> 32);
+        let lo = lo.wrapping_sub(u64::from(borrow) * super::EPSILON);
+        let hi_lo = hi & 0xFFFF_FFFF;
+        let hi_lo_epsilon = (hi_lo << 32) - hi_lo;
+        let (result, overflow) = lo.overflowing_add(hi_lo_epsilon);
+        result.wrapping_add(u64::from(overflow) * super::EPSILON)
+    }
+
+    fn check_mul_and_square(a: [u64; WIDTH], b: [u64; WIDTH]) {
+        let lhs = PackedGoldilocksNeon(Goldilocks::new_array(a));
+        let rhs = PackedGoldilocksNeon(Goldilocks::new_array(b));
+
+        let mul = lhs * rhs;
+        let square = lhs.square();
+        for lane in 0..WIDTH {
+            let mul_raw = mul.0[lane].value;
+            let square_raw = square.0[lane].value;
+            let expected_mul = mul_reduce_reference(a[lane], b[lane]);
+            let expected_square = mul_reduce_reference(a[lane], a[lane]);
+            assert_eq!(
+                mul_raw, expected_mul,
+                "mul lane {lane}: a={:#x}, b={:#x}",
+                a[lane], b[lane]
+            );
+            assert_eq!(
+                square_raw, expected_square,
+                "square lane {lane}: a={:#x}",
+                a[lane]
+            );
+            assert_eq!(
+                mul_raw % super::P,
+                ((a[lane] as u128 * b[lane] as u128) % super::P as u128) as u64,
+                "mul residue lane {lane}: a={:#x}, b={:#x}",
+                a[lane],
+                b[lane]
+            );
+            assert_eq!(
+                square_raw % super::P,
+                ((a[lane] as u128 * a[lane] as u128) % super::P as u128) as u64,
+                "square residue lane {lane}: a={:#x}",
+                a[lane]
+            );
+        }
+    }
+
+    #[test]
+    fn mul_and_square_full_range_edges() {
+        for &a0 in &MUL_EDGE {
+            for &b0 in &MUL_EDGE {
+                for &a1 in &MUL_EDGE {
+                    for &b1 in &MUL_EDGE {
+                        check_mul_and_square([a0, a1], [b0, b1]);
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn mul_and_square_full_range_random() {
+        let mut rng = SmallRng::seed_from_u64(0xD0A1_1A0E);
+        for _ in 0..100_000 {
+            check_mul_and_square(
+                [rng.random::<u64>(), rng.random::<u64>()],
+                [rng.random::<u64>(), rng.random::<u64>()],
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -177,28 +177,72 @@ impl Algebra<Goldilocks> for PackedGoldilocksNeon {
 }
 
 /// `Σ a[i]·f[i]` with delayed reduction: 128-bit products accumulate unreduced
-/// per lane, and a single 192-bit reduction runs at the end. Coefficients
+/// per lane, and a single vector reduction runs at the end. Coefficients
 /// broadcast via `ld1rd`; products via SVE2 vector 64-bit `mul`/`umulh`.
 ///
 /// The loop keeps four per-lane accumulators: `lo` (Σ products mod 2^64), `hi`
 /// (Σ high halves mod 2^64), and exact wrap counts for each (`lo_w`, `hi_w`;
-/// both ≤ N, so they cannot themselves wrap). Folding `lo_w` into `hi` with
-/// checked scalar arithmetic afterwards makes the accumulation exact for any
-/// `N` and any inputs — no probabilistic carry argument.
+/// both < the chunk length). Chunks contain at most `u32::MAX` products, so the
+/// carry above bit 127 is at most `u32::MAX - 1` and its final `c << 32` fold
+/// cannot overflow.
 ///
-/// All loads, stores, and pointer steps are fixed to the low two lanes
-/// (`ptrue vl2`, 16-byte steps), so the routine is correct at any SVE vector
-/// length; wider lanes are loaded as zero and never stored.
+/// All loads and pointer steps are fixed to the low two lanes (`ptrue vl2`,
+/// 16-byte packed steps and 8-byte scalar steps), so the routine is correct at
+/// any SVE vector length; wider lanes are loaded as zero and ignored.
 #[cfg(target_feature = "sve2")]
 #[inline]
 fn sve2_mixed_dot_delayed<const N: usize>(
     a: &[PackedGoldilocksNeon; N],
     f: &[Goldilocks; N],
 ) -> PackedGoldilocksNeon {
+    sve2_mixed_dot_delayed_with_chunk_limit(a, f, u32::MAX as usize)
+}
+
+#[cfg(target_feature = "sve2")]
+#[inline]
+fn sve2_mixed_dot_delayed_with_chunk_limit<const N: usize>(
+    a: &[PackedGoldilocksNeon; N],
+    f: &[Goldilocks; N],
+    chunk_limit: usize,
+) -> PackedGoldilocksNeon {
     if N == 0 {
         return PackedGoldilocksNeon::ZERO;
     }
-    let mut acc = [0u64; 8]; // [lo, hi, hi_wraps, lo_wraps] × 2 lanes
+    assert!((1..=u32::MAX as usize).contains(&chunk_limit));
+
+    if N <= chunk_limit {
+        // SAFETY: Both arrays contain N readable elements and N is nonzero and
+        // bounded by u32::MAX.
+        return unsafe { sve2_mixed_dot_chunk(a, f) };
+    }
+
+    let mut chunks = a.chunks(chunk_limit).zip(f.chunks(chunk_limit));
+    let (first_a, first_f) = chunks.next().expect("N is nonzero");
+    // SAFETY: `chunks` produces equally sized, nonempty chunks no longer than
+    // `chunk_limit`, which is bounded by u32::MAX above.
+    let mut sum = unsafe { sve2_mixed_dot_chunk(first_a, first_f) };
+    for (a_chunk, f_chunk) in chunks {
+        // SAFETY: Same invariants as the first chunk.
+        sum += unsafe { sve2_mixed_dot_chunk(a_chunk, f_chunk) };
+    }
+    sum
+}
+
+/// Accumulate one chunk of products without intermediate field reductions.
+///
+/// # Safety
+///
+/// Both slices must have the same nonzero length, at most `u32::MAX`.
+#[cfg(target_feature = "sve2")]
+#[inline]
+unsafe fn sve2_mixed_dot_chunk(
+    a: &[PackedGoldilocksNeon],
+    f: &[Goldilocks],
+) -> PackedGoldilocksNeon {
+    let lo: uint64x2_t;
+    let hi_raw: uint64x2_t;
+    let hi_wraps: uint64x2_t;
+    let lo_wraps: uint64x2_t;
     unsafe {
         core::arch::asm!(
             "ptrue p7.d, vl2",
@@ -222,58 +266,49 @@ fn sve2_mixed_dot_delayed<const N: usize>(
             "add   {fp}, {fp}, #8",
             "subs  {cnt}, {cnt}, #1",
             "b.ne  2b",
-            "st1d  {{ z0.d }}, p7, [{op}]",
-            "add   {op}, {op}, #16",
-            "st1d  {{ z1.d }}, p7, [{op}]",
-            "add   {op}, {op}, #16",
-            "st1d  {{ z2.d }}, p7, [{op}]",
-            "add   {op}, {op}, #16",
-            "st1d  {{ z3.d }}, p7, [{op}]",
             ap = inout(reg) a.as_ptr() as *const u64 => _,
             fp = inout(reg) f.as_ptr() as *const u64 => _,
-            op = inout(reg) acc.as_mut_ptr() => _,
-            cnt = inout(reg) N => _,
-            out("v0") _, out("v1") _, out("v2") _, out("v3") _, out("v4") _,
+            cnt = inout(reg) a.len() => _,
+            out("v0") lo,
+            out("v1") hi_raw,
+            out("v2") hi_wraps,
+            out("v3") lo_wraps,
+            out("v4") _,
             out("v5") _, out("v6") _, out("v7") _, out("v31") _,
             out("p1") _, out("p2") _, out("p7") _,
-            options(nostack),
+            options(readonly, nostack),
         );
     }
-    PackedGoldilocksNeon::from_fn(|lane| {
-        let (lo, hi_raw) = (acc[lane], acc[2 + lane]);
-        let (hi_wraps, lo_wraps) = (acc[4 + lane], acc[6 + lane]);
-        let (hi, c) = hi_raw.overflowing_add(lo_wraps);
-        reduce192(lo, hi, hi_wraps + c as u64)
-    })
+    PackedGoldilocksNeon::from_vector(reduce_sve2_dot_accumulators(lo, hi_raw, hi_wraps, lo_wraps))
 }
 
-/// Reduce `carry·2^128 + hi·2^64 + lo` to a Goldilocks element, using
-/// `2^64 ≡ ε` and `2^128 ≡ ε² ≡ P − 2^32 (mod P)` — two shift-epsilon folds,
-/// no 128-bit division.
-#[cfg(target_feature = "sve2")]
+/// Reduce the four exact accumulator limbs for one bounded SVE2 dot chunk.
+///
+/// The caller must ensure the resulting top carry is at most
+/// `u32::MAX - 1`; `sve2_mixed_dot_chunk` establishes this via its length cap.
+#[cfg(any(target_feature = "sve2", test))]
 #[inline]
-fn reduce192(lo: u64, hi: u64, carry: u64) -> Goldilocks {
-    const EPS2_MOD_P: u64 = P - (1 << 32); // ε² mod P
-    // Fold hi: t ≡ hi·2^64 + lo (mod P), t < 2^96.
-    let t = (hi as u128) * (EPSILON as u128) + lo as u128;
-    let (t_lo, t_hi) = (t as u64, (t >> 64) as u64); // t_hi ≤ ε
-    // r ≡ t_hi·2^64 + t_lo (mod P); t_hi·ε ≤ ε², so the wrap fix cannot re-wrap.
-    let (mut r, c) = t_lo.overflowing_add(t_hi * EPSILON);
-    if c {
-        r = r.wrapping_add(EPSILON);
+fn reduce_sve2_dot_accumulators(
+    lo: uint64x2_t,
+    hi_raw: uint64x2_t,
+    hi_wraps: uint64x2_t,
+    lo_wraps: uint64x2_t,
+) -> uint64x2_t {
+    unsafe {
+        use core::arch::aarch64::vcgtq_u64;
+
+        // Fold the low-word wraps into the high word. A true comparison mask
+        // is all ones, so subtracting it adds the possible extra top carry.
+        let hi = vaddq_u64(hi_raw, lo_wraps);
+        let extra = vcgtq_u64(hi_raw, hi);
+        let carry = vsubq_u64(hi_wraps, extra);
+
+        let reduced = reduce128_vector(lo, hi);
+        // 2^128 ≡ -2^32 (mod P). The chunk bound makes this correction < P.
+        let correction = core::arch::aarch64::vshlq_n_u64::<32>(carry);
+        let borrow = vcgtq_u64(correction, reduced);
+        vsubq_u64(vsubq_u64(reduced, correction), vshrq_n_u64::<32>(borrow))
     }
-    // Fold carry the same way via carry·2^128 ≡ carry·(ε² mod P). Here
-    // u_hi ≤ carry, so the wrap fix cannot re-wrap while carry < 2^32 − 1
-    // (callers pass carry ≤ N + 1, a slice length).
-    debug_assert!(carry < (1 << 32) - 1, "reduce192 carry bound violated");
-    let u = (carry as u128) * (EPS2_MOD_P as u128) + r as u128;
-    let (u_lo, u_hi) = (u as u64, (u >> 64) as u64);
-    let (mut v, c2) = u_lo.overflowing_add(u_hi * EPSILON);
-    if c2 {
-        v = v.wrapping_add(EPSILON);
-    }
-    // v is a valid, not necessarily canonical, representative.
-    Goldilocks::new(v)
 }
 
 impl_packed_value!(PackedGoldilocksNeon, Goldilocks, WIDTH);
@@ -339,7 +374,6 @@ pub(crate) fn halve(input: uint64x2_t) -> uint64x2_t {
 #[inline]
 fn mul(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
     unsafe {
-        use core::arch::aarch64::{vcgtq_u64, vmlal_n_u32, vmovn_u64, vsraq_n_u64};
         use core::arch::asm;
         let lo: uint64x2_t;
         let hi: uint64x2_t;
@@ -353,19 +387,26 @@ fn mul(x: uint64x2_t, y: uint64x2_t) -> uint64x2_t {
             options(pure, nomem, nostack),
         );
 
-        // Reduction with the plonky2-NEON idioms: `vmlal_n_u32` folds hi_lo·ε into
-        // the accumulator in one op; `vsraq` (mask ≫ 32 = ε) applies each rare
-        // wraparound correction in one op. ~9 vector ops vs 13 for the naive form.
-        // t1 = lo − hi_hi, minus ε on per-lane borrow (2^64 ≡ ε mod P).
+        reduce128_vector(lo, hi)
+    }
+}
+
+/// Reduce `hi·2^64 + lo` using the established vector Goldilocks fold.
+#[cfg(any(target_feature = "sve2", test))]
+#[inline(always)]
+fn reduce128_vector(lo: uint64x2_t, hi: uint64x2_t) -> uint64x2_t {
+    unsafe {
+        use core::arch::aarch64::{vcgtq_u64, vmlal_n_u32, vmovn_u64, vsraq_n_u64};
+
+        // `vmlal_n_u32` folds hi_lo·ε into the accumulator in one op; `vsraq`
+        // (mask ≫ 32 = ε) applies each rare wraparound correction in one op.
         let hi_hi = vshrq_n_u64::<32>(hi);
         let borrow = vcgtq_u64(hi_hi, lo);
         let t1 = vsubq_u64(vsubq_u64(lo, hi_hi), vshrq_n_u64::<32>(borrow));
-        // res = t1 + hi_lo·ε via widening multiply-accumulate.
         let hi_lo32 = vmovn_u64(hi);
         let res = vmlal_n_u32(t1, hi_lo32, EPSILON as u32);
-        // += ε on per-lane overflow (res wrapped iff res < t1).
-        let ovf = vcgtq_u64(t1, res);
-        vsraq_n_u64::<32>(res, ovf)
+        let overflow = vcgtq_u64(t1, res);
+        vsraq_n_u64::<32>(res, overflow)
     }
 }
 
@@ -656,11 +697,118 @@ mod mixed_dot_tests {
         case::<1>(1);
         case::<2>(2);
         case::<3>(3);
+        case::<4>(4);
         case::<5>(5);
+        case::<6>(6);
+        case::<16>(16);
         case::<63>(63);
         case::<64>(64);
         case::<65>(65);
         case::<129>(129);
+    }
+
+    fn reduce_accumulators_ref(lo: u64, hi_raw: u64, hi_wraps: u64, lo_wraps: u64) -> u64 {
+        const P128: u128 = P as u128;
+        let two64 = (u64::MAX as u128 + 1) % P128;
+        let two128 = two64 * two64 % P128;
+        let limbs = [
+            lo as u128 % P128,
+            (hi_raw as u128 % P128) * two64 % P128,
+            (lo_wraps as u128 % P128) * two64 % P128,
+            (hi_wraps as u128 % P128) * two128 % P128,
+        ];
+        limbs.into_iter().fold(0, |sum, limb| (sum + limb) % P128) as u64
+    }
+
+    fn check_vector_reducer(
+        lo: [u64; WIDTH],
+        hi_raw: [u64; WIDTH],
+        hi_wraps: [u64; WIDTH],
+        lo_wraps: [u64; WIDTH],
+    ) {
+        let got = PackedGoldilocksNeon::from_vector(reduce_sve2_dot_accumulators(
+            unsafe { core::mem::transmute::<[u64; WIDTH], uint64x2_t>(lo) },
+            unsafe { core::mem::transmute::<[u64; WIDTH], uint64x2_t>(hi_raw) },
+            unsafe { core::mem::transmute::<[u64; WIDTH], uint64x2_t>(hi_wraps) },
+            unsafe { core::mem::transmute::<[u64; WIDTH], uint64x2_t>(lo_wraps) },
+        ));
+        for lane in 0..WIDTH {
+            assert_eq!(
+                got.as_slice()[lane].as_canonical_u64(),
+                reduce_accumulators_ref(lo[lane], hi_raw[lane], hi_wraps[lane], lo_wraps[lane]),
+                "lane {lane}: lo={:#x} hi_raw={:#x} hi_wraps={:#x} lo_wraps={:#x}",
+                lo[lane],
+                hi_raw[lane],
+                hi_wraps[lane],
+                lo_wraps[lane]
+            );
+        }
+    }
+
+    #[test]
+    fn sve2_dot_reducer_matches_weighted_limb_reference() {
+        const MAX_CARRY: u64 = (1 << 32) - 2;
+        for &lo in &EDGE {
+            for &hi in &EDGE {
+                for &carry in &[0, 1, MAX_CARRY] {
+                    check_vector_reducer([lo, hi], [hi, lo], [carry, carry], [0, 0]);
+                }
+            }
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x5E2_D07);
+        for _ in 0..100_000 {
+            check_vector_reducer(
+                [rng.random(), rng.random()],
+                [rng.random(), rng.random()],
+                [
+                    (rng.random::<u32>() as u64) % MAX_CARRY,
+                    (rng.random::<u32>() as u64) % MAX_CARRY,
+                ],
+                [
+                    (rng.random::<u32>() as u64) % (MAX_CARRY + 1),
+                    (rng.random::<u32>() as u64) % (MAX_CARRY + 1),
+                ],
+            );
+        }
+    }
+
+    #[test]
+    fn sve2_dot_reducer_handles_hi_fold_overflow() {
+        const MAX_CARRY: u64 = (1 << 32) - 2;
+        check_vector_reducer(
+            [0, u64::MAX],
+            [u64::MAX, u64::MAX - 5],
+            [0, MAX_CARRY - 1],
+            [1, 10],
+        );
+    }
+
+    #[cfg(target_feature = "sve2")]
+    #[test]
+    fn sve2_mixed_dot_forced_small_chunks_match_reference() {
+        fn case<const N: usize>(seed: u64) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let a: [PackedGoldilocksNeon; N] = core::array::from_fn(|_| {
+                PackedGoldilocksNeon(Goldilocks::new_array([rng.random(), rng.random()]))
+            });
+            let f: [Goldilocks; N] = core::array::from_fn(|_| Goldilocks::new(rng.random()));
+            let got = sve2_mixed_dot_delayed_with_chunk_limit(&a, &f, 3);
+            for lane in 0..WIDTH {
+                assert_eq!(
+                    got.as_slice()[lane].as_canonical_u64(),
+                    dot_ref(&a, &f, lane),
+                    "lane {lane}, N={N}"
+                );
+            }
+        }
+
+        case::<0>(0);
+        case::<1>(1);
+        case::<2>(2);
+        case::<3>(3);
+        case::<4>(4);
+        case::<7>(7);
     }
 
     proptest! {
@@ -680,42 +828,6 @@ mod mixed_dot_tests {
                     dot_ref(&packed, &coeffs, lane)
                 );
             }
-        }
-    }
-
-    #[cfg(target_feature = "sve2")]
-    #[test]
-    fn reduce192_matches_reference() {
-        fn reference(lo: u64, hi: u64, carry: u64) -> u64 {
-            const P128: u128 = P as u128;
-            let two64 = (u64::MAX as u128 + 1) % P128;
-            let two128 = two64 * two64 % P128;
-            let total =
-                lo as u128 % P128 + (hi as u128) * two64 % P128 + (carry as u128) * two128 % P128;
-            (total % P128) as u64
-        }
-
-        let mut rng = SmallRng::seed_from_u64(0x192);
-        for _ in 0..100_000 {
-            let (lo, hi): (u64, u64) = (rng.random(), rng.random());
-            // Callers pass carry ≤ N + 1; test the documented domain boundary.
-            let carry = rng.random::<u64>() % ((1 << 32) - 1);
-            assert_eq!(
-                reduce192(lo, hi, carry).as_canonical_u64(),
-                reference(lo, hi, carry),
-                "lo={lo:#x} hi={hi:#x} carry={carry:#x}"
-            );
-        }
-        for &(lo, hi, carry) in &[
-            (0, 0, 0),
-            (u64::MAX, u64::MAX, (1 << 32) - 2),
-            (P, P, 1),
-            (u64::MAX, 0, 0),
-        ] {
-            assert_eq!(
-                reduce192(lo, hi, carry).as_canonical_u64(),
-                reference(lo, hi, carry)
-            );
         }
     }
 }

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -195,6 +195,10 @@ impl PrimeCharacteristicRing for PackedGoldilocksNeon {
 
     #[inline]
     fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
+        #[cfg(target_feature = "sve2")]
+        if N >= 32 {
+            return sve2_packed_dot_delayed_with_chunk_limit(lhs, rhs, u32::MAX as usize);
+        }
         Self::from_fn(|lane| {
             let lhs_lane: [Goldilocks; N] = core::array::from_fn(|i| lhs[i].as_slice()[lane]);
             let rhs_lane: [Goldilocks; N] = core::array::from_fn(|i| rhs[i].as_slice()[lane]);
@@ -389,17 +393,48 @@ fn sve2_mixed_dot_delayed_with_chunk_limit(
     if a.len() <= chunk_limit {
         // SAFETY: Both slices have the same nonzero length, bounded by
         // chunk_limit <= u32::MAX.
-        return unsafe { sve2_mixed_dot_chunk(a, f) };
+        return unsafe { sve2_dot_chunk::<false>(a, f.as_ptr().cast()) };
     }
 
     let mut chunks = a.chunks(chunk_limit).zip(f.chunks(chunk_limit));
     let (first_a, first_f) = chunks.next().expect("a is nonempty");
     // SAFETY: `chunks` produces equally sized, nonempty chunks no longer than
     // `chunk_limit`, which is bounded by u32::MAX above.
-    let mut sum = unsafe { sve2_mixed_dot_chunk(first_a, first_f) };
+    let mut sum = unsafe { sve2_dot_chunk::<false>(first_a, first_f.as_ptr().cast()) };
     for (a_chunk, f_chunk) in chunks {
         // SAFETY: Same invariants as the first chunk.
-        sum += unsafe { sve2_mixed_dot_chunk(a_chunk, f_chunk) };
+        sum += unsafe { sve2_dot_chunk::<false>(a_chunk, f_chunk.as_ptr().cast()) };
+    }
+    sum
+}
+
+#[cfg(target_feature = "sve2")]
+#[inline]
+fn sve2_packed_dot_delayed_with_chunk_limit(
+    lhs: &[PackedGoldilocksNeon],
+    rhs: &[PackedGoldilocksNeon],
+    chunk_limit: usize,
+) -> PackedGoldilocksNeon {
+    assert_eq!(lhs.len(), rhs.len());
+    if lhs.is_empty() {
+        return PackedGoldilocksNeon::ZERO;
+    }
+    assert!((1..=u32::MAX as usize).contains(&chunk_limit));
+
+    if lhs.len() <= chunk_limit {
+        // SAFETY: Both slices have the same nonzero length, bounded by
+        // u32::MAX, and rhs contains that many readable two-lane packed values.
+        return unsafe { sve2_dot_chunk::<true>(lhs, rhs.as_ptr().cast()) };
+    }
+
+    let mut chunks = lhs.chunks(chunk_limit).zip(rhs.chunks(chunk_limit));
+    let (first_lhs, first_rhs) = chunks.next().expect("lhs is nonempty");
+    // SAFETY: Equal-length typed slices produce equally sized, nonempty chunks
+    // of at most u32::MAX readable packed values.
+    let mut sum = unsafe { sve2_dot_chunk::<true>(first_lhs, first_rhs.as_ptr().cast()) };
+    for (lhs_chunk, rhs_chunk) in chunks {
+        // SAFETY: Same invariants as the first chunk.
+        sum += unsafe { sve2_dot_chunk::<true>(lhs_chunk, rhs_chunk.as_ptr().cast()) };
     }
     sum
 }
@@ -408,52 +443,65 @@ fn sve2_mixed_dot_delayed_with_chunk_limit(
 ///
 /// # Safety
 ///
-/// Both slices must have the same nonzero length, at most `u32::MAX`.
+/// `a` must have nonzero length, at most `u32::MAX`. `rhs` must point to at
+/// least `a.len()` readable two-u64 packed values when `PACKED_RHS` is true,
+/// or `a.len()` readable u64 scalars otherwise. Loads and byte strides are
+/// fixed to these representations, independently of the hardware SVE length.
 #[cfg(target_feature = "sve2")]
 #[inline]
-unsafe fn sve2_mixed_dot_chunk(
+unsafe fn sve2_dot_chunk<const PACKED_RHS: bool>(
     a: &[PackedGoldilocksNeon],
-    f: &[Goldilocks],
+    rhs: *const u64,
 ) -> PackedGoldilocksNeon {
     let lo: uint64x2_t;
     let hi_raw: uint64x2_t;
     let hi_wraps: uint64x2_t;
     let lo_wraps: uint64x2_t;
+    macro_rules! accumulate {
+        ($rhs_load:literal, $rhs_stride:literal) => {
+            core::arch::asm!(
+                "ptrue p7.d, vl2",
+                "dup   z0.d, #0",
+                "dup   z1.d, #0",
+                "dup   z2.d, #0",
+                "dup   z3.d, #0",
+                "dup   z31.d, #1",
+                "2:",
+                "ld1d  {{ z4.d }}, p7/z, [{ap}]",
+                $rhs_load,
+                "mul   z6.d, z4.d, z5.d",
+                "umulh z7.d, z4.d, z5.d",
+                "add   z0.d, z0.d, z6.d",
+                "cmplo p1.d, p7/z, z0.d, z6.d",
+                "add   z3.d, p1/m, z3.d, z31.d",
+                "add   z1.d, z1.d, z7.d",
+                "cmplo p2.d, p7/z, z1.d, z7.d",
+                "add   z2.d, p2/m, z2.d, z31.d",
+                "add   {ap}, {ap}, #16",
+                "add   {fp}, {fp}, #{rhs_stride}",
+                "subs  {cnt}, {cnt}, #1",
+                "b.ne  2b",
+                ap = inout(reg) a.as_ptr() as *const u64 => _,
+                fp = inout(reg) rhs => _,
+                cnt = inout(reg) a.len() => _,
+                rhs_stride = const $rhs_stride,
+                out("v0") lo,
+                out("v1") hi_raw,
+                out("v2") hi_wraps,
+                out("v3") lo_wraps,
+                out("v4") _,
+                out("v5") _, out("v6") _, out("v7") _, out("v31") _,
+                out("p1") _, out("p2") _, out("p7") _,
+                options(readonly, nostack),
+            );
+        };
+    }
     unsafe {
-        core::arch::asm!(
-            "ptrue p7.d, vl2",
-            "dup   z0.d, #0",
-            "dup   z1.d, #0",
-            "dup   z2.d, #0",
-            "dup   z3.d, #0",
-            "dup   z31.d, #1",
-            "2:",
-            "ld1d  {{ z4.d }}, p7/z, [{ap}]",
-            "ld1rd {{ z5.d }}, p7/z, [{fp}]",
-            "mul   z6.d, z4.d, z5.d",
-            "umulh z7.d, z4.d, z5.d",
-            "add   z0.d, z0.d, z6.d",
-            "cmplo p1.d, p7/z, z0.d, z6.d",
-            "add   z3.d, p1/m, z3.d, z31.d",
-            "add   z1.d, z1.d, z7.d",
-            "cmplo p2.d, p7/z, z1.d, z7.d",
-            "add   z2.d, p2/m, z2.d, z31.d",
-            "add   {ap}, {ap}, #16",
-            "add   {fp}, {fp}, #8",
-            "subs  {cnt}, {cnt}, #1",
-            "b.ne  2b",
-            ap = inout(reg) a.as_ptr() as *const u64 => _,
-            fp = inout(reg) f.as_ptr() as *const u64 => _,
-            cnt = inout(reg) a.len() => _,
-            out("v0") lo,
-            out("v1") hi_raw,
-            out("v2") hi_wraps,
-            out("v3") lo_wraps,
-            out("v4") _,
-            out("v5") _, out("v6") _, out("v7") _, out("v31") _,
-            out("p1") _, out("p2") _, out("p7") _,
-            options(readonly, nostack),
-        );
+        if PACKED_RHS {
+            accumulate!("ld1d  {{ z5.d }}, p7/z, [{fp}]", 16);
+        } else {
+            accumulate!("ld1rd {{ z5.d }}, p7/z, [{fp}]", 8);
+        }
     }
     PackedGoldilocksNeon::from_vector(reduce_sve2_dot_accumulators(lo, hi_raw, hi_wraps, lo_wraps))
 }
@@ -461,7 +509,7 @@ unsafe fn sve2_mixed_dot_chunk(
 /// Reduce the four exact accumulator limbs for one bounded SVE2 dot chunk.
 ///
 /// The caller must ensure the resulting top carry is at most
-/// `u32::MAX - 1`; `sve2_mixed_dot_chunk` establishes this via its length cap.
+/// `u32::MAX - 1`; `sve2_dot_chunk` establishes this via its length cap.
 #[cfg(any(target_feature = "sve2", test))]
 #[inline]
 fn reduce_sve2_dot_accumulators(
@@ -1065,6 +1113,54 @@ mod mixed_dot_tests {
         case::<4>(4);
         case::<7>(7);
         case::<100>(100);
+    }
+
+    #[cfg(target_feature = "sve2")]
+    #[test]
+    fn sve2_packed_dot_forced_small_chunks_match_reference() {
+        let mut rng = SmallRng::seed_from_u64(0x0005_E29B);
+        for len in [0, 1, 2, 3, 4, 5, 6, 7, 16, 64, 129] {
+            for maximum in [false, true] {
+                let mut inputs = || {
+                    (0..len)
+                        .map(|_| {
+                            PackedGoldilocksNeon::from_fn(|_| {
+                                Goldilocks::new(if maximum { u64::MAX } else { rng.random() })
+                            })
+                        })
+                        .collect::<Vec<_>>()
+                };
+                let lhs = inputs();
+                let rhs = inputs();
+                let got = sve2_packed_dot_delayed_with_chunk_limit(&lhs, &rhs, 3);
+                for lane in 0..WIDTH {
+                    let coeffs = rhs.iter().map(|v| v.as_slice()[lane]).collect::<Vec<_>>();
+                    assert_eq!(
+                        got.as_slice()[lane].as_canonical_u64(),
+                        dot_ref(&lhs, &coeffs, lane),
+                        "lane {lane}, len={len}, maximum={maximum}"
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(target_feature = "sve2")]
+    #[test]
+    fn sve2_packed_dot_slice_driver_rejects_mismatched_lengths() {
+        let values = [PackedGoldilocksNeon::ONE; 4];
+        for (lhs_len, rhs_len) in [(0, 1), (1, 0), (2, 3), (3, 2), (3, 4), (4, 3)] {
+            assert!(
+                std::panic::catch_unwind(|| {
+                    sve2_packed_dot_delayed_with_chunk_limit(
+                        &values[..lhs_len],
+                        &values[..rhs_len],
+                        3,
+                    )
+                })
+                .is_err()
+            );
+        }
     }
 
     #[cfg(target_feature = "sve2")]

--- a/goldilocks/src/aarch64_neon/packing.rs
+++ b/goldilocks/src/aarch64_neon/packing.rs
@@ -119,6 +119,26 @@ impl PrimeCharacteristicRing for PackedGoldilocksNeon {
     }
 
     #[inline]
+    fn mul_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.double(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(exp)),
+        }
+    }
+
+    #[inline]
+    fn div_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.halve(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
+        }
+    }
+
+    #[inline]
     fn sum_array<const N: usize>(input: &[Self]) -> Self {
         assert_eq!(N, input.len());
         match N {

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -217,12 +217,14 @@ mod test_quadratic_extension {
 mod test_cubic_trinomial_extension {
 
     use num_bigint::BigUint;
-    use p3_field::extension::CubicTrinomialExtensionField;
+    use p3_field::extension::{CubicTrinomialExtensionField, HasFrobenius};
     use p3_field::{ExtensionField, PrimeCharacteristicRing};
     use p3_field_testing::{
         test_extension_field, test_field, test_frobenius, test_packed_extension_field,
         test_two_adic_extension_field,
     };
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use crate::Goldilocks;
 
@@ -253,6 +255,31 @@ mod test_cubic_trinomial_extension {
         let x_cubed = x * x * x;
         let x_plus_one = x + EF::ONE;
         assert_eq!(x_cubed, x_plus_one, "X^3 should equal X + 1");
+    }
+
+    #[test]
+    fn test_frobenius_matches_exponentiation_oracle() {
+        const P: u64 = 0xFFFF_FFFF_0000_0001;
+
+        let edge_values = [0, 1, P - 1, P, P + 1, u64::MAX];
+        for a0 in edge_values {
+            for a1 in edge_values {
+                for a2 in edge_values {
+                    let x = EF::new([F::new(a0), F::new(a1), F::new(a2)]);
+                    assert_eq!(x.frobenius(), x.exp_u64(P), "x = {x:?}");
+                }
+            }
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0xF0B3_1A5);
+        for _ in 0..128 {
+            let x = EF::new([
+                F::new(rng.random()),
+                F::new(rng.random()),
+                F::new(rng.random()),
+            ]);
+            assert_eq!(x.frobenius(), x.exp_u64(P), "x = {x:?}");
+        }
     }
 
     test_field!(

--- a/goldilocks/src/extension.rs
+++ b/goldilocks/src/extension.rs
@@ -271,7 +271,7 @@ mod test_cubic_trinomial_extension {
             }
         }
 
-        let mut rng = SmallRng::seed_from_u64(0xF0B3_1A5);
+        let mut rng = SmallRng::seed_from_u64(0x0F0B_31A5);
         for _ in 0..128 {
             let x = EF::new([
                 F::new(rng.random()),

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -16,8 +16,8 @@ use p3_field::op_assign_macros::{
 use p3_field::{
     Field, InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField64, RawDataSerializable, TwoAdicField, UniformSamplingField,
-    impl_raw_serializable_primefield64, quotient_map_large_iint, quotient_map_large_uint,
-    quotient_map_small_int, tonelli_shanks_two_adic,
+    impl_raw_serializable_primefield64, quotient_map_large_iint, quotient_map_small_int,
+    tonelli_shanks_two_adic,
 };
 use p3_util::{branch_hint, flatten_to_base, gcd_inner};
 use rand::Rng;
@@ -471,17 +471,9 @@ impl Field for Goldilocks {
     }
 }
 
-// We use macros to implement QuotientMap<Int> for all integer types except for u64 and i64.
+// We use macros to implement QuotientMap<Int> for all integer types except u64, i64, and u128.
 quotient_map_small_int!(Goldilocks, u64, [u8, u16, u32]);
 quotient_map_small_int!(Goldilocks, i64, [i8, i16, i32]);
-quotient_map_large_uint!(
-    Goldilocks,
-    u64,
-    Goldilocks::ORDER_U64,
-    "`[0, 2^64 - 2^32]`",
-    "`[0, 2^64 - 1]`",
-    [u128]
-);
 quotient_map_large_iint!(
     Goldilocks,
     i64,
@@ -489,6 +481,33 @@ quotient_map_large_iint!(
     "`[1 + 2^32 - 2^64, 2^64 - 1]`",
     [(i128, u128)]
 );
+
+impl QuotientMap<u128> for Goldilocks {
+    /// Convert a given `u128` integer into an element of the `Goldilocks` field.
+    ///
+    /// Uses the specialized Goldilocks reduction and returns a canonical representation.
+    #[inline]
+    fn from_int(int: u128) -> Self {
+        Self::new(reduce128(int).as_canonical_u64())
+    }
+
+    /// Convert a given `u128` integer into an element of the `Goldilocks` field.
+    ///
+    /// Returns `None` if the input does not lie in the range `[0, 2^64 - 2^32]`.
+    #[inline]
+    fn from_canonical_checked(int: u128) -> Option<Self> {
+        (int < Self::ORDER_U64 as u128).then(|| Self::new(int as u64))
+    }
+
+    /// Convert a given `u128` integer into an element of the `Goldilocks` field.
+    ///
+    /// # Safety
+    /// The input must lie in the range `[0, 2^64 - 1]`.
+    #[inline]
+    unsafe fn from_canonical_unchecked(int: u128) -> Self {
+        Self::new(int as u64)
+    }
+}
 
 impl QuotientMap<u64> for Goldilocks {
     /// Convert a given `u64` integer into an element of the `Goldilocks` field.
@@ -875,6 +894,153 @@ mod tests {
         assert_eq!(f.injective_exp_n().injective_exp_root_n(), f);
         assert_eq!(y.injective_exp_n().injective_exp_root_n(), y);
         assert_eq!(F::TWO.injective_exp_n().injective_exp_root_n(), F::TWO);
+    }
+
+    #[test]
+    fn u128_conversion_matches_modulo_oracle() {
+        const EDGES: [u128; 12] = [
+            0,
+            1,
+            P as u128 - 1,
+            P as u128,
+            P as u128 + 1,
+            u64::MAX as u128,
+            1 << 64,
+            (1 << 64) + P as u128,
+            1 << 96,
+            1 << 127,
+            u128::MAX - 1,
+            u128::MAX,
+        ];
+
+        let check = |input: u128| {
+            let expected = (input % P as u128) as u64;
+            let actual = F::from_int(input);
+            assert_eq!(actual.value, expected, "input = {input:#034x}");
+        };
+
+        for input in EDGES {
+            check(input);
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x128_C0DE);
+        for _ in 0..10_000 {
+            check(rng.random());
+        }
+    }
+
+    #[test]
+    fn i128_conversion_matches_modulo_oracle() {
+        const P_I128: i128 = P as i128;
+        const EDGES: [i128; 14] = [
+            i128::MIN,
+            i128::MIN + 1,
+            -(1 << 96),
+            -P_I128 - 1,
+            -P_I128,
+            -P_I128 + 1,
+            -1,
+            0,
+            1,
+            P_I128 - 1,
+            P_I128,
+            P_I128 + 1,
+            i128::MAX - 1,
+            i128::MAX,
+        ];
+
+        let check = |input: i128| {
+            let magnitude_mod_p = (input.unsigned_abs() % P as u128) as u64;
+            let expected_raw = if input < 0 {
+                P - magnitude_mod_p
+            } else {
+                magnitude_mod_p
+            };
+            let actual = F::from_int(input);
+            assert_eq!(actual.value, expected_raw, "input = {input}");
+        };
+
+        for input in EDGES {
+            check(input);
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x128_51C0);
+        for _ in 0..10_000 {
+            check(rng.random());
+        }
+    }
+
+    #[test]
+    fn large_integer_checked_conversion_preserves_bounds_and_raw_values() {
+        let unsigned_cases = [
+            (0, Some(0)),
+            (P as u128 - 1, Some(P - 1)),
+            (P as u128, None),
+            (P as u128 + 1, None),
+            (u128::MAX, None),
+        ];
+        for (input, expected_raw) in unsigned_cases {
+            assert_eq!(
+                F::from_canonical_checked(input).map(|value| value.value),
+                expected_raw,
+                "input = {input}"
+            );
+        }
+
+        const BOUND: i128 = (P >> 1) as i128;
+        let signed_cases = [
+            (-BOUND - 1, None),
+            (-BOUND, Some(P - BOUND as u64)),
+            (-1, Some(P - 1)),
+            (0, Some(0)),
+            (BOUND, Some(BOUND as u64)),
+            (BOUND + 1, None),
+            (i128::MIN, None),
+            (i128::MAX, None),
+        ];
+        for (input, expected_raw) in signed_cases {
+            assert_eq!(
+                F::from_canonical_checked(input).map(|value| value.value),
+                expected_raw,
+                "input = {input}"
+            );
+        }
+    }
+
+    #[test]
+    fn large_integer_unchecked_conversion_preserves_cast_behavior() {
+        let unsigned_cases = [
+            (0, 0),
+            (P as u128 - 1, P - 1),
+            (P as u128, P),
+            (u64::MAX as u128, u64::MAX),
+        ];
+        for (input, expected_raw) in unsigned_cases {
+            let actual = unsafe { F::from_canonical_unchecked(input) };
+            assert_eq!(actual.value, expected_raw, "input = {input}");
+        }
+
+        const MIN_UNCHECKED: i128 = 1 + (1_i128 << 32) - (1_i128 << 64);
+        let signed_inputs = [
+            MIN_UNCHECKED,
+            i64::MIN as i128 - 1,
+            i64::MIN as i128,
+            -1,
+            0,
+            i64::MAX as i128,
+            i64::MAX as i128 + 1,
+            u64::MAX as i128,
+        ];
+        for input in signed_inputs {
+            let narrowed = input as i64;
+            let expected_raw = if narrowed >= 0 {
+                narrowed as u64
+            } else {
+                P.wrapping_add_signed(narrowed)
+            };
+            let actual = unsafe { F::from_canonical_unchecked(input) };
+            assert_eq!(actual.value, expected_raw, "input = {input}");
+        }
     }
 
     #[test]

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -303,6 +303,18 @@ impl PrimeCharacteristicRing for Goldilocks {
         match exp {
             0 => *self,
             1 => self.halve(),
+            2..=32 => {
+                let lo = self.value & ((1u64 << exp) - 1);
+                let hi = self.value >> exp;
+
+                // Multiplying the expression below by 2^exp gives self.value modulo P,
+                // since 2^64 - 2^32 + 1 = P. Moreover, a < 2^64 and -P < a - b < P,
+                // so correcting a wrapping subtraction once produces a canonical result.
+                let a = hi + (lo << (32 - exp));
+                let b = lo << (64 - exp);
+                let (result, borrow) = a.overflowing_sub(b);
+                Self::new(result.wrapping_sub(Self::NEG_ORDER * u64::from(borrow)))
+            }
             _ => self.mul_2exp_u64(192 - exp),
         }
     }
@@ -787,6 +799,8 @@ mod tests {
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_64, test_two_adic_field,
     };
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::*;
 
@@ -861,6 +875,48 @@ mod tests {
         assert_eq!(f.injective_exp_n().injective_exp_root_n(), f);
         assert_eq!(y.injective_exp_n().injective_exp_root_n(), y);
         assert_eq!(F::TWO.injective_exp_n().injective_exp_root_n(), F::TWO);
+    }
+
+    #[test]
+    fn div_2exp_matches_field_division_for_all_representatives() {
+        const EPSILON: u64 = (1 << 32) - 1;
+        const RAW_EDGES: [u64; 10] = [
+            0,
+            1,
+            EPSILON - 1,
+            EPSILON,
+            1 << 32,
+            1 << 63,
+            P - 1,
+            P,
+            P + 1,
+            u64::MAX,
+        ];
+        const LARGE_EXPONENTS: [u64; 5] = [193, 384, 1 << 32, 1 << 63, u64::MAX];
+
+        let check = |raw: u64, exp: u64| {
+            let x = F::new(raw);
+            let divisor = F::TWO.exp_u64(exp % 192);
+            assert_eq!(
+                x.div_2exp_u64(exp),
+                x / divisor,
+                "raw = {raw:#018x}, exp = {exp}"
+            );
+        };
+
+        for raw in RAW_EDGES {
+            for exp in 0..=192 {
+                check(raw, exp);
+            }
+            for exp in LARGE_EXPONENTS {
+                check(raw, exp);
+            }
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0xD12_2E98);
+        for _ in 0..10_000 {
+            check(rng.random(), rng.random());
+        }
     }
 
     // Goldilocks has a redundant representation for both 0 and 1.

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -990,7 +990,25 @@ mod tests {
     fn packed_powers_of_two_match_scalar_oracle_for_arbitrary_representatives() {
         type PF = <F as Field>::Packing;
 
-        const EXPONENTS: [u64; 13] = [0, 1, 2, 3, 5, 31, 32, 63, 95, 96, 191, 192, u64::MAX];
+        const EXPONENTS: [u64; 17] = [
+            0,
+            1,
+            2,
+            3,
+            5,
+            31,
+            32,
+            33,
+            63,
+            95,
+            96,
+            191,
+            192,
+            194,
+            224,
+            225,
+            u64::MAX,
+        ];
         const RAW_EDGES: [u64; 10] = [
             0,
             1,

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -859,7 +859,7 @@ const fn from_unusual_int(int: i64) -> Goldilocks {
 #[cfg(test)]
 mod tests {
     use p3_field::extension::BinomialExtensionField;
-    use p3_field::tonelli_shanks_two_adic;
+    use p3_field::{PackedValue, tonelli_shanks_two_adic};
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_64, test_two_adic_field,
     };
@@ -870,6 +870,81 @@ mod tests {
 
     type F = Goldilocks;
     type EF = BinomialExtensionField<F, 5>;
+
+    /// Compare every packed lane with an independent full-u64 sum modulo the field order.
+    /// This avoids using the scalar Goldilocks sum as the oracle because it also delays reduction.
+    #[test]
+    fn packed_sum_array_matches_full_u64_oracle() {
+        type PF = <F as Field>::Packing;
+
+        const RAW_EDGES: [u64; 10] = [
+            0,
+            1,
+            (1 << 32) - 1,
+            1 << 32,
+            1 << 63,
+            P - 1,
+            P,
+            P + 1,
+            u64::MAX - 1,
+            u64::MAX,
+        ];
+
+        fn check<const N: usize>(values: &[u64]) {
+            type PF = <F as Field>::Packing;
+
+            assert_eq!(values.len(), PF::WIDTH * N);
+            let input: [PF; N] =
+                core::array::from_fn(|term| PF::from_fn(|lane| F::new(values[lane * N + term])));
+            let actual = PF::sum_array::<N>(&input);
+
+            for lane in 0..PF::WIDTH {
+                let expected = (values[lane * N..(lane + 1) * N]
+                    .iter()
+                    .map(|&value| u128::from(value))
+                    .sum::<u128>()
+                    % u128::from(P)) as u64;
+                assert_eq!(
+                    actual.as_slice()[lane].as_canonical_u64(),
+                    expected,
+                    "N={N}, lane={lane}"
+                );
+            }
+        }
+
+        macro_rules! check_length {
+            ($rng:ident, $n:literal, $random_cases:literal) => {{
+                let edge_values = (0..PF::WIDTH * $n)
+                    .map(|index| RAW_EDGES[index % RAW_EDGES.len()])
+                    .collect::<Vec<_>>();
+                check::<$n>(&edge_values);
+                check::<$n>(&[u64::MAX; PF::WIDTH * $n]);
+
+                for _ in 0..$random_cases {
+                    let values = (0..PF::WIDTH * $n)
+                        .map(|_| $rng.random::<u64>())
+                        .collect::<Vec<_>>();
+                    check::<$n>(&values);
+                }
+            }};
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x5A_0B17_5EED);
+        check_length!(rng, 0, 16);
+        check_length!(rng, 1, 16);
+        check_length!(rng, 2, 16);
+        check_length!(rng, 3, 16);
+        check_length!(rng, 4, 16);
+        check_length!(rng, 5, 16);
+        check_length!(rng, 6, 16);
+        check_length!(rng, 7, 16);
+        check_length!(rng, 8, 16);
+        check_length!(rng, 12, 16);
+        check_length!(rng, 16, 16);
+        check_length!(rng, 32, 16);
+        check_length!(rng, 64, 8);
+        check_length!(rng, 129, 4);
+    }
 
     #[test]
     fn deserialize_rejects_non_canonical_encodings() {

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -172,6 +172,28 @@ impl Goldilocks {
         }
         powers_of_two
     };
+
+    /// Returns the canonical coefficient 2^exp mod P for packed multiplication.
+    #[cfg(any(
+        test,
+        all(target_arch = "aarch64", target_feature = "neon"),
+        all(
+            target_arch = "x86_64",
+            any(target_feature = "avx2", target_feature = "avx512f")
+        ),
+        all(target_arch = "wasm32", target_feature = "simd128")
+    ))]
+    #[inline]
+    pub(crate) const fn power_of_two(exp: u64) -> Self {
+        // 2^96 = -1 mod P, so powers repeat with period 192.
+        let exp = (exp % 192) as usize;
+        if exp < 96 {
+            Self::POWERS_OF_TWO[exp]
+        } else {
+            // Every table entry is nonzero and canonical, so this cannot underflow.
+            Self::new(Self::ORDER_U64 - Self::POWERS_OF_TWO[exp - 96].value)
+        }
+    }
 }
 
 impl PartialEq for Goldilocks {
@@ -945,6 +967,82 @@ mod tests {
         check_length!(rng, 63, 8);
         check_length!(rng, 64, 8);
         check_length!(rng, 129, 4);
+    }
+
+    #[test]
+    fn power_of_two_coefficient_matches_generic_exponentiation() {
+        for exp in (0..384).chain([1 << 32, 1 << 63, u64::MAX - 1, u64::MAX]) {
+            let coefficient = F::power_of_two(exp);
+            assert_eq!(coefficient, F::TWO.exp_u64(exp), "exp = {exp}");
+            assert!(
+                coefficient.value < P,
+                "noncanonical coefficient: exp = {exp}"
+            );
+            assert_eq!(
+                coefficient * F::power_of_two(192 - exp % 192),
+                F::ONE,
+                "inverse coefficient: exp = {exp}"
+            );
+        }
+    }
+
+    #[test]
+    fn packed_powers_of_two_match_scalar_oracle_for_arbitrary_representatives() {
+        type PF = <F as Field>::Packing;
+
+        const EXPONENTS: [u64; 13] = [0, 1, 2, 3, 5, 31, 32, 63, 95, 96, 191, 192, u64::MAX];
+        const RAW_EDGES: [u64; 10] = [
+            0,
+            1,
+            (1 << 32) - 2,
+            (1 << 32) - 1,
+            1 << 32,
+            1 << 63,
+            P - 1,
+            P,
+            P + 1,
+            u64::MAX,
+        ];
+
+        let check = |raw: &[u64]| {
+            assert_eq!(raw.len(), PF::WIDTH);
+            let input = PF::from_fn(|lane| F::new(raw[lane]));
+
+            for exp in EXPONENTS {
+                let power = F::TWO.exp_u64(exp);
+                let product = input.mul_2exp_u64(exp);
+                let quotient = input.div_2exp_u64(exp);
+
+                for (lane, &raw) in raw.iter().enumerate() {
+                    let scalar = F::new(raw);
+                    assert_eq!(
+                        product.as_slice()[lane],
+                        scalar * power,
+                        "mul: raw = {raw:#018x}, exp = {exp}, lane = {lane}"
+                    );
+                    assert_eq!(
+                        quotient.as_slice()[lane],
+                        scalar / power,
+                        "div: raw = {raw:#018x}, exp = {exp}, lane = {lane}"
+                    );
+                }
+            }
+        };
+
+        for offset in 0..RAW_EDGES.len() {
+            let raw = (0..PF::WIDTH)
+                .map(|lane| RAW_EDGES[(offset + lane) % RAW_EDGES.len()])
+                .collect::<Vec<_>>();
+            check(&raw);
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x2E80_2E80_5EED);
+        for _ in 0..256 {
+            let raw = (0..PF::WIDTH)
+                .map(|_| rng.random::<u64>())
+                .collect::<Vec<_>>();
+            check(&raw);
+        }
     }
 
     #[test]

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -969,6 +969,109 @@ mod tests {
         check_length!(rng, 129, 4);
     }
 
+    /// Reduce each full-u64 product separately in the oracle, so repeated max * max
+    /// also checks sums exceeding u128 without overflowing the expected-value calculation.
+    #[test]
+    fn packed_dot_products_match_full_u64_oracle() {
+        use p3_field::Algebra;
+
+        type PF = <F as Field>::Packing;
+
+        const RAW_EDGES: [u64; 10] = [
+            0,
+            1,
+            (1 << 32) - 2,
+            (1 << 32) - 1,
+            1 << 32,
+            1 << 63,
+            P - 1,
+            P,
+            P + 1,
+            u64::MAX,
+        ];
+
+        fn check<const N: usize>(lhs: &[PF; N], rhs: &[PF; N], coeffs: &[F; N]) {
+            let ordinary = PF::dot_product(lhs, rhs);
+            let mixed = PF::mixed_dot_product(lhs, coeffs);
+            let broadcast = PF::dot_product(lhs, &coeffs.map(PF::from));
+            assert_eq!(mixed, broadcast, "mixed/broadcast, N={N}");
+
+            for lane in 0..PF::WIDTH {
+                let mut ordinary_expected = 0u128;
+                let mut mixed_expected = 0u128;
+                for term in 0..N {
+                    let a = u128::from(lhs[term].as_slice()[lane].value);
+                    let b = u128::from(rhs[term].as_slice()[lane].value);
+                    ordinary_expected += (a * b) % u128::from(P);
+                    mixed_expected += (a * u128::from(coeffs[term].value)) % u128::from(P);
+                }
+                assert_eq!(
+                    ordinary.as_slice()[lane].as_canonical_u64(),
+                    (ordinary_expected % u128::from(P)) as u64,
+                    "ordinary, N={N}, lane={lane}"
+                );
+                assert_eq!(
+                    mixed.as_slice()[lane].as_canonical_u64(),
+                    (mixed_expected % u128::from(P)) as u64,
+                    "mixed, N={N}, lane={lane}"
+                );
+            }
+        }
+
+        fn check_length<const N: usize>(rng: &mut SmallRng) {
+            // Repeated edge pairs exercise carries above bit 128, zero representatives,
+            // and the largest possible high limbs in every lane.
+            for a in RAW_EDGES {
+                for b in RAW_EDGES {
+                    check::<N>(
+                        &[PF::from(F::new(a)); N],
+                        &[PF::from(F::new(b)); N],
+                        &[F::new(b); N],
+                    );
+                }
+            }
+            for offset in 0..RAW_EDGES.len() {
+                let lhs = core::array::from_fn(|term| {
+                    PF::from_fn(|lane| F::new(RAW_EDGES[(offset + term + lane) % RAW_EDGES.len()]))
+                });
+                let rhs = core::array::from_fn(|term| {
+                    PF::from_fn(|lane| {
+                        F::new(RAW_EDGES[(offset + 3 * term + 7 * lane) % RAW_EDGES.len()])
+                    })
+                });
+                let coeffs = core::array::from_fn(|term| {
+                    F::new(RAW_EDGES[(offset + term) % RAW_EDGES.len()])
+                });
+                check::<N>(&lhs, &rhs, &coeffs);
+            }
+            for _ in 0..128 {
+                let lhs = core::array::from_fn(|_| PF::from_fn(|_| F::new(rng.random())));
+                let rhs = core::array::from_fn(|_| PF::from_fn(|_| F::new(rng.random())));
+                let coeffs = core::array::from_fn(|_| F::new(rng.random()));
+                check::<N>(&lhs, &rhs, &coeffs);
+            }
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0xD07_F011_5EED);
+        check_length::<0>(&mut rng);
+        check_length::<1>(&mut rng);
+        check_length::<2>(&mut rng);
+        check_length::<3>(&mut rng);
+        check_length::<4>(&mut rng);
+        check_length::<5>(&mut rng);
+        check_length::<6>(&mut rng);
+        check_length::<7>(&mut rng);
+        check_length::<8>(&mut rng);
+        check_length::<12>(&mut rng);
+        check_length::<16>(&mut rng);
+        check_length::<31>(&mut rng);
+        check_length::<32>(&mut rng);
+        check_length::<33>(&mut rng);
+        check_length::<64>(&mut rng);
+        check_length::<65>(&mut rng);
+        check_length::<129>(&mut rng);
+    }
+
     #[test]
     fn power_of_two_coefficient_matches_generic_exponentiation() {
         for exp in (0..384).chain([1 << 32, 1 << 63, u64::MAX - 1, u64::MAX]) {

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -17,7 +17,6 @@ use p3_field::{
     Field, InjectiveMonomial, Packable, PermutationMonomial, PrimeCharacteristicRing, PrimeField,
     PrimeField64, RawDataSerializable, TwoAdicField, UniformSamplingField,
     impl_raw_serializable_primefield64, quotient_map_large_iint, quotient_map_small_int,
-    tonelli_shanks_two_adic,
 };
 use p3_util::{branch_hint, flatten_to_base, gcd_inner};
 use rand::Rng;
@@ -413,6 +412,18 @@ impl RawDataSerializable for Goldilocks {
     impl_raw_serializable_primefield64!();
 }
 
+/// Compute `x^(2^31 - 1)` using a fixed addition chain.
+#[inline(always)]
+fn exp_2_31_minus_1(x: Goldilocks) -> Goldilocks {
+    let x3 = x.square() * x;
+    let x7 = x3.square() * x;
+    let x63 = x7.exp_power_of_2(3) * x7;
+    let x4095 = x63.exp_power_of_2(6) * x63;
+    let x24 = x4095.exp_power_of_2(12) * x4095;
+    let x30 = x24.exp_power_of_2(6) * x63;
+    x30.square() * x
+}
+
 impl Field for Goldilocks {
     #[cfg(all(
         target_arch = "x86_64",
@@ -467,7 +478,40 @@ impl Field for Goldilocks {
 
     #[inline]
     fn try_sqrt(&self) -> Option<Self> {
-        tonelli_shanks_two_adic(*self)
+        // Zero is its own square root and would otherwise break Tonelli-Shanks.
+        if self.is_zero() {
+            return Some(Self::ZERO);
+        }
+
+        // Goldilocks has `p - 1 = (2^32 - 1) * 2^32`, so the initial
+        // Tonelli-Shanks exponent is `(2^32 - 2) / 2 = 2^31 - 1`.
+        let u = exp_2_31_minus_1(*self);
+        let mut r = u * *self;
+        let mut t = r * u;
+        let mut m = 32;
+
+        while t != Self::ONE {
+            // Find the least i with t^(2^i) = 1. If no such i is below m,
+            // t has order 2^m and the input is a quadratic non-residue.
+            let mut i = 0;
+            let mut t2i = t;
+            while t2i != Self::ONE {
+                t2i = t2i.square();
+                i += 1;
+                if i == m {
+                    return None;
+                }
+            }
+
+            // The current correction is the (i + 1)-th two-adic generator:
+            // G_m^(2^(m-i-1)) = G_(i+1), and its square is G_i. Since
+            // i < m <= 32, both table indices are always in range.
+            r *= Self::TWO_ADIC_GENERATORS[i + 1];
+            t *= Self::TWO_ADIC_GENERATORS[i];
+            m = i;
+        }
+
+        Some(r)
     }
 }
 
@@ -815,6 +859,7 @@ const fn from_unusual_int(int: i64) -> Goldilocks {
 #[cfg(test)]
 mod tests {
     use p3_field::extension::BinomialExtensionField;
+    use p3_field::tonelli_shanks_two_adic;
     use p3_field_testing::{
         test_field, test_field_dft, test_prime_field, test_prime_field_64, test_two_adic_field,
     };
@@ -965,6 +1010,41 @@ mod tests {
         }
 
         let mut rng = SmallRng::seed_from_u64(0x128_51C0);
+        for _ in 0..10_000 {
+            check(rng.random());
+        }
+    }
+
+    #[test]
+    fn sqrt_matches_generic_tonelli_shanks_for_arbitrary_representatives() {
+        const RAW_EDGES: [u64; 10] = [
+            0,
+            1,
+            (1 << 32) - 1,
+            1 << 32,
+            1 << 63,
+            P - 1,
+            P,
+            P + 1,
+            u64::MAX - 1,
+            u64::MAX,
+        ];
+
+        let check = |raw: u64| {
+            let input = F::new(raw);
+            let expected = tonelli_shanks_two_adic(input);
+            let actual = input.try_sqrt();
+            assert_eq!(actual.is_some(), expected.is_some(), "raw = {raw:#018x}");
+            if let Some(root) = actual {
+                assert_eq!(root.square(), input, "raw = {raw:#018x}");
+            }
+        };
+
+        for raw in RAW_EDGES {
+            check(raw);
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x5A7_C0DE);
         for _ in 0..10_000 {
             check(rng.random());
         }

--- a/goldilocks/src/goldilocks.rs
+++ b/goldilocks/src/goldilocks.rs
@@ -942,6 +942,7 @@ mod tests {
         check_length!(rng, 12, 16);
         check_length!(rng, 16, 16);
         check_length!(rng, 32, 16);
+        check_length!(rng, 63, 8);
         check_length!(rng, 64, 8);
         check_length!(rng, 129, 4);
     }

--- a/goldilocks/src/mds.rs
+++ b/goldilocks/src/mds.rs
@@ -6,7 +6,7 @@
 //! work by Angus Gruen and Hamish Ivey-Law. Other sizes are from Ulrich Haböck's
 //! database.
 
-use p3_dft::{Radix2Bowers, TwoAdicSubgroupDft};
+use p3_dft::{Radix2DFTSmallBatch, TwoAdicSubgroupDft};
 use p3_field::PrimeCharacteristicRing;
 use p3_mds::MdsPermutation;
 use p3_mds::karatsuba_convolution::Convolve;
@@ -69,7 +69,8 @@ impl Convolve<Goldilocks, i128, i64> for SmallConvolveGoldilocks {
     }
 }
 
-const FFT_ALGO: Radix2Bowers = Radix2Bowers;
+static FFT_ALGO: LazyLock<Radix2DFTSmallBatch<Goldilocks>> =
+    LazyLock::new(|| Radix2DFTSmallBatch::new(64));
 
 pub(crate) const MATRIX_CIRC_MDS_8_SML_ROW: [i64; 8] = [7, 1, 3, 8, 8, 3, 4, 9];
 
@@ -163,7 +164,7 @@ static MATRIX_CIRC_MDS_32_FREQ: LazyLock<[Goldilocks; 32]> = LazyLock::new(|| {
 
 impl Permutation<[Goldilocks; 32]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 32]) -> [Goldilocks; 32] {
-        apply_circulant_fft_precomputed(&FFT_ALGO, &MATRIX_CIRC_MDS_32_FREQ, &input)
+        apply_circulant_fft_precomputed(&*FFT_ALGO, &MATRIX_CIRC_MDS_32_FREQ, &input)
     }
 }
 impl MdsPermutation<Goldilocks, 32> for MdsMatrixGoldilocks {}
@@ -199,7 +200,7 @@ static MATRIX_CIRC_MDS_64_FREQ: LazyLock<[Goldilocks; 64]> = LazyLock::new(|| {
 
 impl Permutation<[Goldilocks; 64]> for MdsMatrixGoldilocks {
     fn permute(&self, input: [Goldilocks; 64]) -> [Goldilocks; 64] {
-        apply_circulant_fft_precomputed(&FFT_ALGO, &MATRIX_CIRC_MDS_64_FREQ, &input)
+        apply_circulant_fft_precomputed(&*FFT_ALGO, &MATRIX_CIRC_MDS_64_FREQ, &input)
     }
 }
 impl MdsPermutation<Goldilocks, 64> for MdsMatrixGoldilocks {}
@@ -234,9 +235,62 @@ impl MdsPermutation<Goldilocks, 68> for MdsMatrixGoldilocks {}
 
 #[cfg(test)]
 mod tests {
+    use p3_mds::util::apply_circulant;
     use p3_symmetric::Permutation;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
-    use super::{Goldilocks, MdsMatrixGoldilocks};
+    use super::{
+        Goldilocks, MATRIX_CIRC_MDS_32_GOLDILOCKS, MATRIX_CIRC_MDS_64_GOLDILOCKS,
+        MdsMatrixGoldilocks,
+    };
+
+    #[test]
+    fn goldilocks32_and_64_match_direct_circulant_on_raw_edges_and_random_inputs() {
+        const RAW_EDGES: [u64; 10] = [
+            0,
+            1,
+            (1 << 32) - 1,
+            1 << 32,
+            1 << 63,
+            0xFFFF_FFFF_0000_0000,
+            0xFFFF_FFFF_0000_0001,
+            0xFFFF_FFFF_0000_0002,
+            u64::MAX - 1,
+            u64::MAX,
+        ];
+
+        for offset in 0..RAW_EDGES.len() {
+            let input32 = core::array::from_fn(|i| {
+                Goldilocks::new(RAW_EDGES[(i + offset) % RAW_EDGES.len()])
+            });
+            let input64 = core::array::from_fn(|i| {
+                Goldilocks::new(RAW_EDGES[(i + offset) % RAW_EDGES.len()])
+            });
+            assert_eq!(
+                MdsMatrixGoldilocks.permute(input32),
+                apply_circulant(&MATRIX_CIRC_MDS_32_GOLDILOCKS, &input32)
+            );
+            assert_eq!(
+                MdsMatrixGoldilocks.permute(input64),
+                apply_circulant(&MATRIX_CIRC_MDS_64_GOLDILOCKS, &input64)
+            );
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x4D_D5_32_64);
+        for _ in 0..32 {
+            let input32 = Goldilocks::new_array(rng.random());
+            let input64 = Goldilocks::new_array(rng.random());
+            assert_eq!(
+                MdsMatrixGoldilocks.permute(input32),
+                apply_circulant(&MATRIX_CIRC_MDS_32_GOLDILOCKS, &input32)
+            );
+            assert_eq!(
+                MdsMatrixGoldilocks.permute(input64),
+                apply_circulant(&MATRIX_CIRC_MDS_64_GOLDILOCKS, &input64)
+            );
+        }
+    }
 
     #[test]
     fn goldilocks8() {

--- a/goldilocks/src/mds.rs
+++ b/goldilocks/src/mds.rs
@@ -277,7 +277,7 @@ mod tests {
             );
         }
 
-        let mut rng = SmallRng::seed_from_u64(0x4D_D5_32_64);
+        let mut rng = SmallRng::seed_from_u64(0x4DD5_3264);
         for _ in 0..32 {
             let input32 = Goldilocks::new_array(rng.random());
             let input64 = Goldilocks::new_array(rng.random());

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -875,13 +875,13 @@ fn internal_layer_mat_mul_goldilocks_12<A: Algebra<Goldilocks>>(state: &mut [A; 
     state[8] = sum.dup() - four_s8;
 
     // V[9] = 1/2^2
-    state[9] = sum.dup() + s9.halve().halve();
+    state[9] = sum.dup() + s9.div_2exp_u64(2);
 
     // V[10] = -1/2^2
-    state[10] = sum.dup() - s10.halve().halve();
+    state[10] = sum.dup() - s10.div_2exp_u64(2);
 
     // V[11] = 1/2^3
-    state[11] = sum + s11.halve().halve().halve();
+    state[11] = sum + s11.div_2exp_u64(3);
 }
 
 fn internal_layer_mat_mul_goldilocks_16<A: Algebra<Goldilocks>>(state: &mut [A; 16]) {
@@ -942,26 +942,25 @@ fn internal_layer_mat_mul_goldilocks_16<A: Algebra<Goldilocks>>(state: &mut [A; 
     state[8] = sum.dup() - four_s8;
 
     // V[9] = 1/2^3
-    state[9] = sum.dup() + s9.halve().halve().halve();
+    state[9] = sum.dup() + s9.div_2exp_u64(3);
 
     // V[10] = 1/2^4
-    state[10] = sum.dup() + s10.halve().halve().halve().halve();
+    state[10] = sum.dup() + s10.div_2exp_u64(4);
 
     // V[11] = 1/2^5
-    state[11] = sum.dup() + s11.halve().halve().halve().halve().halve();
+    state[11] = sum.dup() + s11.div_2exp_u64(5);
 
     // V[12] = -1/2^3
-    state[12] = sum.dup() - s12.halve().halve().halve();
+    state[12] = sum.dup() - s12.div_2exp_u64(3);
 
     // V[13] = -1/2^4
-    state[13] = sum.dup() - s13.halve().halve().halve().halve();
+    state[13] = sum.dup() - s13.div_2exp_u64(4);
 
     // V[14] = -1/2^5
-    state[14] = sum.dup() - s14.halve().halve().halve().halve().halve();
+    state[14] = sum.dup() - s14.div_2exp_u64(5);
 
     // V[15] = 1/2^32
-    let inv_2_32 = MATRIX_DIAG_16_GOLDILOCKS[15];
-    let v15 = s15 * inv_2_32;
+    let v15 = s15.div_2exp_u64(32);
     state[15] = sum + v15;
 }
 

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -171,10 +171,7 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
             0 => Self::ZERO,
             1 => input[0],
             2 => input[0] + input[1],
-            _ => {
-                let vectors: [v128; N] = core::array::from_fn(|i| input[i].to_vector());
-                Self::from_vector(sum_delayed_reduce::<N>(&vectors))
-            }
+            _ => Self::from_vector(sum_delayed_reduce::<N>(input)),
         }
     }
 
@@ -503,28 +500,29 @@ fn dot_pairs<const N: usize>(get: impl Fn(usize) -> (v128, v128)) -> v128 {
     reduce128(sum_hi, sum_lo)
 }
 
-/// Delayed-reduction sum: `sum(terms)` with a single final [`reduce128`] instead of one
-/// reduction per term (the generic `sum_array`/`+`-chain default pays a full `add`, ~9 ops
-/// including a canonicalize step, for every term).
-///
-/// Each term is a single (arbitrary, possibly non-canonical) 64-bit value, i.e. a 128-bit
-/// value with a zero high half, so — unlike [`dot_pairs`] — no bit-96 split
-/// is needed: accumulating with plain wrapping 128-bit-per-lane addition (carry from the low
-/// word into the high word on overflow) gives the *exact* sum as long as `N < 2^64`, which
-/// always holds. `reduce128` finishes it.
+/// Delayed-reduction sum of the original packed input, keeping only the wrapped low word and a
+/// carry count. Each input is an arbitrary 64-bit value, so the exact sum is
+/// `acc_lo + carry_count * 2^64`; on wasm32, `N <= 2^32 - 1` and `carry_count <= N - 1`.
 #[inline]
-fn sum_delayed_reduce<const N: usize>(terms: &[v128; N]) -> v128 {
-    let mut acc_hi = u64x2_splat(0);
-    let mut acc_lo = u64x2_splat(0);
+fn sum_delayed_reduce<const N: usize>(terms: &[PackedGoldilocksWasmSimd128]) -> v128 {
+    let mut acc_lo = terms[0].to_vector();
+    let mut carry_count = u64x2_splat(0);
 
-    for &term in terms {
+    for term in &terms[1..] {
+        let term = term.to_vector();
         let new_lo = i64x2_add(acc_lo, term);
-        let carry = unsigned_add_carry(acc_lo, term, new_lo);
-        acc_hi = i64x2_add(acc_hi, carry);
+        carry_count = i64x2_add(carry_count, unsigned_add_carry(acc_lo, term, new_lo));
         acc_lo = new_lo;
     }
 
-    reduce128(acc_hi, acc_lo)
+    // `2^64 ≡ EPSILON (mod P)`, so the high carry count contributes
+    // `correction = (carry_count << 32) - carry_count`. The largest possible count is
+    // `2^32 - 2`, making `correction <= (2^32 - 2)(2^32 - 1) < P`; the shift and subtraction
+    // therefore cannot wrap. The stronger bound `correction <= 0xffffffff00000000` satisfies
+    // `add_small_64s_64_s`'s precondition for an arbitrary pre-shifted `acc_lo`, so one overflow
+    // correction is sufficient and no full `reduce128` is needed.
+    let correction = i64x2_sub(i64x2_shl(carry_count, 32), carry_count);
+    shift(add_small_64s_64_s(shift(acc_lo), correction))
 }
 
 /// Goldilocks modular multiplication. Computes `x * y mod FIELD_ORDER`.
@@ -702,6 +700,62 @@ mod tests {
         check_random_n!(11, 16);
         check_random_n!(15, 16);
         check_random_n!(64, 8);
+    }
+
+    /// Compare every sum lane with an independent full-u64 sum modulo the field order. The
+    /// scalar Goldilocks sum is deliberately not used as the oracle here because it shares the
+    /// delayed-reduction shape that this packed implementation exercises.
+    #[test]
+    fn sum_array_full_u64_oracle() {
+        use p3_field::{PackedValue, PrimeCharacteristicRing, PrimeField64};
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        fn oracle(values: &[u64]) -> u64 {
+            (values.iter().map(|&value| u128::from(value)).sum::<u128>()
+                % u128::from(Goldilocks::ORDER_U64)) as u64
+        }
+
+        fn check<const N: usize>(terms0: [u64; N], terms1: [u64; N]) {
+            let packed: [PackedGoldilocksWasmSimd128; N] = core::array::from_fn(|i| {
+                PackedGoldilocksWasmSimd128([
+                    Goldilocks::new(terms0[i]),
+                    Goldilocks::new(terms1[i]),
+                ])
+            });
+            let actual = PackedGoldilocksWasmSimd128::sum_array::<N>(&packed);
+
+            assert_eq!(actual.as_slice()[0].as_canonical_u64(), oracle(&terms0));
+            assert_eq!(actual.as_slice()[1].as_canonical_u64(), oracle(&terms1));
+        }
+
+        macro_rules! check_length {
+            ($rng:ident, $n:literal, $count:literal) => {{
+                check::<$n>([u64::MAX; $n], [0; $n]);
+                check::<$n>([0xFFFF_FFFF_0000_0000; $n], [u64::MAX; $n]);
+                for _ in 0..$count {
+                    let terms0 = core::array::from_fn(|_| $rng.random::<u64>());
+                    let terms1 = core::array::from_fn(|_| $rng.random::<u64>());
+                    check::<$n>(terms0, terms1);
+                }
+            }};
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0x5A_0B17_5EED);
+        check_length!(rng, 0, 16);
+        check_length!(rng, 1, 16);
+        check_length!(rng, 2, 16);
+        check_length!(rng, 3, 16);
+        check_length!(rng, 4, 16);
+        check_length!(rng, 5, 16);
+        check_length!(rng, 6, 16);
+        check_length!(rng, 7, 16);
+        check_length!(rng, 11, 16);
+        check_length!(rng, 15, 16);
+        check_length!(rng, 16, 16);
+        check_length!(rng, 32, 16);
+        check_length!(rng, 64, 8);
+        check_length!(rng, 129, 4);
     }
 
     /// Adversarial + random coverage for `dot_product`'s delayed-reduction path (`N > 1`),

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -154,6 +154,26 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
     }
 
     #[inline]
+    fn mul_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.double(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(exp)),
+        }
+    }
+
+    #[inline]
+    fn div_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.halve(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
+        }
+    }
+
+    #[inline]
     fn square(&self) -> Self {
         Self::from_vector(square(self.to_vector()))
     }

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -633,11 +633,12 @@ mod tests {
         fn check(a: [u64; 2], b: [u64; 2]) {
             let sum = [a[0].wrapping_add(b[0]), a[1].wrapping_add(b[1])];
             let carry = super::unsigned_add_carry(
-                unsafe { core::mem::transmute(a) },
-                unsafe { core::mem::transmute(b) },
-                unsafe { core::mem::transmute(sum) },
+                unsafe { core::mem::transmute::<[u64; 2], core::arch::wasm32::v128>(a) },
+                unsafe { core::mem::transmute::<[u64; 2], core::arch::wasm32::v128>(b) },
+                unsafe { core::mem::transmute::<[u64; 2], core::arch::wasm32::v128>(sum) },
             );
-            let carry: [u64; 2] = unsafe { core::mem::transmute(carry) };
+            let carry: [u64; 2] =
+                unsafe { core::mem::transmute::<core::arch::wasm32::v128, [u64; 2]>(carry) };
             assert_eq!(carry[0], u64::from(sum[0] < a[0]));
             assert_eq!(carry[1], u64::from(sum[1] < a[1]));
         }
@@ -659,7 +660,7 @@ mod tests {
             }
         }
 
-        let mut rng = SmallRng::seed_from_u64(0xCA77_0FF1_CE);
+        let mut rng = SmallRng::seed_from_u64(0x00CA_770F_F1CE);
         for _ in 0..4096 {
             let a = [rng.random(), rng.random()];
             let b = [rng.random(), rng.random()];

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -169,6 +169,16 @@ impl PrimeCharacteristicRing for PackedGoldilocksWasmSimd128 {
         match exp {
             0 => *self,
             1 => self.halve(),
+            2..=32 => {
+                let x = self.to_vector();
+                let lo = v128_and(x, u64x2_splat((1u64 << exp) - 1));
+                let hi = u64x2_shr(x, exp as u32);
+                let a = i64x2_add(hi, i64x2_shl(lo, (32 - exp) as u32));
+                let b = i64x2_shl(lo, (64 - exp) as u32);
+                // 2^-exp = 2^(32-exp) - 2^(64-exp) mod P. Both a and b are
+                // below P; in particular b <= 2^64 - 2^32, as required by the helper.
+                Self::from_vector(shift(sub_small_64s_64_s(shift(a), b)))
+            }
             _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
         }
     }

--- a/goldilocks/src/wasm32_simd128/packing.rs
+++ b/goldilocks/src/wasm32_simd128/packing.rs
@@ -439,13 +439,14 @@ fn reduce128(hi: v128, lo: v128) -> v128 {
     shift(lo2_s)
 }
 
-/// `1` in each lane where `a < b` (unsigned), else `0`. Used to detect unsigned-add
-/// overflow when accumulating 128-bit-per-lane values across `v128` pairs, via the same
-/// sign-bit-shift trick as [`canonicalize_s`] and friends.
+/// Return `1` in each lane where the `a + b` addition overflowed, else `0`.
+///
+/// This bitwise carry formula keeps the comparison vectorized on Wasm SIMD, which has no
+/// unsigned 64-bit vector comparison: `((a & b) | ((a | b) & !sum)) >> 63`.
 #[inline(always)]
-fn unsigned_lt_as_carry(a: v128, b: v128) -> v128 {
-    let mask = i64x2_gt(shift(b), shift(a));
-    u64x2_shr(mask, 63)
+fn unsigned_add_carry(a: v128, b: v128, sum: v128) -> v128 {
+    let carry_mask = v128_or(v128_and(a, b), v128_andnot(v128_or(a, b), sum));
+    u64x2_shr(carry_mask, 63)
 }
 
 /// Delayed-reduction dot product: `sum(get(i).0 * get(i).1)` with a single final
@@ -480,7 +481,7 @@ fn dot_pairs<const N: usize>(get: impl Fn(usize) -> (v128, v128)) -> v128 {
         let term_hi96 = u64x2_shr(term_hi, 32);
 
         let new_lo_lo = i64x2_add(acc_lo_lo, term_lo);
-        let carry = unsigned_lt_as_carry(new_lo_lo, acc_lo_lo);
+        let carry = unsigned_add_carry(acc_lo_lo, term_lo, new_lo_lo);
         acc_lo_hi = i64x2_add(i64x2_add(acc_lo_hi, term_hi), carry);
         acc_lo_lo = new_lo_lo;
 
@@ -496,7 +497,7 @@ fn dot_pairs<const N: usize>(get: impl Fn(usize) -> (v128, v128)) -> v128 {
     // `sum = lo + (P - acc_hi96)`, a 128-bit + 64-bit add with carry into the high word.
     let p_minus_hi = i64x2_sub(u64x2_splat(P), acc_hi96);
     let sum_lo = i64x2_add(lo_lo, p_minus_hi);
-    let carry2 = unsigned_lt_as_carry(sum_lo, lo_lo);
+    let carry2 = unsigned_add_carry(lo_lo, p_minus_hi, sum_lo);
     let sum_hi = i64x2_add(lo_hi, carry2);
 
     reduce128(sum_hi, sum_lo)
@@ -518,7 +519,7 @@ fn sum_delayed_reduce<const N: usize>(terms: &[v128; N]) -> v128 {
 
     for &term in terms {
         let new_lo = i64x2_add(acc_lo, term);
-        let carry = unsigned_lt_as_carry(new_lo, acc_lo);
+        let carry = unsigned_add_carry(acc_lo, term, new_lo);
         acc_hi = i64x2_add(acc_hi, carry);
         acc_lo = new_lo;
     }
@@ -592,6 +593,51 @@ mod tests {
         &[super::ONES],
         crate::PackedGoldilocksWasmSimd128(super::SPECIAL_VALS)
     );
+
+    /// Check the carry helper directly, including both operand orderings and values at the
+    /// full `u64` boundary. The delayed sum and dot tests below exercise this helper indirectly,
+    /// but their arithmetic can otherwise mask an operand-ordering error in carry detection.
+    #[test]
+    fn unsigned_add_carry_matches_wrapping_add() {
+        use rand::rngs::SmallRng;
+        use rand::{RngExt, SeedableRng};
+
+        fn check(a: [u64; 2], b: [u64; 2]) {
+            let sum = [a[0].wrapping_add(b[0]), a[1].wrapping_add(b[1])];
+            let carry = super::unsigned_add_carry(
+                unsafe { core::mem::transmute(a) },
+                unsafe { core::mem::transmute(b) },
+                unsafe { core::mem::transmute(sum) },
+            );
+            let carry: [u64; 2] = unsafe { core::mem::transmute(carry) };
+            assert_eq!(carry[0], u64::from(sum[0] < a[0]));
+            assert_eq!(carry[1], u64::from(sum[1] < a[1]));
+        }
+
+        const EDGES: [u64; 8] = [
+            0,
+            1,
+            2,
+            0x7FFF_FFFF_FFFF_FFFF,
+            0x8000_0000_0000_0000,
+            0xFFFF_FFFF_0000_0000,
+            u64::MAX - 1,
+            u64::MAX,
+        ];
+        for &a in &EDGES {
+            for &b in &EDGES {
+                check([a, b], [b, a]);
+                check([b, a], [a, b]);
+            }
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0xCA77_0FF1_CE);
+        for _ in 0..4096 {
+            let a = [rng.random(), rng.random()];
+            let b = [rng.random(), rng.random()];
+            check(a, b);
+        }
+    }
 
     /// Adversarial + random coverage for `sum_array`'s delayed-reduction path (`N > 2`),
     /// across every lane independently.

--- a/goldilocks/src/wasm32_simd128/poseidon2.rs
+++ b/goldilocks/src/wasm32_simd128/poseidon2.rs
@@ -175,11 +175,11 @@ fn internal_round_goldilocks_12(
     let two_s8 = s8 + s8;
     state[8] = sum - (two_s8 + two_s8);
     // V[9] = 1/2^2
-    state[9] = sum + s9.halve().halve();
+    state[9] = sum + s9.div_2exp_u64(2);
     // V[10] = -1/2^2
-    state[10] = sum - s10.halve().halve();
+    state[10] = sum - s10.div_2exp_u64(2);
     // V[11] = 1/2^3
-    state[11] = sum + s11.halve().halve().halve();
+    state[11] = sum + s11.div_2exp_u64(3);
 }
 
 /// Apply one internal round of the width-16 Goldilocks Poseidon2 internal linear layer to a
@@ -234,20 +234,19 @@ fn internal_round_goldilocks_16(
     let two_s8 = s8 + s8;
     state[8] = sum - (two_s8 + two_s8);
     // V[9] = 1/2^3
-    state[9] = sum + s9.halve().halve().halve();
+    state[9] = sum + s9.div_2exp_u64(3);
     // V[10] = 1/2^4
-    state[10] = sum + s10.halve().halve().halve().halve();
+    state[10] = sum + s10.div_2exp_u64(4);
     // V[11] = 1/2^5
-    state[11] = sum + s11.halve().halve().halve().halve().halve();
+    state[11] = sum + s11.div_2exp_u64(5);
     // V[12] = -1/2^3
-    state[12] = sum - s12.halve().halve().halve();
+    state[12] = sum - s12.div_2exp_u64(3);
     // V[13] = -1/2^4
-    state[13] = sum - s13.halve().halve().halve().halve();
+    state[13] = sum - s13.div_2exp_u64(4);
     // V[14] = -1/2^5
-    state[14] = sum - s14.halve().halve().halve().halve().halve();
+    state[14] = sum - s14.div_2exp_u64(5);
     // V[15] = 1/2^32
-    let inv_2_32 = crate::MATRIX_DIAG_16_GOLDILOCKS[15];
-    state[15] = sum + s15 * inv_2_32;
+    state[15] = sum + s15.div_2exp_u64(32);
 }
 
 /// The internal layers of the Poseidon2 permutation, specialized for `PackedGoldilocksWasmSimd128`.

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -147,6 +147,19 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
         match exp {
             0 => *self,
             1 => self.halve(),
+            2..=32 => unsafe {
+                let x = self.to_vector();
+                let lo = _mm256_and_si256(x, _mm256_set1_epi64x((1i64 << exp) - 1));
+                let hi = _mm256_srl_epi64(x, _mm_cvtsi64_si128(exp as i64));
+                let a = _mm256_add_epi64(
+                    hi,
+                    _mm256_sll_epi64(lo, _mm_cvtsi64_si128((32 - exp) as i64)),
+                );
+                let b = _mm256_sll_epi64(lo, _mm_cvtsi64_si128((64 - exp) as i64));
+                // 2^-exp = 2^(32-exp) - 2^(64-exp) mod P. Both a and b are
+                // below P; in particular b <= 2^64 - 2^32, as required by the helper.
+                Self::from_vector(shift(sub_small_64s_64_s(shift(a), b)))
+            },
             _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
         }
     }

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -132,6 +132,26 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     }
 
     #[inline]
+    fn mul_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.double(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(exp)),
+        }
+    }
+
+    #[inline]
+    fn div_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.halve(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
+        }
+    }
+
+    #[inline]
     fn square(&self) -> Self {
         Self::from_vector(square(self.to_vector()))
     }

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -214,6 +214,18 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     }
 
     #[inline]
+    fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
+        if (2..=6).contains(&N) {
+            Self::from_vector(dot_product_delayed_reduce::<N>(|i| {
+                (lhs[i].to_vector(), rhs[i].to_vector())
+            }))
+        } else {
+            let products: [Self; N] = core::array::from_fn(|i| lhs[i] * rhs[i]);
+            Self::sum_array::<N>(&products)
+        }
+    }
+
+    #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
@@ -247,11 +259,17 @@ impl Algebra<Goldilocks> for PackedGoldilocksAVX2 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(
-            a,
-            f,
-            <Self as Algebra<Goldilocks>>::BATCHED_LC_CHUNK,
-        )
+        if (2..=6).contains(&N) {
+            Self::from_vector(dot_product_delayed_reduce::<N>(|i| {
+                (a[i].to_vector(), Self::broadcast(f[i]).to_vector())
+            }))
+        } else {
+            dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(
+                a,
+                f,
+                <Self as Algebra<Goldilocks>>::BATCHED_LC_CHUNK,
+            )
+        }
     }
 }
 
@@ -653,6 +671,61 @@ unsafe fn sub_small_64s_64_s(x_s: __m256i, y: __m256i) -> __m256i {
         // The mask contains 0xffffffff in the high 32 bits if wraparound occurred and 0 otherwise.
         let wrapback_amt = _mm256_srli_epi64::<32>(mask); // -FIELD_ORDER if underflowed else 0.
         _mm256_sub_epi64(res_wrapped_s, wrapback_amt)
+    }
+}
+
+/// Accumulate 2..=6 full-u64 products without losing carries above bit 128.
+///
+/// With B = 2^32, the exact sum is lo + B^2 * mid + B^3 * top. Each product
+/// contributes its low64 word, the bottom32 of its high64 word, and its top32.
+/// Carries from lo enter mid. After k terms, mid <= k*B - 1 and top <= k*(B - 1),
+/// so neither accumulator can overflow for k <= 6, even for noncanonical inputs.
+#[inline]
+fn dot_product_delayed_reduce<const N: usize>(
+    inputs: impl Fn(usize) -> (__m256i, __m256i),
+) -> __m256i {
+    debug_assert!((2..=6).contains(&N));
+    unsafe {
+        let (a, b) = inputs(0);
+        let (hi, lo) = mul64_64(a, b);
+        let mut lo_s = shift(lo);
+        let mut mid = _mm256_and_si256(hi, EPSILON);
+        let mut top = _mm256_srli_epi64::<32>(hi);
+        let mut accumulate = |i| {
+            let (a, b) = inputs(i);
+            let (hi, lo) = mul64_64(a, b);
+            let old_s = lo_s;
+            lo_s = _mm256_add_epi64(lo_s, lo);
+            // Shifted signed order is unsigned order of the unshifted low words.
+            let carry = _mm256_cmpgt_epi64(old_s, lo_s);
+            mid = _mm256_add_epi64(mid, _mm256_and_si256(hi, EPSILON));
+            mid = _mm256_sub_epi64(mid, carry);
+            top = _mm256_add_epi64(top, _mm256_srli_epi64::<32>(hi));
+        };
+        // Spell out the bounded schedule so LLVM can interleave every product,
+        // including the six-term case that otherwise retains a counted loop.
+        accumulate(1);
+        if N > 2 {
+            accumulate(2);
+        }
+        if N > 3 {
+            accumulate(3);
+        }
+        if N > 4 {
+            accumulate(4);
+        }
+        if N > 5 {
+            accumulate(5);
+        }
+
+        // B^2 = B - 1 and B^3 = -1 modulo P. Splitting mid at bit 32 gives
+        // lo - (top + (mid >> 32)) + (mid & (B - 1)) * (B - 1).
+        // correction <= N*B - 1 and term <= (B - 1)^2 are both below
+        // 2^64 - 2^32, satisfying the small-sub/add helper bounds.
+        let correction = _mm256_add_epi64(top, _mm256_srli_epi64::<32>(mid));
+        let term = _mm256_mul_epu32(mid, EPSILON);
+        let adjusted_s = sub_small_64s_64_s(lo_s, correction);
+        shift(add_small_64s_64_s(adjusted_s, term))
     }
 }
 

--- a/goldilocks/src/x86_64_avx2/packing.rs
+++ b/goldilocks/src/x86_64_avx2/packing.rs
@@ -137,6 +137,50 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX2 {
     }
 
     #[inline]
+    fn sum_array<const N: usize>(input: &[Self]) -> Self {
+        assert_eq!(N, input.len());
+        match N {
+            0 => Self::ZERO,
+            1 => input[0],
+            2 => input[0] + input[1],
+            3 => input[0] + input[1] + input[2],
+            4 => (input[0] + input[1]) + (input[2] + input[3]),
+            5 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<1>(&input[4..]),
+            6 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<2>(&input[4..]),
+            7 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<3>(&input[4..]),
+            8 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<4>(&input[4..]),
+            9..=63 => {
+                // Keep the existing eight-term trees for short sums: carry bookkeeping
+                // adds latency until enough independent work amortizes the final fold.
+                let mut acc = Self::sum_array::<8>(&input[..8]);
+                for i in (16..=N).step_by(8) {
+                    acc += Self::sum_array::<8>(&input[(i - 8)..i]);
+                }
+                let tail = &input[(8 * (N / 8))..];
+                match N & 7 {
+                    0 => acc,
+                    1 => acc + Self::sum_array::<1>(tail),
+                    2 => acc + Self::sum_array::<2>(tail),
+                    3 => acc + Self::sum_array::<3>(tail),
+                    4 => acc + Self::sum_array::<4>(tail),
+                    5 => acc + Self::sum_array::<5>(tail),
+                    6 => acc + Self::sum_array::<6>(tail),
+                    7 => acc + Self::sum_array::<7>(tail),
+                    _ => unreachable!(),
+                }
+            }
+            _ => {
+                let mut chunks = input.chunks(MAX_SUM_CHUNK);
+                let mut sum = Self::from_vector(sum_delayed_reduce(chunks.next().unwrap()));
+                for chunk in chunks {
+                    sum += Self::from_vector(sum_delayed_reduce(chunk));
+                }
+                sum
+            }
+        }
+    }
+
+    #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
@@ -248,6 +292,7 @@ const SHIFTED_FIELD_ORDER: __m256i =
 
 /// Equal to 2^32 - 1 = 2^64 mod P.
 const EPSILON: __m256i = unsafe { transmute([Goldilocks::ORDER_U64.wrapping_neg(); WIDTH]) };
+const MAX_SUM_CHUNK: usize = 64;
 
 /// Add 2^63 with overflow. Needed to emulate unsigned comparisons (see point 3. in
 /// packed_prime_field.rs).
@@ -447,6 +492,119 @@ unsafe fn add_small_64s_64_s(x_s: __m256i, y: __m256i) -> __m256i {
     }
 }
 
+/// Sum a nonempty chunk of at most [`MAX_SUM_CHUNK`] arbitrary packed u64 values.
+#[inline]
+fn sum_delayed_reduce(input: &[PackedGoldilocksAVX2]) -> __m256i {
+    debug_assert!(!input.is_empty());
+    debug_assert!(input.len() <= MAX_SUM_CHUNK);
+
+    unsafe {
+        let zero = _mm256_setzero_si256();
+
+        // Only a final chunk can have fewer than four terms. A single dependency chain is
+        // preferable for this small tail and avoids indexing four empty accumulators.
+        if input.len() < 4 {
+            let mut lo_s = shift(input[0].to_vector());
+            let mut carries = zero;
+            for value in &input[1..] {
+                let old_s = lo_s;
+                lo_s = _mm256_add_epi64(lo_s, value.to_vector());
+                let carry = _mm256_cmpgt_epi64(old_s, lo_s);
+                carries = _mm256_sub_epi64(carries, carry);
+            }
+
+            let correction = _mm256_sub_epi64(_mm256_slli_epi64::<32>(carries), carries);
+            return shift(add_small_64s_64_s(lo_s, correction));
+        }
+
+        let (groups, remainder) = input.as_chunks::<4>();
+        let (first, groups) = groups.split_first().unwrap();
+        let mut lo0_s = shift(first[0].to_vector());
+        let mut lo1_s = shift(first[1].to_vector());
+        let mut lo2_s = shift(first[2].to_vector());
+        let mut lo3_s = shift(first[3].to_vector());
+        let mut carries0 = zero;
+        let mut carries1 = zero;
+        let mut carries2 = zero;
+        let mut carries3 = zero;
+
+        // Keep these four updates explicit so the independent dependency chains are visible
+        // to the compiler without dynamically indexing an accumulator array.
+        for values in groups {
+            let old0_s = lo0_s;
+            lo0_s = _mm256_add_epi64(lo0_s, values[0].to_vector());
+            let carry0 = _mm256_cmpgt_epi64(old0_s, lo0_s);
+            carries0 = _mm256_sub_epi64(carries0, carry0);
+
+            let old1_s = lo1_s;
+            lo1_s = _mm256_add_epi64(lo1_s, values[1].to_vector());
+            let carry1 = _mm256_cmpgt_epi64(old1_s, lo1_s);
+            carries1 = _mm256_sub_epi64(carries1, carry1);
+
+            let old2_s = lo2_s;
+            lo2_s = _mm256_add_epi64(lo2_s, values[2].to_vector());
+            let carry2 = _mm256_cmpgt_epi64(old2_s, lo2_s);
+            carries2 = _mm256_sub_epi64(carries2, carry2);
+
+            let old3_s = lo3_s;
+            lo3_s = _mm256_add_epi64(lo3_s, values[3].to_vector());
+            let carry3 = _mm256_cmpgt_epi64(old3_s, lo3_s);
+            carries3 = _mm256_sub_epi64(carries3, carry3);
+        }
+
+        // Distribute the one-to-three remainder terms across distinct chains.
+        if let Some(value) = remainder.first() {
+            let old_s = lo0_s;
+            lo0_s = _mm256_add_epi64(lo0_s, value.to_vector());
+            let carry = _mm256_cmpgt_epi64(old_s, lo0_s);
+            carries0 = _mm256_sub_epi64(carries0, carry);
+        }
+        if let Some(value) = remainder.get(1) {
+            let old_s = lo1_s;
+            lo1_s = _mm256_add_epi64(lo1_s, value.to_vector());
+            let carry = _mm256_cmpgt_epi64(old_s, lo1_s);
+            carries1 = _mm256_sub_epi64(carries1, carry);
+        }
+        if let Some(value) = remainder.get(2) {
+            let old_s = lo2_s;
+            lo2_s = _mm256_add_epi64(lo2_s, value.to_vector());
+            let carry = _mm256_cmpgt_epi64(old_s, lo2_s);
+            carries2 = _mm256_sub_epi64(carries2, carry);
+        }
+
+        let (lo01_s, carries01) = merge_sum_accumulators(lo0_s, carries0, lo1_s, carries1);
+        let (lo23_s, carries23) = merge_sum_accumulators(lo2_s, carries2, lo3_s, carries3);
+        let (lo_s, carries) = merge_sum_accumulators(lo01_s, carries01, lo23_s, carries23);
+
+        // Each chain counts its internal low-word carries, and each merge adds the carry from
+        // combining its two low words. Thus the final count is the carry count of the exact
+        // whole-chunk sum and is at most `input.len() - 1 <= 63`.
+        // Since `2^64 = 2^32 - 1 (mod P)`, the correction is `(c << 32) - c`.
+        // It is at most `63 * (2^32 - 1) < P`, so the bounded add is valid.
+        let correction = _mm256_sub_epi64(_mm256_slli_epi64::<32>(carries), carries);
+        shift(add_small_64s_64_s(lo_s, correction))
+    }
+}
+
+/// Merge two exact delayed-sum states, including the carry from adding their low words.
+#[inline(always)]
+unsafe fn merge_sum_accumulators(
+    lo0_s: __m256i,
+    carries0: __m256i,
+    lo1_s: __m256i,
+    carries1: __m256i,
+) -> (__m256i, __m256i) {
+    unsafe {
+        // Both inputs are shifted, so undo the second shift before adding it to the first. The
+        // result remains shifted and can use a signed comparison for the unsigned merge carry.
+        let lo_s = _mm256_add_epi64(lo0_s, shift(lo1_s));
+        let carry = _mm256_cmpgt_epi64(lo0_s, lo_s);
+        let carries = _mm256_add_epi64(carries0, carries1);
+        let carries = _mm256_sub_epi64(carries, carry);
+        (lo_s, carries)
+    }
+}
+
 /// Goldilocks subtraction of a "small" number. `x_s` is pre-shifted by 2**63. `y` is assumed to be
 /// <= `0xffffffff00000000`. The result is shifted by 2**63.
 #[inline]
@@ -516,7 +674,10 @@ fn square(x: __m256i) -> __m256i {
 
 #[cfg(test)]
 mod tests {
+    use p3_field::{PackedValue, PrimeCharacteristicRing, PrimeField64};
     use p3_field_testing::test_packed_field;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::{Goldilocks, PackedGoldilocksAVX2, WIDTH};
 
@@ -540,6 +701,64 @@ mod tests {
         0x0000_0000_0000_0001,
         0xFFFF_FFFF_0000_0002,
     ]));
+
+    #[test]
+    fn sum_array_chunk_remainders_match_full_u64_oracle() {
+        fn check<const N: usize>(values: [[u64; WIDTH]; N]) {
+            let input = values.map(|lanes| PackedGoldilocksAVX2(Goldilocks::new_array(lanes)));
+            let actual = PackedGoldilocksAVX2::sum_array::<N>(&input);
+            let delayed = (N <= super::MAX_SUM_CHUNK)
+                .then(|| PackedGoldilocksAVX2::from_vector(super::sum_delayed_reduce(&input)));
+
+            for lane in 0..WIDTH {
+                let expected = (values
+                    .iter()
+                    .map(|term| u128::from(term[lane]))
+                    .sum::<u128>()
+                    % u128::from(Goldilocks::ORDER_U64)) as u64;
+                assert_eq!(
+                    actual.as_slice()[lane].as_canonical_u64(),
+                    expected,
+                    "N={N}, lane={lane}"
+                );
+                if let Some(delayed) = delayed {
+                    assert_eq!(delayed.as_slice()[lane].as_canonical_u64(), expected);
+                }
+            }
+        }
+
+        macro_rules! check_length {
+            ($rng:ident, $n:literal) => {{
+                const EDGES: [u64; 8] = [
+                    0,
+                    1,
+                    (1 << 32) - 1,
+                    1 << 32,
+                    1 << 63,
+                    Goldilocks::ORDER_U64 - 1,
+                    Goldilocks::ORDER_U64,
+                    u64::MAX,
+                ];
+                check::<$n>(core::array::from_fn(|term| {
+                    core::array::from_fn(|lane| EDGES[(term * WIDTH + lane) % EDGES.len()])
+                }));
+                check::<$n>([[u64::MAX; WIDTH]; $n]);
+                for _ in 0..8 {
+                    check::<$n>(core::array::from_fn(|_| $rng.random()));
+                }
+            }};
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0xA2_51_65_66_67);
+        check_length!(rng, 9);
+        check_length!(rng, 10);
+        check_length!(rng, 11);
+        check_length!(rng, 63);
+        check_length!(rng, 64);
+        check_length!(rng, 65);
+        check_length!(rng, 66);
+        check_length!(rng, 67);
+    }
 
     test_packed_field!(
         crate::PackedGoldilocksAVX2,

--- a/goldilocks/src/x86_64_avx2/poseidon2.rs
+++ b/goldilocks/src/x86_64_avx2/poseidon2.rs
@@ -221,20 +221,19 @@ fn internal_round_goldilocks_16(state: &mut [PackedGoldilocksAVX2; 16], rc: Pack
     let two_s8 = s8 + s8;
     state[8] = sum - (two_s8 + two_s8);
     // V[9] = 1/2^3
-    state[9] = sum + s9.halve().halve().halve();
+    state[9] = sum + s9.div_2exp_u64(3);
     // V[10] = 1/2^4
-    state[10] = sum + s10.halve().halve().halve().halve();
+    state[10] = sum + s10.div_2exp_u64(4);
     // V[11] = 1/2^5
-    state[11] = sum + s11.halve().halve().halve().halve().halve();
+    state[11] = sum + s11.div_2exp_u64(5);
     // V[12] = -1/2^3
-    state[12] = sum - s12.halve().halve().halve();
+    state[12] = sum - s12.div_2exp_u64(3);
     // V[13] = -1/2^4
-    state[13] = sum - s13.halve().halve().halve().halve();
+    state[13] = sum - s13.div_2exp_u64(4);
     // V[14] = -1/2^5
-    state[14] = sum - s14.halve().halve().halve().halve().halve();
+    state[14] = sum - s14.div_2exp_u64(5);
     // V[15] = 1/2^32
-    let inv_2_32 = crate::MATRIX_DIAG_16_GOLDILOCKS[15];
-    state[15] = sum + s15 * inv_2_32;
+    state[15] = sum + s15.div_2exp_u64(32);
 }
 
 /// The internal layers of the Poseidon2 permutation, specialized for `PackedGoldilocksAVX2`.

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -132,6 +132,26 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     }
 
     #[inline]
+    fn mul_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.double(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(exp)),
+        }
+    }
+
+    #[inline]
+    fn div_2exp_u64(&self, mut exp: u64) -> Self {
+        exp %= 192;
+        match exp {
+            0 => *self,
+            1 => self.halve(),
+            _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
+        }
+    }
+
+    #[inline]
     fn square(&self) -> Self {
         Self::from_vector(square(self.to_vector()))
     }

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -13,7 +13,7 @@ use p3_field::op_assign_macros::{
     impl_sum_prod_base_field, ring_sum,
 };
 use p3_field::{
-    Algebra, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
+    Algebra, Dup, Field, InjectiveMonomial, PackedField, PackedFieldPow2, PackedValue,
     PermutationMonomial, PrimeCharacteristicRing, PrimeField64, dispatch_chunked_mixed_dot_product,
     impl_packed_field_pow_2,
 };
@@ -137,6 +137,50 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     }
 
     #[inline]
+    fn sum_array<const N: usize>(input: &[Self]) -> Self {
+        assert_eq!(N, input.len());
+        match N {
+            0 => Self::ZERO,
+            1 => input[0].dup(),
+            2 => input[0].dup() + input[1].dup(),
+            3 => input[0].dup() + input[1].dup() + input[2].dup(),
+            4 => (input[0].dup() + input[1].dup()) + (input[2].dup() + input[3].dup()),
+            5 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<1>(&input[4..]),
+            6 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<2>(&input[4..]),
+            7 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<3>(&input[4..]),
+            8 => Self::sum_array::<4>(&input[..4]) + Self::sum_array::<4>(&input[4..]),
+            9..=63 => {
+                // Keep the existing eight-term trees for short sums: carry bookkeeping
+                // adds latency until enough independent work amortizes the final fold.
+                let mut acc = Self::sum_array::<8>(&input[..8]);
+                for i in (16..=N).step_by(8) {
+                    acc += Self::sum_array::<8>(&input[(i - 8)..i]);
+                }
+                let tail = &input[(8 * (N / 8))..];
+                match N & 7 {
+                    0 => acc,
+                    1 => acc + Self::sum_array::<1>(tail),
+                    2 => acc + Self::sum_array::<2>(tail),
+                    3 => acc + Self::sum_array::<3>(tail),
+                    4 => acc + Self::sum_array::<4>(tail),
+                    5 => acc + Self::sum_array::<5>(tail),
+                    6 => acc + Self::sum_array::<6>(tail),
+                    7 => acc + Self::sum_array::<7>(tail),
+                    _ => unreachable!(),
+                }
+            }
+            _ => {
+                let mut chunks = input.chunks(MAX_SUM_CHUNK);
+                let mut sum = Self::from_vector(sum_delayed_reduce(chunks.next().unwrap()));
+                for chunk in chunks {
+                    sum += Self::from_vector(sum_delayed_reduce(chunk));
+                }
+                sum
+            }
+        }
+    }
+
+    #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
@@ -196,6 +240,7 @@ impl_packed_field_pow_2!(
 
 const FIELD_ORDER: __m512i = unsafe { transmute([Goldilocks::ORDER_U64; WIDTH]) };
 const EPSILON: __m512i = unsafe { transmute([Goldilocks::ORDER_U64.wrapping_neg(); WIDTH]) };
+const MAX_SUM_CHUNK: usize = 64;
 
 #[inline]
 unsafe fn canonicalize(x: __m512i) -> __m512i {
@@ -238,6 +283,118 @@ unsafe fn sub_no_double_overflow_64_64(x: __m512i, y: __m512i) -> __m512i {
         let mask = _mm512_cmplt_epu64_mask(x, y); // mask set if sub will underflow (x < y)
         let res_wrapped = _mm512_sub_epi64(x, y);
         _mm512_mask_add_epi64(res_wrapped, mask, res_wrapped, FIELD_ORDER)
+    }
+}
+
+/// Sum a nonempty chunk of at most [`MAX_SUM_CHUNK`] arbitrary packed u64 values.
+#[inline]
+fn sum_delayed_reduce(input: &[PackedGoldilocksAVX512]) -> __m512i {
+    debug_assert!(!input.is_empty());
+    debug_assert!(input.len() <= MAX_SUM_CHUNK);
+
+    unsafe {
+        let zero = _mm512_setzero_si512();
+        let one = _mm512_set1_epi64(1);
+
+        // Only a final chunk can have fewer than four terms. A single dependency chain is
+        // preferable for this small tail and avoids indexing four empty accumulators.
+        if input.len() < 4 {
+            let mut lo = input[0].to_vector();
+            let mut carries = zero;
+            for value in &input[1..] {
+                let old = lo;
+                lo = _mm512_add_epi64(lo, value.to_vector());
+                let carry = _mm512_cmplt_epu64_mask(lo, old);
+                carries = _mm512_mask_add_epi64(carries, carry, carries, one);
+            }
+
+            let correction = _mm512_sub_epi64(_mm512_slli_epi64::<32>(carries), carries);
+            return add_no_double_overflow_64_64(lo, correction);
+        }
+
+        let (groups, remainder) = input.as_chunks::<4>();
+        let (first, groups) = groups.split_first().unwrap();
+        let mut lo0 = first[0].to_vector();
+        let mut lo1 = first[1].to_vector();
+        let mut lo2 = first[2].to_vector();
+        let mut lo3 = first[3].to_vector();
+        let mut carries0 = zero;
+        let mut carries1 = zero;
+        let mut carries2 = zero;
+        let mut carries3 = zero;
+
+        // Keep these four updates explicit so the independent dependency chains are visible
+        // to the compiler without dynamically indexing an accumulator array.
+        for values in groups {
+            let old0 = lo0;
+            lo0 = _mm512_add_epi64(lo0, values[0].to_vector());
+            let carry0 = _mm512_cmplt_epu64_mask(lo0, old0);
+            carries0 = _mm512_mask_add_epi64(carries0, carry0, carries0, one);
+
+            let old1 = lo1;
+            lo1 = _mm512_add_epi64(lo1, values[1].to_vector());
+            let carry1 = _mm512_cmplt_epu64_mask(lo1, old1);
+            carries1 = _mm512_mask_add_epi64(carries1, carry1, carries1, one);
+
+            let old2 = lo2;
+            lo2 = _mm512_add_epi64(lo2, values[2].to_vector());
+            let carry2 = _mm512_cmplt_epu64_mask(lo2, old2);
+            carries2 = _mm512_mask_add_epi64(carries2, carry2, carries2, one);
+
+            let old3 = lo3;
+            lo3 = _mm512_add_epi64(lo3, values[3].to_vector());
+            let carry3 = _mm512_cmplt_epu64_mask(lo3, old3);
+            carries3 = _mm512_mask_add_epi64(carries3, carry3, carries3, one);
+        }
+
+        // Distribute the one-to-three remainder terms across distinct chains.
+        if let Some(value) = remainder.first() {
+            let old = lo0;
+            lo0 = _mm512_add_epi64(lo0, value.to_vector());
+            let carry = _mm512_cmplt_epu64_mask(lo0, old);
+            carries0 = _mm512_mask_add_epi64(carries0, carry, carries0, one);
+        }
+        if let Some(value) = remainder.get(1) {
+            let old = lo1;
+            lo1 = _mm512_add_epi64(lo1, value.to_vector());
+            let carry = _mm512_cmplt_epu64_mask(lo1, old);
+            carries1 = _mm512_mask_add_epi64(carries1, carry, carries1, one);
+        }
+        if let Some(value) = remainder.get(2) {
+            let old = lo2;
+            lo2 = _mm512_add_epi64(lo2, value.to_vector());
+            let carry = _mm512_cmplt_epu64_mask(lo2, old);
+            carries2 = _mm512_mask_add_epi64(carries2, carry, carries2, one);
+        }
+
+        let (lo01, carries01) = merge_sum_accumulators(lo0, carries0, lo1, carries1);
+        let (lo23, carries23) = merge_sum_accumulators(lo2, carries2, lo3, carries3);
+        let (lo, carries) = merge_sum_accumulators(lo01, carries01, lo23, carries23);
+
+        // Each chain counts its internal low-word carries, and each merge adds the carry from
+        // combining its two low words. Thus the final count is the carry count of the exact
+        // whole-chunk sum and is at most `input.len() - 1 <= 63`.
+        // Since `2^64 = 2^32 - 1 (mod P)`, the correction is `(c << 32) - c`, at most
+        // `63 * (2^32 - 1) < P`, so the bounded add is valid.
+        let correction = _mm512_sub_epi64(_mm512_slli_epi64::<32>(carries), carries);
+        add_no_double_overflow_64_64(lo, correction)
+    }
+}
+
+/// Merge two exact delayed-sum states, including the carry from adding their low words.
+#[inline(always)]
+unsafe fn merge_sum_accumulators(
+    lo0: __m512i,
+    carries0: __m512i,
+    lo1: __m512i,
+    carries1: __m512i,
+) -> (__m512i, __m512i) {
+    unsafe {
+        let lo = _mm512_add_epi64(lo0, lo1);
+        let carry = _mm512_cmplt_epu64_mask(lo, lo0);
+        let carries = _mm512_add_epi64(carries0, carries1);
+        let carries = _mm512_mask_add_epi64(carries, carry, carries, _mm512_set1_epi64(1));
+        (lo, carries)
     }
 }
 
@@ -409,7 +566,10 @@ fn square(x: __m512i) -> __m512i {
 
 #[cfg(test)]
 mod tests {
+    use p3_field::{PackedValue, PrimeCharacteristicRing, PrimeField64};
     use p3_field_testing::test_packed_field;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
 
     use super::{Goldilocks, PackedGoldilocksAVX512, WIDTH};
 
@@ -445,6 +605,64 @@ mod tests {
         0x0000_0000_0000_0001,
         0xFFFF_FFFF_0000_0002,
     ]));
+
+    #[test]
+    fn sum_array_chunk_remainders_match_full_u64_oracle() {
+        fn check<const N: usize>(values: [[u64; WIDTH]; N]) {
+            let input = values.map(|lanes| PackedGoldilocksAVX512(Goldilocks::new_array(lanes)));
+            let actual = PackedGoldilocksAVX512::sum_array::<N>(&input);
+            let delayed = (N <= super::MAX_SUM_CHUNK)
+                .then(|| PackedGoldilocksAVX512::from_vector(super::sum_delayed_reduce(&input)));
+
+            for lane in 0..WIDTH {
+                let expected = (values
+                    .iter()
+                    .map(|term| u128::from(term[lane]))
+                    .sum::<u128>()
+                    % u128::from(Goldilocks::ORDER_U64)) as u64;
+                assert_eq!(
+                    actual.as_slice()[lane].as_canonical_u64(),
+                    expected,
+                    "N={N}, lane={lane}"
+                );
+                if let Some(delayed) = delayed {
+                    assert_eq!(delayed.as_slice()[lane].as_canonical_u64(), expected);
+                }
+            }
+        }
+
+        macro_rules! check_length {
+            ($rng:ident, $n:literal) => {{
+                const EDGES: [u64; 8] = [
+                    0,
+                    1,
+                    (1 << 32) - 1,
+                    1 << 32,
+                    1 << 63,
+                    Goldilocks::ORDER_U64 - 1,
+                    Goldilocks::ORDER_U64,
+                    u64::MAX,
+                ];
+                check::<$n>(core::array::from_fn(|term| {
+                    core::array::from_fn(|lane| EDGES[(term * WIDTH + lane) % EDGES.len()])
+                }));
+                check::<$n>([[u64::MAX; WIDTH]; $n]);
+                for _ in 0..8 {
+                    check::<$n>(core::array::from_fn(|_| $rng.random()));
+                }
+            }};
+        }
+
+        let mut rng = SmallRng::seed_from_u64(0xA7_51_65_66_67);
+        check_length!(rng, 9);
+        check_length!(rng, 10);
+        check_length!(rng, 11);
+        check_length!(rng, 63);
+        check_length!(rng, 64);
+        check_length!(rng, 65);
+        check_length!(rng, 66);
+        check_length!(rng, 67);
+    }
 
     test_packed_field!(
         crate::PackedGoldilocksAVX512,

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -147,6 +147,19 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
         match exp {
             0 => *self,
             1 => self.halve(),
+            2..=32 => unsafe {
+                let x = self.to_vector();
+                let lo = _mm512_and_si512(x, _mm512_set1_epi64((1i64 << exp) - 1));
+                let hi = _mm512_srl_epi64(x, _mm_cvtsi64_si128(exp as i64));
+                let a = _mm512_add_epi64(
+                    hi,
+                    _mm512_sll_epi64(lo, _mm_cvtsi64_si128((32 - exp) as i64)),
+                );
+                let b = _mm512_sll_epi64(lo, _mm_cvtsi64_si128((64 - exp) as i64));
+                // 2^-exp = 2^(32-exp) - 2^(64-exp) mod P. Both a and b are
+                // below P, so a - b > -P and one borrow correction suffices.
+                Self::from_vector(sub_no_double_overflow_64_64(a, b))
+            },
             _ => *self * Self::broadcast(Goldilocks::power_of_two(192 - exp)),
         }
     }

--- a/goldilocks/src/x86_64_avx512/packing.rs
+++ b/goldilocks/src/x86_64_avx512/packing.rs
@@ -214,6 +214,18 @@ impl PrimeCharacteristicRing for PackedGoldilocksAVX512 {
     }
 
     #[inline]
+    fn dot_product<const N: usize>(lhs: &[Self; N], rhs: &[Self; N]) -> Self {
+        if (2..=6).contains(&N) {
+            Self::from_vector(dot_product_delayed_reduce::<N>(|i| {
+                (lhs[i].to_vector(), rhs[i].to_vector())
+            }))
+        } else {
+            let products: [Self; N] = core::array::from_fn(|i| lhs[i] * rhs[i]);
+            Self::sum_array::<N>(&products)
+        }
+    }
+
+    #[inline]
     fn zero_vec(len: usize) -> Vec<Self> {
         // SAFETY: this is a repr(transparent) wrapper around an array.
         unsafe { reconstitute_from_base(Goldilocks::zero_vec(len * WIDTH)) }
@@ -233,11 +245,17 @@ impl Algebra<Goldilocks> for PackedGoldilocksAVX512 {
 
     #[inline(always)]
     fn mixed_dot_product<const N: usize>(a: &[Self; N], f: &[Goldilocks; N]) -> Self {
-        dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(
-            a,
-            f,
-            <Self as Algebra<Goldilocks>>::BATCHED_LC_CHUNK,
-        )
+        if (2..=6).contains(&N) {
+            Self::from_vector(dot_product_delayed_reduce::<N>(|i| {
+                (a[i].to_vector(), Self::broadcast(f[i]).to_vector())
+            }))
+        } else {
+            dispatch_chunked_mixed_dot_product::<Self, Goldilocks, N>(
+                a,
+                f,
+                <Self as Algebra<Goldilocks>>::BATCHED_LC_CHUNK,
+            )
+        }
     }
 }
 
@@ -552,6 +570,45 @@ fn square64(x: __m512i) -> (__m512i, __m512i) {
         let res_lo = _mm512_add_epi64(mul_ll, mul_lh_lo);
 
         (res_hi, res_lo)
+    }
+}
+
+/// Accumulate 2..=6 full-u64 products without losing carries above bit 128.
+///
+/// With B = 2^32, the exact sum is lo + B^2 * mid + B^3 * top. Each product
+/// contributes its low64 word, the bottom32 of its high64 word, and its top32.
+/// Carries from lo enter mid. After k terms, mid <= k*B - 1 and top <= k*(B - 1),
+/// so neither accumulator can overflow for k <= 6, even for noncanonical inputs.
+#[inline]
+fn dot_product_delayed_reduce<const N: usize>(
+    inputs: impl Fn(usize) -> (__m512i, __m512i),
+) -> __m512i {
+    debug_assert!((2..=6).contains(&N));
+    unsafe {
+        let (a, b) = inputs(0);
+        let (hi, mut lo) = mul64_64(a, b);
+        let mut mid = _mm512_and_si512(hi, EPSILON);
+        let mut top = _mm512_srli_epi64::<32>(hi);
+        let one = _mm512_set1_epi64(1);
+        for i in 1..N {
+            let (a, b) = inputs(i);
+            let (hi, product_lo) = mul64_64(a, b);
+            let old = lo;
+            lo = _mm512_add_epi64(lo, product_lo);
+            let carry = _mm512_cmplt_epu64_mask(lo, old);
+            mid = _mm512_add_epi64(mid, _mm512_and_si512(hi, EPSILON));
+            mid = _mm512_mask_add_epi64(mid, carry, mid, one);
+            top = _mm512_add_epi64(top, _mm512_srli_epi64::<32>(hi));
+        }
+
+        // B^2 = B - 1 and B^3 = -1 modulo P. Splitting mid at bit 32 gives
+        // lo - (top + (mid >> 32)) + (mid & (B - 1)) * (B - 1).
+        // correction <= N*B - 1 and term <= (B - 1)^2 are both below P,
+        // satisfying the no-double-overflow helper bounds for arbitrary lo.
+        let correction = _mm512_add_epi64(top, _mm512_srli_epi64::<32>(mid));
+        let term = _mm512_mul_epu32(mid, EPSILON);
+        let adjusted = sub_no_double_overflow_64_64(lo, correction);
+        add_no_double_overflow_64_64(adjusted, term)
     }
 }
 

--- a/goldilocks/src/x86_64_avx512/poseidon2.rs
+++ b/goldilocks/src/x86_64_avx512/poseidon2.rs
@@ -232,20 +232,19 @@ fn internal_round_goldilocks_16(
     let two_s8 = s8 + s8;
     state[8] = sum - (two_s8 + two_s8);
     // V[9] = 1/2^3
-    state[9] = sum + s9.halve().halve().halve();
+    state[9] = sum + s9.div_2exp_u64(3);
     // V[10] = 1/2^4
-    state[10] = sum + s10.halve().halve().halve().halve();
+    state[10] = sum + s10.div_2exp_u64(4);
     // V[11] = 1/2^5
-    state[11] = sum + s11.halve().halve().halve().halve().halve();
+    state[11] = sum + s11.div_2exp_u64(5);
     // V[12] = -1/2^3
-    state[12] = sum - s12.halve().halve().halve();
+    state[12] = sum - s12.div_2exp_u64(3);
     // V[13] = -1/2^4
-    state[13] = sum - s13.halve().halve().halve().halve();
+    state[13] = sum - s13.div_2exp_u64(4);
     // V[14] = -1/2^5
-    state[14] = sum - s14.halve().halve().halve().halve().halve();
+    state[14] = sum - s14.div_2exp_u64(5);
     // V[15] = 1/2^32
-    let inv_2_32 = crate::MATRIX_DIAG_16_GOLDILOCKS[15];
-    state[15] = sum + s15 * inv_2_32;
+    state[15] = sum + s15.div_2exp_u64(32);
 }
 
 /// The internal layers of the Poseidon2 permutation, specialized for `PackedGoldilocksAVX512`.

--- a/goldilocks/src/x86_64_avx512/poseidon2.rs
+++ b/goldilocks/src/x86_64_avx512/poseidon2.rs
@@ -203,7 +203,9 @@ fn internal_round_goldilocks_16(
     let s13 = state[13];
     let s14 = state[14];
     let s15 = state[15];
-    let sum_tail = s1 + s2 + s3 + s4 + s5 + s6 + s7 + s8 + s9 + s10 + s11 + s12 + s13 + s14 + s15;
+    let sum_tail = PackedGoldilocksAVX512::sum_array::<15>(&[
+        s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15,
+    ]);
 
     add_rc_and_sbox(&mut state[0], rc);
     let s0 = state[0];

--- a/mds/src/util.rs
+++ b/mds/src/util.rs
@@ -98,13 +98,15 @@ pub fn apply_circulant_fft_precomputed<
     input: &[F; N],
 ) -> [F; N] {
     // Transform the input vector to the frequency domain.
-    let input = fft.dft(input.to_vec());
+    let mut input = fft.dft(input.to_vec());
 
     // Convolution theorem: point-wise multiply in frequency domain.
-    let product = freq_column.iter().zip(input).map(|(&x, y)| x * y).collect();
+    for (&coefficient, value) in freq_column.iter().zip(&mut input) {
+        *value = coefficient * *value;
+    }
 
     // Transform back to the time domain to get the circulant product.
-    let output = fft.idft(product);
+    let output = fft.idft(input);
     output.try_into().unwrap()
 }
 

--- a/poseidon2/benches/poseidon2.rs
+++ b/poseidon2/benches/poseidon2.rs
@@ -3,14 +3,14 @@ use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_bn254::{
     BN254_POSEIDON2_HALF_FULL_ROUNDS, BN254_POSEIDON2_PARTIAL_ROUNDS_3, Bn254, Poseidon2Bn254,
 };
-use p3_field::{Field, PrimeCharacteristicRing};
+use p3_field::{Field, PackedValue, PrimeCharacteristicRing};
 use p3_goldilocks::{Goldilocks, Poseidon2Goldilocks};
 use p3_koala_bear::{KoalaBear, Poseidon2KoalaBear};
 use p3_mersenne_31::{Mersenne31, Poseidon2Mersenne31};
 use p3_symmetric::Permutation;
 use p3_util::pretty_name;
-use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use rand::{RngExt, SeedableRng};
 
 fn bench_poseidon12(c: &mut Criterion) {
     let mut rng = SmallRng::seed_from_u64(1);
@@ -32,10 +32,13 @@ fn bench_poseidon12(c: &mut Criterion) {
 
     let poseidon2_gold_8 = Poseidon2Goldilocks::<8>::new_from_rng_128(&mut rng);
     poseidon2::<Goldilocks, Poseidon2Goldilocks<8>, 8>(c, &poseidon2_gold_8);
+    poseidon2_goldilocks_varied::<8>(c, &poseidon2_gold_8);
     let poseidon2_gold_12 = Poseidon2Goldilocks::<12>::new_from_rng_128(&mut rng);
     poseidon2::<Goldilocks, Poseidon2Goldilocks<12>, 12>(c, &poseidon2_gold_12);
+    poseidon2_goldilocks_varied::<12>(c, &poseidon2_gold_12);
     let poseidon2_gold_16 = Poseidon2Goldilocks::<16>::new_from_rng_128(&mut rng);
     poseidon2::<Goldilocks, Poseidon2Goldilocks<16>, 16>(c, &poseidon2_gold_16);
+    poseidon2_goldilocks_varied::<16>(c, &poseidon2_gold_16);
 
     let poseidon2_bn254 = Poseidon2Bn254::<3>::new_from_rng(
         2 * BN254_POSEIDON2_HALF_FULL_ROUNDS,
@@ -54,6 +57,48 @@ where
     let name = format!("poseidon2::<{}, {}>", pretty_name::<F::Packing>(), WIDTH);
     let id = BenchmarkId::new(name, WIDTH);
     c.bench_with_input(id, &input, |b, &input| b.iter(|| poseidon2.permute(input)));
+}
+
+fn poseidon2_goldilocks_varied<const WIDTH: usize>(
+    c: &mut Criterion,
+    poseidon2: &Poseidon2Goldilocks<WIDTH>,
+) where
+    Poseidon2Goldilocks<WIDTH>:
+        Permutation<[Goldilocks; WIDTH]> + Permutation<[<Goldilocks as Field>::Packing; WIDTH]>,
+{
+    const INPUT_COUNT: usize = 64;
+    let mut input_rng = SmallRng::seed_from_u64(0x9e37_79b9_7f4a_7c15);
+    let scalar_inputs: [[Goldilocks; WIDTH]; INPUT_COUNT] = core::array::from_fn(|_| {
+        core::array::from_fn(|_| Goldilocks::new(input_rng.random::<u64>()))
+    });
+    let packed_inputs: [[<Goldilocks as Field>::Packing; WIDTH]; INPUT_COUNT] =
+        core::array::from_fn(|_| {
+            core::array::from_fn(|_| {
+                <Goldilocks as Field>::Packing::from_fn(|_| {
+                    Goldilocks::new(input_rng.random::<u64>())
+                })
+            })
+        });
+
+    let scalar_id = BenchmarkId::new("poseidon2 Goldilocks varied scalar", WIDTH);
+    c.bench_with_input(scalar_id, &scalar_inputs, |b, inputs| {
+        let mut index = 0;
+        b.iter(|| {
+            let input = std::hint::black_box(inputs[index]);
+            index = (index + 1) & (INPUT_COUNT - 1);
+            std::hint::black_box(poseidon2.permute(input))
+        });
+    });
+
+    let packed_id = BenchmarkId::new("poseidon2 Goldilocks varied packed", WIDTH);
+    c.bench_with_input(packed_id, &packed_inputs, |b, inputs| {
+        let mut index = 0;
+        b.iter(|| {
+            let input = std::hint::black_box(inputs[index]);
+            index = (index + 1) & (INPUT_COUNT - 1);
+            std::hint::black_box(poseidon2.permute(input))
+        });
+    });
 }
 
 criterion_group!(benches, bench_poseidon12);


### PR DESCRIPTION
Reduce Goldilocks arithmetic costs across scalar, AVX2, AVX-512, NEON/SVE2, and Wasm SIMD implementations. The changes preserve field results for every raw `u64` representation, including noncanonical values, without changing public APIs, serialization, or production dependencies.

The branch contains 27 optimization commits and two test-only lint cleanups, keeping independent algorithms and backends separately reviewable.

## Changes

- Specialize division by small powers of two, packed power coefficients, full-width integer conversion, and two-adic square roots.
- Delay reduction in cubic Frobenius, short x86 dot products, and large packed sums. Use four accumulation chains for sums at N >= 64; preserve the existing short paths.
- Reduce NEON multiplication register pressure; keep SVE2 dot reduction in vector registers, accumulate slice linear combinations directly, and vectorize packed-RHS dots at N >= 32.
- Keep Wasm carry detection vectorized and eliminate temporary sum copies with a bounded final carry fold.
- Cache the existing small-batch MDS transform plan and reuse its pointwise-product buffer, reducing warm allocations from four to one.
- Apply direct power division to generic/Wasm Poseidon2 widths 12/16 and x86 width 16; balance the AVX-512 width-16 tail sum.
- Add varied-input benchmarks and independent full-range arithmetic oracles covering carry saturation, noncanonical inputs, chunk boundaries, and packed/scalar equivalence.

## Performance

Numbers below are reductions in elapsed time from matched before/after comparisons for each optimization. They are incremental, not additive, and do not establish a combined whole-prover speedup.

Dedicated hosts: AMD EPYC 9R45 / Zen 5 (`c8a.2xlarge`) and Graviton4 / Neoverse V2 (`c8g.2xlarge`), Rust 1.97.0 / LLVM 22.1.6, CPU 2 pinning. Native builds use `target-cpu=native`; AVX2 disables AVX-512F and NEON disables SVE/SVE2. Criterion uses 30 samples, 0.5 s warmup, and 1 s measurement; scratch dependency/throughput kernels use repeated warmed calls and seven-trial medians. Wasm measurements use Wasmtime 45.0.2 and Node 26.3.1, with optimizing-only Node controls where noted.

| Shared operation / consumer | Zen 5 | Graviton4 |
|---|---:|---:|
| Small-power division, 200 independent values | 95.6% | 75.0-75.3% |
| `u128` / `i128` conversion | 61.7% / 51.3% | 89.6% / 87.0% |
| Cubic Frobenius / complete cubic inversion | 19.2% / 2.8% | 19.5% / 3.3% |
| Square roots, varied inputs | 8.1-15.7% | 15.4-16.8% |
| MDS32 / MDS64 caching | 19.3% / 19.7% | 22.4% / 19.7% |
| Additional MDS buffer reuse | ~0.8% | 0.4-1.7% |
| Complete FFTs from NEON multiplication change | N/A | 6.0-6.3% DIT; 10.1-10.9% Bowers |

The independent division-array result includes compiler vectorization; it is not scalar dependency-chain latency.

| Packed measurement | AVX2 | AVX-512 | NEON | SVE2 |
|---|---:|---:|---:|---:|
| Fixed small-power division latency | 53-54% | 63-65% | 35-42% | 53-59% |
| Large sums, independent work | 66-69% | 27-34% | 28-37% | 34-39% |
| Large sums, dependent chains | 50-66% | 28-31% | 24-37% | 28-39% |
| EF2 / EF3 / EF5 multiplication, independent work | 16.6 / 27.7 / 39.3% | 6.9 / 9.7 / 13.6% | — | — |

SVE2 short mixed dots save 12-22% independently and 10-14% dependently. Large packed dots save 4-33% and 6-27%, respectively. Slice linear combinations save 14-42% at useful measured sizes; length 1024 is neutral.

Direct division in Poseidon2 width 16 saves 6.2% on AVX2, 0.8-2.9% on AVX-512, and approximately 9% on the Zen 5 scalar path. The separate AVX-512 tail-sum change saves 0.5-6%, depending on input/layout.

| Wasm host / engine | Fixed small-power division latency | Sum optimization, selected sizes | Packed Poseidon2 width 16, direct division |
|---|---:|---:|---:|
| Zen 5 / Wasmtime | 36-37% | 25-43% | 10.7-10.9% |
| Zen 5 / Node | 38-40% | 23-63% | ~9%; ~12% optimizing-only |
| Graviton4 / Wasmtime | 51-54% | 22-41% | ~9% |
| Graviton4 / Node | 49-52% | 5-21% | ~9% |

The separate Wasm carry change saves 20-42% on sums and 0.6-4.3% on complete Poseidon2. Sum ranges cover different useful sizes across engines.

### Tradeoffs and coverage limits

- MDS caching increases first-call allocations from 6 to 23; buffer reuse brings that to 22. Instrumented cold-call medians increase roughly 0.7 microseconds on Zen 5 and 3 microseconds on Graviton4. Warm allocations fall 4 -> 2 -> 1.
- AVX-512 dot N=2 dependent latency regresses ~4.8%; actual EF2/3/5 multiplication improves in both throughput and latency. Fixed packed division at exponent 95 regresses ~3.3% AVX2 / ~5.9% AVX-512 in latency.
- Wasm has localized tradeoffs: the carry change regresses x86 Wasmtime dots N=3/4 by 6.4%/3.4%; the sum change regresses one width-16 permutation case by 1.5%; direct hash division regresses width-12 varied throughput by 2.9% on x86 Wasmtime while improving its latency by 1.6%.
- Small and medium paths retain their existing implementations where setup costs or dependency latency outweigh gains. x86 Poseidon2 width 12 retains its original power expressions.
- Graviton4 runtime coverage is SVE VL=128. Wider-VL safety was reviewed from predicate, pointer, and lane bounds; wider hardware and Intel CPUs were not measured.

## Validation

Exact final source: Goldilocks release library tests passed 211 AVX2, 211 AVX-512, 186 scalar, 375 NEON, 379 SVE2, and 207 Wasm tests on each host, with zero failures.

Broader release library suites cover Goldilocks, field, MDS, DFT, Poseidon1/2, BabyBear, KoalaBear, and Mersenne31: 1,057 passing tests per x86 SIMD mode, 886 scalar, 1,224 NEON, and 1,228 SVE2. Parallel Goldilocks/field/DFT suites passed 246 x86 and 412 Arm tests. Doctests passed one test with six repository-marked ignored examples. These broad runs precede only the final restoration of the original x86 width-12 expressions and the test-only Wasm lint cleanup; exact-final Goldilocks and x86 Clippy checks were repeated afterward.

- Native strict Clippy: `cargo clippy --locked -p p3-goldilocks -p p3-field -p p3-mds -p p3-poseidon2 --all-targets --no-deps -- -D warnings` passed in all five modes.
- `cargo +nightly fmt --all -- --check`, `git diff --check`, and `scripts/check.py fast --package p3-goldilocks` passed.
- Wasm build and packed/scalar smoke checks passed via `scripts/check.py wasm`.
- Wasm filters only the two existing Poseidon constant-generator tests that spawn Python, which WASI cannot execute; native suites run them. Wasm Clippy checks supported lib/bin/test targets and passes with only the existing `doc_overindented_list_items` lint allowed for eight unchanged module-doc lines. Criterion benchmark dependencies are intentionally unavailable on Wasm.

All implementation timings ran on dedicated EC2 hosts, without stopping other local sessions. Both task-owned hosts were explicitly terminated after evidence collection.
