### PR TITLE
ci: reduce exhaustive test runtime

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -22,6 +22,10 @@ env:
 jobs:
   whir_exhaustive:
     name: WHIR exhaustive tests
+    env:
+      # Optimize the exhaustive sweep while retaining the test profile's
+      # debug assertions and overflow checks.
+      CARGO_PROFILE_TEST_OPT_LEVEL: 1
     strategy:
       matrix:
         include:

--- a/binary-dft/tests/commit.rs
+++ b/binary-dft/tests/commit.rs
@@ -113,16 +113,26 @@ fn polynomial_commit_matches_naive_for_both_orders() {
     let mmcs = mmcs();
     for folding in [0, 2, 4, 6] {
         for rate in [1, 2, 3] {
+            let mut unfolded_root = None;
             for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
-                let message = match order {
-                    VariableOrder::Prefix => {
-                        RowMajorMatrixView::new(&values, 1 << (8 - folding)).transpose()
-                    }
-                    VariableOrder::Suffix => RowMajorMatrix::new(values.clone(), 1 << folding),
+                let reference_root = || {
+                    let message = match order {
+                        VariableOrder::Prefix => {
+                            RowMajorMatrixView::new(&values, 1 << (8 - folding)).transpose()
+                        }
+                        VariableOrder::Suffix => RowMajorMatrix::new(values.clone(), 1 << folding),
+                    };
+                    let expected = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default()
+                        .encode_batch(message, rate);
+                    mmcs.commit_matrix(expected).0
                 };
-                let expected = AdditiveRsEncoder::<F, NaiveAdditiveNtt<F>>::default()
-                    .encode_batch(message, rate);
-                let (expected_root, _) = mmcs.commit_matrix(expected);
+                // Without folding, both orders have the same single-column message.
+                // Share its expensive reference encoding, but check both production paths.
+                let expected_root = if folding == 0 {
+                    unfolded_root.get_or_insert_with(reference_root).clone()
+                } else {
+                    reference_root()
+                };
                 let (root, _) = commit_base(
                     order,
                     &AdditiveRsEncoder::<F>::default(),


### PR DESCRIPTION
This should hopefully reduce non-negligibly the CI runtime (became a bit slow lately).