### PR TITLE
feat(sumcheck)!: drive the hiding sumcheck transcript through the typed Fiat-Shamir layer

### DIFF
--- a/sumcheck/src/error.rs
+++ b/sumcheck/src/error.rs
@@ -46,12 +46,14 @@ pub enum SumcheckError {
         actual: usize,
     },
 
-    /// HVZK sumcheck: a per-round wire payload had the wrong number of field
-    /// elements. Each round must carry `max(ℓ_zk - 1, 2)` elements (after the
-    /// linear coefficient is skipped per Lemma 6.4 / paper §6).
+    /// HVZK sumcheck: a per-round wire payload had the wrong number of field elements.
+    ///
+    /// Each round carries `max(ell_zk, 3) - 1` of them.
+    ///
+    /// The linear coefficient is the one left off, per Lemma 6.4 and paper §6.
     #[error("HVZK round {round}: wire size mismatch, expected {expected}, got {actual}")]
     WireSizeMismatch {
-        /// Round index where the mismatch was found.
+        /// Round index where the mismatch was found, counted from zero.
         round: usize,
         /// Element count the configuration fixes.
         expected: usize,
@@ -59,17 +61,26 @@ pub enum SumcheckError {
         actual: usize,
     },
 
-    /// HVZK sumcheck: the proof's claimed `ell_zk` (mask code message length)
-    /// does not match the verifier's expected value. Catches caller-side
-    /// configuration mismatch between prover and verifier before the wire
-    /// shape check.
-    #[error("HVZK ell_zk mismatch: expected {expected}, got {actual}")]
-    EllZkMismatch {
+    /// HVZK sumcheck: the base field has characteristic two.
+    ///
+    /// Lemma 6.4 inverts the endpoint identity, which divides by two.
+    #[error("HVZK sumcheck: Lemma 6.4 requires char(F) != 2")]
+    EvenCharacteristic,
+
+    /// HVZK sumcheck: the mask code message is too short to hide a round.
+    ///
+    /// A mask of degree `ell_zk - 1` must cover the degree-2 plain piece.
+    #[error("HVZK sumcheck: mask message length {ell_zk} is below the required 3")]
+    MaskTooShort {
         /// Mask code message length the configuration fixes.
-        expected: usize,
-        /// Mask code message length the proof carries.
-        actual: usize,
+        ell_zk: usize,
     },
+
+    /// HVZK sumcheck: a masked batch was configured with no rounds.
+    ///
+    /// Such a batch commits no mask and reduces no claim.
+    #[error("HVZK sumcheck: a masked batch must run at least one round")]
+    NoRounds,
 
     /// An opening claim's evaluations do not match the requested column shape.
     ///

--- a/sumcheck/src/zk/data.rs
+++ b/sumcheck/src/zk/data.rs
@@ -47,12 +47,6 @@ pub struct ZkSumcheckData<F, EF> {
     /// Lives in the extension field because the mask coefficients do.
     pub mu_tilde: EF,
 
-    /// Message length of the zero-knowledge mask code.
-    ///
-    /// The verifier rejects up front if its own expected value disagrees with this.
-    /// Pinning this in the transcript closes a non-injectivity gap in the wire-length check: lengths `2` and `3` share a wire layout.
-    pub ell_zk: usize,
-
     /// Per-round wire payload with the linear coefficient dropped.
     ///
     /// One entry per sumcheck round.
@@ -71,8 +65,6 @@ impl<F, EF: Field> Default for ZkSumcheckData<F, EF> {
         Self {
             // Real runs overwrite this in step 2 once the prover has summed the masks.
             mu_tilde: EF::ZERO,
-            // Sentinel: honest runs set this to the encoding's message length; the verifier rejects 0.
-            ell_zk: 0,
             // Filled with one wire entry per sumcheck round.
             round_coefficients: Vec::new(),
             // Filled only when grinding is enabled.

--- a/sumcheck/src/zk/mod.rs
+++ b/sumcheck/src/zk/mod.rs
@@ -46,7 +46,8 @@
 //!
 //! # Module layout
 //!
-//! - Transcript schema and mask oracle handle.
+//! - Proof record and mask oracle handle.
+//! - Fiat-Shamir description of one masked batch, driven by all three parties.
 //! - Prover-side sumcheck with mask sampling and round-polynomial assembly.
 //! - Verifier-side replay with the dropped-coefficient reconstruction.
 //! - Witness-free simulator used to prove honest-verifier zero-knowledge.
@@ -62,7 +63,11 @@
 //! - Base field characteristic must not be `2`.
 //! - Mask message length `ell_zk` must be at least `3`, so the mask (degree `ell_zk - 1`) covers the degree-2 plain round polynomial.
 //!
-//! Both are checked at constructor entry.
+//! Both are checked where the transcript description is built.
+//!
+//! A prover treats a violation as its own configuration bug.
+//!
+//! A verifier reports it.
 //!
 //! # References
 //!
@@ -71,6 +76,7 @@
 pub mod data;
 pub mod prover;
 pub mod simulator;
+pub mod transcript;
 pub mod verifier;
 
 #[cfg(test)]
@@ -82,4 +88,5 @@ pub use data::{
 };
 pub use prover::{ZkLayout, ZkPrefixProver, ZkProver, ZkSuffixProver, stack_codewords};
 pub use simulator::simulate_classic_unpacked;
+pub use transcript::{ZkPrelude, ZkProverTranscript, ZkSumcheckShape, ZkVerifierTranscript};
 pub use verifier::ZkVerifier;

--- a/sumcheck/src/zk/prover/common.rs
+++ b/sumcheck/src/zk/prover/common.rs
@@ -3,17 +3,26 @@
 //! Covers mask sampling and auxiliary-target bookkeeping.
 //! Both prefix and suffix overlays invoke them before the per-round loop starts.
 //! Per-round polynomial assembly lives in a sibling module.
+//!
+//! Neither helper touches a transcript.
+//!
+//! The masking prelude is one step sequence, owned by the transcript module.
+//!
+//! Everything that feeds it is computed here.
+//!
+//! The prover and the witness-free simulator therefore share both halves.
+//!
+//! Neither keeps a copy of the other's.
 
 use alloc::vec::Vec;
 
-use p3_challenger::{CanObserve, FieldChallenger};
 use p3_commit::Mmcs;
-use p3_field::{ExtensionField, Field};
+use p3_field::Field;
 use p3_matrix::Matrix;
 use p3_zk_codes::ZkEncodingWithRandomness;
 use rand::Rng;
 
-use crate::zk::data::{MaskOracle, ZkSumcheckData};
+use crate::zk::data::MaskOracle;
 
 /// Sample `k` mask polynomials, encode them, and commit the batch as one
 /// interleaved oracle.
@@ -32,7 +41,6 @@ use crate::zk::data::{MaskOracle, ZkSumcheckData};
 /// - `encoding` — zero-knowledge encoder.
 ///   Defines the mask message space and draws a uniform sample on demand.
 /// - `mmcs` — Merkle commitment scheme over the codeword alphabet.
-/// - `challenger` — Fiat–Shamir transcript that absorbs the commitment.
 /// - `rng` — driver for both the mask coefficients and the encoder's randomness budget.
 ///
 /// # Returns
@@ -47,11 +55,10 @@ use crate::zk::data::{MaskOracle, ZkSumcheckData};
 ///                 so the base case can reveal blinded combinations of it
 /// ```
 #[allow(clippy::type_complexity)]
-pub(super) fn sample_masks<F, Enc, M, Ch, R>(
+pub(crate) fn sample_masks<F, Enc, M, R>(
     k: usize,
     encoding: &Enc,
     mmcs: &M,
-    challenger: &mut Ch,
     rng: &mut R,
 ) -> (Vec<Vec<F>>, Vec<Vec<F>>, MaskOracle<F, M>)
 where
@@ -59,7 +66,6 @@ where
     Enc: ZkEncodingWithRandomness<F>,
     Enc::Codeword: Matrix<F>,
     M: Mmcs<F>,
-    Ch: CanObserve<M::Commitment>,
     R: Rng,
 {
     // One uniform sample per round, drawn through the encoding so the message
@@ -77,12 +83,11 @@ where
     // separately and stacking the codewords column-wise.
     let (commit, prover_data) =
         mmcs.commit_matrix(encoding.encode_batch_with_randomness(&masks, &mask_randomness));
-    challenger.observe(commit.clone());
 
     (masks, mask_randomness, (commit, prover_data))
 }
 
-/// Compute the auxiliary target, record it on the transcript, and return the running endpoint sum.
+/// Compute the auxiliary target and the running endpoint sum.
 ///
 /// Implements step 2 of the masking layer.
 ///
@@ -95,19 +100,15 @@ where
 ///
 /// # Returns
 ///
-/// The running endpoint sum across all rounds.
-/// The auxiliary target itself is written directly to the transcript record.
-pub(super) fn observe_masks_and_mu_tilde<F, EF, Ch>(
-    masks: &[Vec<EF>],
-    k: usize,
-    ell_zk: usize,
-    challenger: &mut Ch,
-    zk_data: &mut ZkSumcheckData<F, EF>,
-) -> EF
+/// - The auxiliary target `mu_tilde`, which the caller records and binds.
+/// - The running endpoint sum across all rounds.
+///
+/// # Panics
+///
+/// In debug builds, when the closed form disagrees with the naive sum over the cube.
+pub(crate) fn mask_endpoints<EF>(masks: &[Vec<EF>], k: usize) -> (EF, EF)
 where
-    F: Field,
-    EF: ExtensionField<F>,
-    Ch: FieldChallenger<F>,
+    EF: Field,
 {
     // Endpoint sum used by the closed form.
     //
@@ -151,13 +152,7 @@ where
         );
     }
 
-    // Observe the auxiliary target.
-    challenger.observe_algebra_element(mu_tilde);
-    // Pin the transcript record so the verifier reads the same metadata.
-    zk_data.mu_tilde = mu_tilde;
-    zk_data.ell_zk = ell_zk;
-
-    sum_endpoints_init
+    (mu_tilde, sum_endpoints_init)
 }
 
 #[cfg(test)]
@@ -170,14 +165,13 @@ mod tests {
     use rand::rngs::SmallRng;
 
     use super::*;
-    use crate::zk::test_helpers::{EF, F, MyChallenger, make_setup};
+    use crate::zk::test_helpers::{EF, make_setup};
 
     #[test]
-    fn observe_masks_and_mu_tilde_matches_hand_computed_value() {
+    fn mask_endpoints_matches_hand_computed_value() {
         // Fixture:
         //
         //     k       = 2
-        //     ell_zk  = 3
         //     mask[0] = [1, 2, 3]
         //     mask[1] = [4, 5, 6]
         //
@@ -194,57 +188,11 @@ mod tests {
             vec![EF::from_u32(1), EF::from_u32(2), EF::from_u32(3)],
             vec![EF::from_u32(4), EF::from_u32(5), EF::from_u32(6)],
         ];
-        let k = 2;
-        let ell_zk = 3;
 
-        let (perm, _, _) = make_setup(0, ell_zk);
-        let mut challenger = MyChallenger::new(perm);
-        let mut zk_data = ZkSumcheckData::<F, EF>::default();
-        let endpoints = observe_masks_and_mu_tilde::<F, EF, _>(
-            &masks,
-            k,
-            ell_zk,
-            &mut challenger,
-            &mut zk_data,
-        );
+        let (mu_tilde, endpoints) = mask_endpoints::<EF>(&masks, 2);
 
-        // Returned endpoint sum and transcript record fields.
         assert_eq!(endpoints, EF::from_u32(26));
-        assert_eq!(zk_data.mu_tilde, EF::from_u32(52));
-        assert_eq!(zk_data.ell_zk, ell_zk);
-    }
-
-    #[test]
-    fn observe_masks_and_mu_tilde_advances_challenger() {
-        // Invariant:
-        //
-        //     observe(mu_tilde)  ⇒  next sampled challenge differs from the
-        //                           one a fresh challenger would have produced.
-        //
-        // Fixture: single mask of length 2; mu_tilde value is irrelevant.
-        let masks = vec![vec![EF::from_u32(1), EF::from_u32(2)]];
-        let k = 1;
-        let ell_zk = 2;
-
-        let (perm, _, _) = make_setup(0, ell_zk);
-
-        // Baseline: sample without observing.
-        let mut ch_baseline = MyChallenger::new(perm.clone());
-        let baseline: EF = ch_baseline.sample_algebra_element();
-
-        // Observed: sample after observing mu_tilde.
-        let mut ch_observed = MyChallenger::new(perm);
-        let mut zk_data = ZkSumcheckData::<F, EF>::default();
-        let _ = observe_masks_and_mu_tilde::<F, EF, _>(
-            &masks,
-            k,
-            ell_zk,
-            &mut ch_observed,
-            &mut zk_data,
-        );
-        let after_observe: EF = ch_observed.sample_algebra_element();
-
-        assert_ne!(baseline, after_observe);
+        assert_eq!(mu_tilde, EF::from_u32(52));
     }
 
     #[test]
@@ -257,12 +205,11 @@ mod tests {
         let k = 3;
         let ell_zk = 4;
         let seed = 0;
-        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
-        let mut challenger = MyChallenger::new(perm);
+        let (_perm, mmcs, encoding) = make_setup(seed, ell_zk);
         let mut rng = SmallRng::seed_from_u64(seed);
 
         let (masks, randomness, _oracle) =
-            sample_masks::<EF, _, _, _, _>(k, &encoding, &mmcs, &mut challenger, &mut rng);
+            sample_masks::<EF, _, _, _>(k, &encoding, &mmcs, &mut rng);
 
         assert_eq!(masks.len(), k);
         assert_eq!(randomness.len(), k);
@@ -283,17 +230,15 @@ mod tests {
         let k = 2;
         let ell_zk = 4;
         let seed = 42;
-        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+        let (_perm, mmcs, encoding) = make_setup(seed, ell_zk);
 
-        let mut ch1 = MyChallenger::new(perm.clone());
         let mut rng1 = SmallRng::seed_from_u64(seed);
         let (masks1, randomness1, oracle1) =
-            sample_masks::<EF, _, _, _, _>(k, &encoding, &mmcs, &mut ch1, &mut rng1);
+            sample_masks::<EF, _, _, _>(k, &encoding, &mmcs, &mut rng1);
 
-        let mut ch2 = MyChallenger::new(perm);
         let mut rng2 = SmallRng::seed_from_u64(seed);
         let (masks2, randomness2, oracle2) =
-            sample_masks::<EF, _, _, _, _>(k, &encoding, &mmcs, &mut ch2, &mut rng2);
+            sample_masks::<EF, _, _, _>(k, &encoding, &mmcs, &mut rng2);
 
         assert_eq!(masks1, masks2);
         assert_eq!(randomness1, randomness2);

--- a/sumcheck/src/zk/prover/mod.rs
+++ b/sumcheck/src/zk/prover/mod.rs
@@ -20,8 +20,11 @@
 //! - Per-round assembly: round-context type and the polynomial it builds.
 //! - Layout trait extension: per-mode residual handoff.
 //! - Generic prover: single `into_sumcheck` implementation parameterised by layout.
+//!
+//! The prelude helpers reach beyond this module.
+//! The witness-free simulator drives the same two, so no second copy of them exists.
 
-mod common;
+pub(crate) mod common;
 mod layout;
 mod residual;
 mod round;

--- a/sumcheck/src/zk/prover/residual.rs
+++ b/sumcheck/src/zk/prover/residual.rs
@@ -2,6 +2,7 @@
 
 use alloc::vec::Vec;
 
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, HornerIter};
@@ -10,9 +11,10 @@ use p3_multilinear_util::point::Point;
 use p3_zk_codes::ZkEncodingWithRandomness;
 use rand::Rng;
 
-use super::common::{observe_masks_and_mu_tilde, sample_masks};
+use super::common::{mask_endpoints, sample_masks};
 use super::round::{PlainPiece, RoundContext, RoundState, round_poly_to_wire};
 use crate::strategy::SumcheckProver;
+use crate::zk::transcript::{ZkProverTranscript, ZkSumcheckShape};
 use crate::zk::{ZkSumcheckData, ZkSumcheckHandoff};
 
 impl<F, EF> SumcheckProver<F, EF>
@@ -54,6 +56,11 @@ where
     /// - Only the weight side and the claim are scaled by `eps`.
     /// - The evaluation side stays the honest folded message.
     /// - An HVZK code-switch can therefore commit it verbatim.
+    ///
+    /// # Panics
+    ///
+    /// - The configuration cannot describe a masked batch.
+    /// - Folding factor exceeds the residual prover's arity.
     #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
     #[tracing::instrument(skip_all)]
     pub fn into_zk_sumcheck<Enc, M, R, Ch>(
@@ -68,42 +75,41 @@ where
         rng: &mut R,
     ) -> ZkSumcheckHandoff<F, EF, M>
     where
+        F: TranscriptField,
         Enc: ZkEncodingWithRandomness<EF>,
         Enc::Codeword: Matrix<EF>,
         M: Mmcs<EF>,
         R: Rng,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
-        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-        assert!(folding_factor >= 1, "sumcheck requires at least one round");
+        let ell_zk = encoding.message_len();
+
+        // This entry inherits its claim instead of batching recorded ones.
+        let shape = ZkSumcheckShape::new_inherited(folding_factor, ell_zk, pow_bits);
+
+        // Lemma 6.4 hypotheses, plus the one bound the transcript never sees.
+        shape
+            .validate::<F>()
+            .expect("a prover's own configuration must describe a masked batch");
         assert!(
             folding_factor <= self.num_variables(),
             "folding_factor must be <= residual prover arity",
         );
 
-        let ell_zk = encoding.message_len();
-        assert!(
-            ell_zk >= 3,
-            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
-        );
+        let mut transcript = ZkProverTranscript::<Ch, F, EF>::new(challenger, shape);
 
         // Unlike the layout-driven path, this entry receives a scalar claim
-        // directly, so bind it before the masking prelude samples `eps`.
+        // directly, so the description opens by binding it.
         //
         // The bound value is the joint claim, matching the verifier's view.
-        challenger.observe_algebra_element(self.claimed_sum() + aux_claim);
+        transcript.bind_claim(self.claimed_sum() + aux_claim);
 
         let (masks, mask_randomness, mask_oracle) =
-            sample_masks::<EF, _, _, _, _>(folding_factor, encoding, mmcs, challenger, rng);
-        let mut sum_future_endpoints = observe_masks_and_mu_tilde::<F, EF, _>(
-            &masks,
-            folding_factor,
-            ell_zk,
-            challenger,
-            zk_data,
-        );
+            sample_masks::<EF, _, _, _>(folding_factor, encoding, mmcs, rng);
+        let (mu_tilde, mut sum_future_endpoints) = mask_endpoints::<EF>(&masks, folding_factor);
+        zk_data.mu_tilde = mu_tilde;
 
-        let eps: EF = challenger.sample_algebra_element();
+        let eps: EF = transcript.masks(mask_oracle.0.clone(), mu_tilde);
         let mut rs = Vec::with_capacity(folding_factor);
         let mut mask_evals_at_gamma = Vec::with_capacity(folding_factor);
         let pow2: Vec<EF> = EF::TWO.powers().collect_n(folding_factor + 1);
@@ -149,14 +155,12 @@ where
                 },
             );
             let wire = round_poly_to_wire(&h);
-            challenger.observe_algebra_slice(&wire);
+
+            // One call binds the wire, grinds when enabled, and draws the challenge.
+            let (gamma, witness) = transcript.round(&wire);
             zk_data.round_coefficients.push(wire);
+            zk_data.pow_witnesses.extend(witness);
 
-            if pow_bits > 0 {
-                zk_data.pow_witnesses.push(challenger.grind(pow_bits));
-            }
-
-            let gamma: EF = challenger.sample_algebra_element();
             let mask_at_gamma = mask.iter().copied().horner(gamma);
             mask_evals_at_gamma.push(mask_at_gamma);
 
@@ -166,6 +170,9 @@ where
 
             rs.push(gamma);
         }
+
+        // Every described step has been played, so the sponge goes back to the caller.
+        transcript.finish();
 
         // The last challenge has no successor to fuse with.
         // The weight scaling below reads the tables, so it binds here.
@@ -320,6 +327,74 @@ mod tests {
             verifier_handoff.claimed_residual,
             prover_handoff.residual_prover.claimed_sum() + final_mask_residual,
         );
+    }
+
+    #[test]
+    fn a_verifier_handed_a_different_claim_diverges() {
+        // Invariant: the inherited claim is a described step, bound on both sides.
+        //
+        // Nothing inside this crate can compare the prover's scalar with the verifier's.
+        //
+        //     prover   ->  claimed_sum + aux_claim
+        //     verifier ->  whatever its caller supplies
+        //
+        // What the step buys is that a caller which disagrees moves `eps` and every challenge
+        // after it, so the residual handed back no longer matches the prover's.
+        //
+        // Fixture state: 3 variables, 2 rounds, mask length 4, no auxiliary claim.
+        let evals = Poly::new((1..=8).map(EF::from_u64).collect::<Vec<_>>());
+        let weights = Poly::new((11..=18).map(EF::from_u64).collect::<Vec<_>>());
+        let claimed_sum = dot_product::<EF, _, _>(
+            evals.as_slice().iter().copied(),
+            weights.as_slice().iter().copied(),
+        );
+        let poly = ProductPolynomial::<F, EF>::new_unpacked(VariableOrder::Prefix, evals, weights);
+
+        let ell_zk = 4;
+        let folding_factor = 2;
+        let (perm, mmcs, encoding) = make_setup(41, ell_zk);
+        let mut prover_challenger = MyChallenger::new(perm.clone());
+        let mut rng = SmallRng::seed_from_u64(43);
+        let mut zk_data = ZkSumcheckData::<F, EF>::default();
+
+        let prover_handoff = SumcheckProver::new(poly, claimed_sum).into_zk_sumcheck(
+            &mut zk_data,
+            &encoding,
+            &mmcs,
+            folding_factor,
+            0,
+            EF::ZERO,
+            &mut prover_challenger,
+            &mut rng,
+        );
+        let mask_commitment = prover_handoff.mask_oracle.0.clone();
+
+        // One replay per claim, both from the same fresh sponge.
+        let replay = |claim: EF| {
+            let mut challenger = MyChallenger::new(perm.clone());
+            ZkVerifier::<F, EF>::verify_claim::<MyMmcs, _>(
+                &zk_data,
+                &mask_commitment,
+                ell_zk,
+                folding_factor,
+                0,
+                claim,
+                &mut challenger,
+            )
+            .expect("a well-shaped proof always replays")
+        };
+
+        let honest = replay(claimed_sum);
+        let tampered = replay(claimed_sum + EF::ONE);
+
+        // The claim is bound before `eps`, so the whole stream moves with it.
+        assert_ne!(honest.eps, tampered.eps);
+        assert_ne!(honest.randomness, tampered.randomness);
+        assert_ne!(honest.claimed_residual, tampered.claimed_residual);
+
+        // The honest replay is the one that matches the prover.
+        assert_eq!(honest.randomness, prover_handoff.randomness);
+        assert_eq!(honest.eps, prover_handoff.eps);
     }
 
     #[test]

--- a/sumcheck/src/zk/prover/zk_prover.rs
+++ b/sumcheck/src/zk/prover/zk_prover.rs
@@ -3,6 +3,7 @@
 use alloc::vec::Vec;
 use core::marker::PhantomData;
 
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, HornerIter, TwoAdicField, dot_product};
@@ -11,7 +12,7 @@ use p3_multilinear_util::point::Point;
 use p3_zk_codes::{ZkEncoding, ZkEncodingWithRandomness};
 use rand::Rng;
 
-use super::common::{observe_masks_and_mu_tilde, sample_masks};
+use super::common::{mask_endpoints, sample_masks};
 use super::layout::ZkLayout;
 use super::round::{PlainPiece, RoundContext, RoundState, round_poly_to_wire};
 use crate::extrapolate_01inf;
@@ -21,6 +22,7 @@ use crate::strategy::SumcheckProver;
 use crate::svo::calculate_accumulators_batch;
 use crate::table::{OpeningEvals, OpeningRequest};
 use crate::zk::data::{ZkSumcheckData, ZkSumcheckHandoff};
+use crate::zk::transcript::{ZkProverTranscript, ZkSumcheckShape};
 
 /// Honest-verifier zero-knowledge sumcheck prover.
 ///
@@ -143,9 +145,9 @@ where
     /// # Phases
     ///
     /// 1. Plain-piece preamble (alpha, accumulators, plain_sum).
-    /// 2. Sample, encode, commit, observe masks (Construction 6.3 step 1).
-    /// 3. Compute and observe `mu_tilde` (step 2).
-    /// 4. Sample the combining challenge `eps` (step 3).
+    /// 2. Sample, encode and commit the masks (Construction 6.3 step 1).
+    /// 3. Compute `mu_tilde` from the mask endpoints (step 2).
+    /// 4. Bind the oracle and `mu_tilde`, then draw the combining challenge `eps` (step 3).
     /// 5. Per-round sumcheck (step 4).
     /// 6. Residual handoff scaled by `eps` (mode-specific compression).
     ///
@@ -158,9 +160,8 @@ where
     ///
     /// # Panics
     ///
-    /// - Base field characteristic is `2` (violates Lemma 6.4).
-    /// - Mask code message length is below `3` (mask must cover the degree-2 plain piece).
-    /// - Folding factor is `0` or exceeds the polynomial's arity.
+    /// - The configuration cannot describe a masked batch.
+    /// - Folding factor exceeds the polynomial's arity.
     #[allow(clippy::too_many_lines)]
     #[tracing::instrument(skip_all)]
     pub fn into_sumcheck<R, Ch>(
@@ -171,6 +172,7 @@ where
         rng: &mut R,
     ) -> ZkSumcheckHandoff<F, EF, M>
     where
+        F: TranscriptField,
         EF: TwoAdicField,
         Enc::Codeword: Matrix<EF>,
         R: Rng,
@@ -181,22 +183,25 @@ where
         let ell_zk = self.encoding.message_len();
         let n_vars = self.inner.num_variables();
 
-        // Lemma 6.4 hypotheses + sanity bounds on the folding factor.
-        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-        assert!(
-            ell_zk >= 3,
-            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
-        );
-        assert!(k >= 1, "sumcheck requires at least one round");
+        // The batch derives its claim from the claims the layout recorded.
+        let shape = ZkSumcheckShape::new_batching(k, ell_zk, pow_bits);
+
+        // Lemma 6.4 hypotheses, plus the one bound the transcript never sees.
+        shape
+            .validate::<F>()
+            .expect("a prover's own configuration must describe a masked batch");
         assert!(
             k <= n_vars,
             "folding_factor must be <= poly.num_variables()",
         );
 
+        // Every step from here on is played through the description.
+        let mut transcript = ZkProverTranscript::<Ch, F, EF>::new(challenger, shape);
+
         // Phase 1: plain-piece preamble (setup, precedes Construction 6.3).
 
         // `alpha` is the per-claim batching base: powers a^0, a^1, ... weight the claim accumulators below.
-        let alpha: EF = challenger.sample_algebra_element();
+        let alpha: EF = transcript.batching_challenge();
 
         // Materialise every alpha power in one batched pass.
         //
@@ -224,25 +229,25 @@ where
         // Plain sumcheck claim `mu`, batched by the alphas.
         let mut plain_sum = self.inner.batched_sum(alpha);
 
-        // Phase 2: sample, encode, commit, observe masks (Construction 6.3 step 1).
+        // Phase 2: sample, encode and commit the masks (Construction 6.3 step 1).
         //
         // The encoder draws zero-knowledge padding randomness from the same rng.
         let (masks, mask_randomness, mask_oracle) =
-            sample_masks::<EF, _, _, _, _>(k, &self.encoding, &self.mmcs, challenger, rng);
+            sample_masks::<EF, _, _, _>(k, &self.encoding, &self.mmcs, rng);
 
         // Phase 3: mu_tilde via the closed form (Construction 6.3 step 2).
         //
-        // The helper also seeds `zk_data` and returns the running future-mask
-        // endpoint budget for the per-round loop.
-        let sum_endpoints_init =
-            observe_masks_and_mu_tilde::<F, EF, _>(&masks, k, ell_zk, challenger, zk_data);
+        // The helper also returns the running future-mask endpoint budget for
+        // the per-round loop.
+        let (mu_tilde, sum_endpoints_init) = mask_endpoints::<EF>(&masks, k);
+        zk_data.mu_tilde = mu_tilde;
 
-        // Phase 4: combining challenge `eps` (Construction 6.3 step 3).
+        // Phase 4: bind the oracle and mu_tilde, then draw `eps` (Construction 6.3 step 3).
         //
         // The construction is instantiated over `EF`: the masks, `eps`, and the
         // round polynomials all live in `EF`, so Lemma 6.4 applies with `F := EF`
         // and the per-round polynomial is uniform over the full extension field.
-        let eps: EF = challenger.sample_algebra_element();
+        let eps: EF = transcript.masks(mask_oracle.0.clone(), mu_tilde);
 
         // Phase 5: per-round sumcheck (Construction 6.3 step 4).
 
@@ -325,17 +330,12 @@ where
             // reconstructs it from the affine identity.
             let wire = round_poly_to_wire(&h);
 
-            // Absorb the wire on the transcript and stash it.
-            challenger.observe_algebra_slice(&wire);
+            // One call binds the wire, grinds when enabled, and draws the challenge.
+            let (gamma_j, witness) = transcript.round(&wire);
+
+            // Record what the round produced alongside what it bound.
             zk_data.round_coefficients.push(wire);
-
-            // Optional grind before the per-round challenge.
-            if pow_bits > 0 {
-                zk_data.pow_witnesses.push(challenger.grind(pow_bits));
-            }
-
-            // Sample the per-round challenge gamma_j.
-            let gamma_j: EF = challenger.sample_algebra_element();
+            zk_data.pow_witnesses.extend(witness);
 
             // Cache s_j(gamma_j) via Horner for the past-mask term in future rounds.
             let s_j_at_gamma_j: EF = s_j.iter().copied().horner(gamma_j);
@@ -345,6 +345,9 @@ where
             plain_sum = extrapolate_01inf(plain_c0, plain_sum - plain_c0, plain_c_inf, gamma_j);
             rs.push(gamma_j);
         }
+
+        // Every described step has been played, so the sponge goes back to the caller.
+        transcript.finish();
 
         // Phase 6: residual handoff scaled by eps.
         //

--- a/sumcheck/src/zk/simulator.rs
+++ b/sumcheck/src/zk/simulator.rs
@@ -2,9 +2,10 @@
 
 use alloc::vec::Vec;
 
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
-use p3_field::{ExtensionField, Field, HornerIter};
+use p3_field::{ExtensionField, HornerIter};
 use p3_matrix::Matrix;
 use p3_multilinear_util::point::Point;
 use p3_zk_codes::ZkEncodingWithRandomness;
@@ -12,6 +13,8 @@ use rand::distr::{Distribution, StandardUniform};
 use rand::{Rng, RngExt};
 
 use super::data::ZkSumcheckData;
+use super::prover::common::{mask_endpoints, sample_masks};
+use super::transcript::{ZkProverTranscript, ZkSumcheckShape};
 use super::verifier::ZkVerifier;
 
 /// Witness-free HVZK simulator (Lemma 6.4).
@@ -24,6 +27,21 @@ use super::verifier::ZkVerifier;
 /// - Sample and commit fresh masks just like the prover.
 /// - Sample each wire coordinate uniformly over `EF` (the honest joint distribution).
 /// - Reconstruct the dropped `c_1` from the affine identity, so every simulated wire verifies by construction.
+///
+/// # Indistinguishability
+///
+/// The transcript is played through the prover's own description.
+///
+/// It runs over the prover's own mask helpers, not a copy of them.
+///
+/// ```text
+///     shape    ->  ZkSumcheckShape::new_batching, exactly as the layout prover builds it
+///     prelude  ->  the same drawn batching challenge
+///     masks    ->  sample_masks, then mask_endpoints
+///     rounds   ->  the same wire, grinding and challenge steps
+/// ```
+///
+/// A step this simulator plays out of order is a pattern failure, not a silent loss of hiding.
 ///
 /// # Scope
 ///
@@ -48,7 +66,7 @@ use super::verifier::ZkVerifier;
 ///
 /// # Panics
 ///
-/// Same precondition checks as the prover.
+/// When the configuration cannot describe a masked batch, exactly as the prover panics.
 #[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn simulate_classic_unpacked<F, EF, Enc, M, Challenger, R>(
     challenger: &mut Challenger,
@@ -60,7 +78,7 @@ pub fn simulate_classic_unpacked<F, EF, Enc, M, Challenger, R>(
     rng: &mut R,
 ) -> (ZkSumcheckData<F, EF>, M::Commitment, Point<EF>)
 where
-    F: Field,
+    F: TranscriptField,
     EF: ExtensionField<F>,
     Enc: ZkEncodingWithRandomness<EF>,
     Enc::Codeword: Matrix<EF>,
@@ -73,73 +91,55 @@ where
     let k = folding_factor;
     let ell_zk = encoding.message_len();
 
-    // Lemma 6.4 hypotheses.
-    assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-    assert!(
-        ell_zk >= 3,
-        "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
-    );
-    assert!(k >= 1, "sumcheck requires at least one round");
+    // The same description the layout prover builds from the same three numbers.
+    let shape = ZkSumcheckShape::new_batching(k, ell_zk, pow_bits);
+    shape
+        .validate::<F>()
+        .expect("a simulator's own configuration must describe a masked batch");
 
-    // Phase 1: sample alpha and derive mu (replays Construction 6.3 prelude).
+    let mut transcript = ZkProverTranscript::<Challenger, F, EF>::new(challenger, shape);
+
+    // Phase 1: draw alpha and derive mu (replays Construction 6.3 prelude).
     //
     // Honest prover's transcript order after the claim phase:
     //
-    //     alpha  ->  mask commits  ->  mu_tilde  ->  eps  ->  wires
+    //     alpha  ->  mask commit  ->  mu_tilde  ->  eps  ->  wires
     //
     // `verifier.sum(alpha)` reads only the recorded claims, so Lemma 6.4's witness-freeness is preserved.
-    let alpha: EF = challenger.sample_algebra_element();
+    let alpha: EF = transcript.batching_challenge();
     let mu = verifier.sum(alpha);
 
-    // Phase 2: sample, encode, commit, observe masks (Construction 6.3 step 1 replay).
+    // Phase 2: sample, encode and commit the masks (Construction 6.3 step 1 replay).
     //
     // Uniform messages produce uniform Reed-Solomon codewords.
     // Their Merkle commits are indistinguishable from the honest prover's (zero simulator error for RS).
-
-    let masks: Vec<Vec<EF>> = (0..k).map(|_| encoding.sample_message(rng)).collect();
-
-    // Draw explicit randomness in the same order as the prover, batch encode
-    // the masks into one width-`k` matrix, and commit once.
-    let mask_randomness: Vec<Vec<EF>> = masks
-        .iter()
-        .map(|_| encoding.sample_randomness(rng))
-        .collect();
-    let (mask_commitment, _prover_data) =
-        mmcs.commit_matrix(encoding.encode_batch_with_randomness(&masks, &mask_randomness));
-    challenger.observe(mask_commitment.clone());
+    //
+    // The prover's own helper draws them, so the two draw sequences cannot drift.
+    let (masks, _mask_randomness, (mask_commitment, _prover_data)) =
+        sample_masks::<EF, _, _, _>(k, encoding, mmcs, rng);
 
     // Phase 3: mu_tilde via the closed form (Construction 6.3 step 2 replay).
     //
     //     mu_tilde = 2^{k-1} * sum_l ( s_l(0) + s_l(1) )
-    //              = 2^{k-1} * sum_l ( mask[0].double() + sum(mask[1..]) )
     //
     // Byte-equivalent to the honest prover under matched RNG seeds.
-    let two_to_k_minus_1 = EF::TWO.exp_u64((k - 1) as u64);
-    let mu_tilde: EF = two_to_k_minus_1
-        * masks
-            .iter()
-            .map(|m| m[0].double() + m[1..].iter().copied().sum::<EF>())
-            .sum::<EF>();
+    let (mu_tilde, _endpoints) = mask_endpoints::<EF>(&masks, k);
 
-    // Observe mu_tilde and sample the combining challenge.
-    challenger.observe_algebra_element(mu_tilde);
-    let eps: EF = challenger.sample_algebra_element();
+    // Bind the oracle and mu_tilde, then draw the combining challenge.
+    let eps: EF = transcript.masks(mask_commitment.clone(), mu_tilde);
 
     // Phase 4: per-round wire sampling (Construction 6.3 step 4 simulated; every coordinate uniform over EF).
     //
     // Wire shape (linear coefficient c_1 dropped):
     //
-    //     h_size    = max(ell_zk, 3)
-    //     wire_size = h_size - 1
+    //     wire_size = max(ell_zk, 3) - 1
     //
     //     wire = [ c_0, c_2, c_3, ..., c_d ]
-    let h_size = ell_zk.max(3);
-    let wire_size = h_size - 1;
+    let wire_size = shape.wire_len();
 
     // Output container; metadata fields populated up front.
     let mut zk_data = ZkSumcheckData::<F, EF> {
         mu_tilde,
-        ell_zk,
         round_coefficients: Vec::with_capacity(k),
         pow_witnesses: Vec::with_capacity(if pow_bits > 0 { k } else { 0 }),
     };
@@ -153,16 +153,9 @@ where
         // (Lemma 6.4 with `F := EF`).
         let wire: Vec<EF> = (0..wire_size).map(|_| rng.random::<EF>()).collect();
 
-        // Absorb the wire on the transcript.
-        challenger.observe_algebra_slice(&wire);
-
-        // Drive the grind step when enabled.
-        if pow_bits > 0 {
-            zk_data.pow_witnesses.push(challenger.grind(pow_bits));
-        }
-
-        // Sample the per-round challenge.
-        let gamma_j: EF = challenger.sample_algebra_element();
+        // One call binds the wire, grinds when enabled, and draws the challenge.
+        let (gamma_j, witness) = transcript.round(&wire);
+        zk_data.pow_witnesses.extend(witness);
 
         // Reconstruct c_1:
         //
@@ -184,6 +177,9 @@ where
         zk_data.round_coefficients.push(wire);
         randomness.push(gamma_j);
     }
+
+    // Every described step has been played, so the sponge goes back to the caller.
+    transcript.finish();
 
     (zk_data, mask_commitment, Point::new(randomness))
 }
@@ -515,7 +511,6 @@ mod tests {
                     round_idx,
                 );
             }
-            prop_assert_eq!(sim_zk_data.ell_zk, ell_zk, "ell_zk header must match the encoding");
             prop_assert!(
                 sim_zk_data.pow_witnesses.is_empty(),
                 "pow_witnesses must be empty when pow_bits == 0",
@@ -563,6 +558,136 @@ mod tests {
                 replay.err(),
             );
         }
+    }
+
+    /// Replay one recorded masked batch through a bare prover-side driver.
+    ///
+    /// Reads nothing but the description and the values the batch bound.
+    /// Returns the per-round challenges the driver draws.
+    fn replay_through_the_description(
+        challenger: &mut MyChallenger,
+        shape: ZkSumcheckShape,
+        mask_commitment: <MyMmcs as Mmcs<EF>>::Commitment,
+        zk_data: &ZkSumcheckData<F, EF>,
+    ) -> Vec<EF> {
+        let mut transcript = ZkProverTranscript::<MyChallenger, F, EF>::new(challenger, shape);
+        let _alpha = transcript.batching_challenge();
+        let _eps = transcript.masks(mask_commitment, zk_data.mu_tilde);
+        let gammas = zk_data
+            .round_coefficients
+            .iter()
+            .map(|wire| transcript.round(wire).0)
+            .collect();
+        transcript.finish();
+        gammas
+    }
+
+    #[test]
+    fn the_simulator_and_the_prover_play_one_description() {
+        // Invariant: honest-verifier zero knowledge needs both parties on one step sequence.
+        //
+        // Neither party keeps a private copy of the masking prelude.
+        //
+        // Both build the same shape from the same three numbers, and both drive it.
+        //
+        // What this pins is that each party's challenge stream is reproduced by a bare driver
+        // over that description alone, fed only the values the party bound.
+        //
+        //     party      | bound values                          | stream
+        //     -----------+---------------------------------------+---------------
+        //     prover     | its commitment, mu_tilde, its wires   | its gammas
+        //     simulator  | its commitment, mu_tilde, its wires   | its gammas
+        //
+        // A step either party played out of order would make the bare driver panic on the
+        // description, or land on a different stream.
+        //
+        // Fixture state: n_vars = 6, folding = 2, ell_zk = 4, num_virtual = 1, seed = 11.
+        //
+        // PoW is disabled, so the replay draws no witness of its own.
+        let n_vars = 6;
+        let folding_factor = 2;
+        let ell_zk = 4;
+        let num_virtual = 1;
+        let pow_bits = 0;
+        let seed = 11u64;
+
+        let shape = ZkSumcheckShape::new_batching(folding_factor, ell_zk, pow_bits);
+
+        // Honest run.
+        //
+        // The verifier-side challenger sits at the post-claim state both parties
+        // start their batch from.
+        let real_run = run_prover(
+            VariableOrder::Prefix,
+            n_vars,
+            folding_factor,
+            ell_zk,
+            0,
+            num_virtual,
+            pow_bits,
+            seed,
+        );
+        let real_gammas: Vec<EF> = real_run.prover_randomness.iter().copied().collect();
+
+        // The layout prover's own stream, reproduced from the description alone.
+        let mut real_replay_ch = real_run.verifier_challenger.clone();
+        assert_eq!(
+            replay_through_the_description(
+                &mut real_replay_ch,
+                shape,
+                real_run.mask_commitment.clone(),
+                &real_run.zk_data,
+            ),
+            real_gammas,
+            "the layout prover's stream must come out of the shared description",
+        );
+
+        // Simulator run from a challenger driven to the same post-claim state.
+        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+        let mut verifier_sim = ZkVerifier::<F, EF>::new_prefix(&[TableShape::new(n_vars, 1)]);
+        let mut sim_ch = MyChallenger::new(perm);
+        for &eval in &real_run.virtual_evals {
+            verifier_sim.add_virtual_eval(eval, &mut sim_ch);
+        }
+        let mut sim_replay_ch = sim_ch.clone();
+        let mut sim_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let (sim_zk_data, sim_commitment, sim_gammas) =
+            simulate_classic_unpacked::<F, EF, _, _, _, _>(
+                &mut sim_ch,
+                &verifier_sim,
+                folding_factor,
+                pow_bits,
+                &encoding,
+                &mmcs,
+                &mut sim_rng,
+            );
+
+        // The simulator's own stream, reproduced from the very same description.
+        assert_eq!(
+            replay_through_the_description(
+                &mut sim_replay_ch,
+                shape,
+                sim_commitment.clone(),
+                &sim_zk_data,
+            ),
+            sim_gammas.iter().copied().collect::<Vec<_>>(),
+            "the simulator's stream must come out of the shared description",
+        );
+
+        // Matched RNG seeds, so the masking prelude couples value for value.
+        assert_eq!(real_run.zk_data.mu_tilde, sim_zk_data.mu_tilde);
+        assert_eq!(real_run.mask_commitment, sim_commitment);
+
+        // The wires themselves are not equal, and Lemma 6.4 does not claim they are.
+        //
+        //     prover     ->  the round polynomial its masked witness produces
+        //     simulator  ->  a uniform draw over the same space
+        //
+        // What the two share is the description, which is what the assertions above pin.
+        assert_eq!(
+            real_run.zk_data.round_coefficients.len(),
+            sim_zk_data.round_coefficients.len(),
+        );
     }
 
     #[test]

--- a/sumcheck/src/zk/transcript.rs
+++ b/sumcheck/src/zk/transcript.rs
@@ -1,0 +1,1085 @@
+//! Fiat-Shamir transcript of the hiding sumcheck.
+//!
+//! One description of everything a masked batch absorbs.
+//!
+//! Prover, verifier and simulator all drive that same description.
+//!
+//! # Shape
+//!
+//! ```text
+//!     prelude      ->  1 extension element, drawn or bound
+//!     mask oracle  ->  1 commitment
+//!     mu_tilde     ->  1 extension element
+//!     eps          ->  1 extension element, drawn
+//!
+//!     round i:  wire       ->  max(ell_zk, 3) - 1 extension elements
+//!               grinding   ->  only when the difficulty is positive
+//!               challenge  ->  1 extension element
+//! ```
+//!
+//! A round polynomial has `max(ell_zk, 3)` coefficients, and the linear one stays off the wire.
+//!
+//! The affine round identity reconstructs it.
+//!
+//! # Two preludes, one description
+//!
+//! ```text
+//!     recorded claims  ->  one challenge weights the claims a layout already recorded
+//!     inherited claim  ->  one scalar arrives from the caller, bound before anything is drawn
+//! ```
+//!
+//! Everything after the prelude is identical, so one description covers both.
+//!
+//! They are distinct steps, so a side that binds where the other draws fails loudly.
+//!
+//! # Sub-protocol
+//!
+//! A masked sumcheck is always a phase of something larger.
+//!
+//! It seeds a transcript of its own from a borrowed sponge, and hands the sponge back.
+//!
+//! The surrounding protocol brackets this run inside its own description.
+//!
+//! That is what lets the two descriptions be written independently and still compose.
+//!
+//! # What the shape binds
+//!
+//! A fingerprint of the description enters the sponge before any step runs.
+//!
+//! ```text
+//!     num_rounds  ->  round count, and so the mask oracle's column count
+//!     pow_bits    ->  presence and difficulty of the per-round grinding step
+//!     ell_zk      ->  wire width, and the instance label on top of it
+//!     prelude     ->  which of the two opening steps is played
+//! ```
+//!
+//! The mask oracle is one opaque step, binding its content and not its width.
+//!
+//! One column is committed per round, so the round count bounds that width.
+//!
+//! ```text
+//!     rate, randomness budget, domain size  ->  committed content only, never seen here
+//! ```
+//!
+//! The protocol one layer up carries all three in its own instance label.
+//!
+//! # Simulator
+//!
+//! The witness-free simulator of Lemma 6.4 plays this same description.
+//!
+//! Hiding holds only while its transcript is indistinguishable from the prover's.
+//!
+//! A divergence between the two is a loud pattern failure here, not a silent loss of hiding.
+
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+use p3_challenger::fs::{
+    DomainSeparator, FieldToFieldCodec, FieldUnit, Hierarchy, Interaction, InteractionPattern,
+    Kind, Length, ProverState, TranscriptField, VerifierState,
+};
+use p3_challenger::{CanObserve, CanSample, GrindingChallenger};
+use p3_field::{ExtensionField, Field};
+
+use crate::error::SumcheckError;
+
+/// Version byte bound into the transcript seed.
+///
+/// Bumping it separates two revisions of this protocol.
+/// It does so even when their step sequences agree.
+const VERSION: u8 = 1;
+
+/// Protocol name bound into the transcript seed.
+///
+/// Distinct from the plain sumcheck names, so no masked batch shares a seed with a plain one.
+const NAME: &[u8] = b"p3-sumcheck-hvzk";
+
+/// Step label of the challenge that weights the claims a layout recorded.
+const CLAIM_BATCHING: &str = "claim_batching";
+
+/// Step label of the scalar claim a batch inherits from its caller.
+const JOINT_CLAIM: &str = "joint_claim";
+
+/// Step label of the interleaved mask oracle of a batch.
+const MASK_COMMITMENT: &str = "mask_commitment";
+
+/// Step label of `mu_tilde`, the sum of the batch's mask evaluations over the cube.
+const MU_TILDE: &str = "mu_tilde";
+
+/// Step label of `eps`, the challenge combining the mask and plain pieces.
+const MASK_COMBINATION: &str = "mask_combination";
+
+/// Step label of the wire coefficients one round sends.
+const ROUND_POLY: &str = "round_poly";
+
+/// Step label of a per-round grinding step.
+const ROUND_POW: &str = "round_pow";
+
+/// Step label of a per-round challenge.
+const ROUND_CHALLENGE: &str = "round_challenge";
+
+/// Coefficient count of the plain round polynomial.
+///
+/// The plain piece is quadratic, so it occupies three coefficient slots.
+/// A round polynomial is therefore never shorter than this, whatever the mask length is.
+const PLAIN_COEFFICIENTS: usize = 3;
+
+/// Sponge alphabet of a challenger that speaks the base field natively.
+type Alphabet<F> = FieldUnit<F>;
+
+/// How a batch reaches the claim it runs against.
+///
+/// The two variants are two different opening steps, never two readings of one step.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ZkPrelude {
+    /// One drawn challenge weights the claims a layout already recorded.
+    ///
+    /// The claim is then derived on both sides from those recorded claims.
+    RecordedClaims,
+    /// One scalar claim arrives from the caller and is bound before anything is drawn.
+    ///
+    /// The two sides supply it independently, so the step is what keeps them honest.
+    InheritedClaim,
+}
+
+/// Numbers that fix the transcript of one masked batch of sumcheck rounds.
+///
+/// Both sides build this from their own configuration, never from a proof.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ZkSumcheckShape {
+    /// Which of the two opening steps this batch plays.
+    pub prelude: ZkPrelude,
+    /// Number of rounds the batch runs, and so the number of masks it commits.
+    ///
+    /// The mask oracle interleaves one column per round.
+    /// This count is therefore what binds that oracle's width.
+    pub num_rounds: usize,
+    /// Message length of the zero-knowledge mask code.
+    ///
+    /// Sets the wire width through `max(ell_zk, 3) - 1`.
+    pub ell_zk: usize,
+    /// Grinding difficulty guarding each round's challenge, or zero to omit grinding.
+    pub pow_bits: usize,
+}
+
+impl ZkSumcheckShape {
+    /// Collect the numbers that fix a batch opening on the claims a layout recorded.
+    ///
+    /// # Arguments
+    ///
+    /// - `num_rounds`: number of rounds the batch runs.
+    /// - `ell_zk`: message length of the mask code.
+    /// - `pow_bits`: grinding difficulty per round, or zero to omit grinding.
+    #[must_use]
+    pub const fn new_batching(num_rounds: usize, ell_zk: usize, pow_bits: usize) -> Self {
+        Self {
+            prelude: ZkPrelude::RecordedClaims,
+            num_rounds,
+            ell_zk,
+            pow_bits,
+        }
+    }
+
+    /// Collect the numbers that fix a batch opening on a claim it inherits.
+    ///
+    /// # Arguments
+    ///
+    /// - `num_rounds`: number of rounds the batch runs.
+    /// - `ell_zk`: message length of the mask code.
+    /// - `pow_bits`: grinding difficulty per round, or zero to omit grinding.
+    #[must_use]
+    pub const fn new_inherited(num_rounds: usize, ell_zk: usize, pow_bits: usize) -> Self {
+        Self {
+            prelude: ZkPrelude::InheritedClaim,
+            num_rounds,
+            ell_zk,
+            pow_bits,
+        }
+    }
+
+    /// Coefficient count of one round polynomial.
+    ///
+    /// ```text
+    ///     h_size = max(ell_zk, 3)
+    /// ```
+    #[must_use]
+    pub const fn round_poly_len(&self) -> usize {
+        if self.ell_zk > PLAIN_COEFFICIENTS {
+            self.ell_zk
+        } else {
+            PLAIN_COEFFICIENTS
+        }
+    }
+
+    /// Number of coefficients one round puts on the wire.
+    ///
+    /// The linear coefficient is dropped, and the verifier rebuilds it from the round identity.
+    #[must_use]
+    pub const fn wire_len(&self) -> usize {
+        self.round_poly_len() - 1
+    }
+
+    /// Reject a configuration that no masked batch can run under.
+    ///
+    /// Both sides derive this shape from their own configuration.
+    ///
+    /// A rejection here is therefore a setup failure, not a malformed proof.
+    ///
+    /// A verifier still reports it instead of panicking.
+    ///
+    /// # Errors
+    ///
+    /// - The base field has characteristic two, which Lemma 6.4 rules out.
+    /// - The mask is too short to cover the degree-2 plain piece.
+    /// - The batch runs no rounds at all.
+    pub fn validate<F: Field>(&self) -> Result<(), SumcheckError> {
+        // Lemma 6.4 divides by two when it inverts the endpoint identity.
+        if F::TWO == F::ZERO {
+            return Err(SumcheckError::EvenCharacteristic);
+        }
+        // A mask of degree ell_zk - 1 must reach the degree-2 plain piece it hides.
+        if self.ell_zk < PLAIN_COEFFICIENTS {
+            return Err(SumcheckError::MaskTooShort {
+                ell_zk: self.ell_zk,
+            });
+        }
+        // A batch with no rounds has no mask to commit and no claim to reduce.
+        if self.num_rounds == 0 {
+            return Err(SumcheckError::NoRounds);
+        }
+        Ok(())
+    }
+
+    /// Describe the transcript this shape fixes.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice.
+    /// A flat sequence of leaf steps always passes structural validation.
+    #[must_use]
+    pub fn pattern<F, EF>(&self) -> InteractionPattern
+    where
+        F: TranscriptField,
+        EF: ExtensionField<F>,
+    {
+        // Four prelude steps, then up to three per round.
+        let mut steps = Vec::with_capacity(4 + 3 * self.num_rounds);
+
+        // The prelude fixes the claim the batch runs against.
+        //
+        // Matching every variant keeps a future third opening from sharing this description.
+        steps.push(match self.prelude {
+            ZkPrelude::RecordedClaims => Interaction::algebra::<F, EF>(
+                Hierarchy::Atomic,
+                Kind::Challenge,
+                CLAIM_BATCHING,
+                Length::Scalar,
+            ),
+            ZkPrelude::InheritedClaim => Interaction::algebra::<F, EF>(
+                Hierarchy::Atomic,
+                Kind::Message,
+                JOINT_CLAIM,
+                Length::Scalar,
+            ),
+        });
+
+        // One interleaved oracle carries every mask of the batch.
+        steps.push(Interaction::opaque(
+            Hierarchy::Atomic,
+            Kind::Message,
+            MASK_COMMITMENT,
+            Length::Scalar,
+        ));
+
+        // The endpoint sum is fixed before the challenge that mixes it with the plain piece.
+        steps.push(Interaction::algebra::<F, EF>(
+            Hierarchy::Atomic,
+            Kind::Message,
+            MU_TILDE,
+            Length::Scalar,
+        ));
+        steps.push(Interaction::algebra::<F, EF>(
+            Hierarchy::Atomic,
+            Kind::Challenge,
+            MASK_COMBINATION,
+            Length::Scalar,
+        ));
+
+        let wire_len = self.wire_len();
+        for _ in 0..self.num_rounds {
+            // The round polynomial is one step carrying every transmitted coefficient.
+            steps.push(Interaction::algebra::<F, EF>(
+                Hierarchy::Atomic,
+                Kind::Message,
+                ROUND_POLY,
+                Length::Fixed(wire_len),
+            ));
+
+            // Grinding sits between the polynomial and the challenge it protects.
+            //
+            // The difficulty travels inside the step.
+            // A verifier expecting a cheaper grind therefore fails the shape check.
+            if self.pow_bits > 0 {
+                steps.push(Interaction::algebra::<F, F>(
+                    Hierarchy::Atomic,
+                    Kind::Pow,
+                    ROUND_POW,
+                    Length::Fixed(self.pow_bits),
+                ));
+            }
+
+            // The challenge binds the variable this round reduces away.
+            steps.push(Interaction::algebra::<F, EF>(
+                Hierarchy::Atomic,
+                Kind::Challenge,
+                ROUND_CHALLENGE,
+                Length::Scalar,
+            ));
+        }
+
+        InteractionPattern::new(steps).expect("a flat sequence of leaf steps is always well formed")
+    }
+
+    /// Bind the protocol identity, this shape, and the mask length.
+    ///
+    /// The round count, the difficulty and the prelude all move the step sequence.
+    /// The fingerprint therefore carries them.
+    ///
+    /// # Soundness
+    ///
+    /// The mask length reaches the description only through the wire width.
+    ///
+    /// ```text
+    ///     wire_len = max(ell_zk, 3) - 1
+    ///
+    ///     ell_zk = 2  ->  wire_len = 2
+    ///     ell_zk = 3  ->  wire_len = 2
+    /// ```
+    ///
+    /// The clamp is not injective, so two mask lengths can share a width.
+    /// The label carries `ell_zk` itself, so they cannot share a seed.
+    #[must_use]
+    pub fn domain_separator<F, EF>(&self) -> DomainSeparator<Alphabet<F>>
+    where
+        F: TranscriptField,
+        EF: ExtensionField<F>,
+    {
+        let mut separator = DomainSeparator::new(VERSION, NAME, self.pattern::<F, EF>());
+
+        separator.instance(&(self.ell_zk as u64).to_be_bytes());
+
+        separator
+    }
+}
+
+/// Prover-side transcript of one masked batch of sumcheck rounds.
+///
+/// # Overview
+///
+/// Holds the only definition of what a prover writes per masked round.
+///
+/// Both hiding provers and the witness-free simulator drive them through this type.
+/// No two of the three can then drift from each other, or from the verifier.
+///
+/// # Borrowing
+///
+/// The challenger is borrowed, not consumed.
+///
+/// A masked sumcheck runs inside a larger protocol.
+/// That protocol's own transcript continues where this one stops.
+pub struct ZkProverTranscript<'a, C, F: TranscriptField, EF> {
+    /// Driver walking the description and holding the borrowed sponge.
+    state: ProverState<&'a mut C, Alphabet<F>>,
+    /// The numbers this batch was described with.
+    shape: ZkSumcheckShape,
+    /// Marker for the extension field the masks and rounds carry.
+    _ef: PhantomData<EF>,
+}
+
+impl<'a, C, F, EF> ZkProverTranscript<'a, C, F, EF>
+where
+    F: TranscriptField,
+    EF: ExtensionField<F>,
+    C: CanObserve<F> + CanSample<F> + GrindingChallenger<Witness = F>,
+{
+    /// Seed the transcript from the shape.
+    ///
+    /// # Arguments
+    ///
+    /// - `challenger`: sponge of the surrounding protocol, borrowed for the batch.
+    /// - `shape`: the numbers that fix this batch's transcript.
+    pub fn new(challenger: &'a mut C, shape: ZkSumcheckShape) -> Self {
+        // Seeding folds the shape fingerprint into the sponge before any step.
+        let separator = shape.domain_separator::<F, EF>();
+
+        Self {
+            state: ProverState::new(challenger, &separator),
+            shape,
+            _ef: PhantomData,
+        }
+    }
+
+    /// Draw the challenge that weights the claims a layout recorded.
+    ///
+    /// # Panics
+    ///
+    /// When the batch was described as inheriting its claim instead.
+    pub fn batching_challenge(&mut self) -> EF {
+        assert_eq!(
+            self.shape.prelude,
+            ZkPrelude::RecordedClaims,
+            "a batch described as inheriting its claim draws no batching challenge",
+        );
+
+        self.state
+            .challenge_extension::<F, EF, FieldToFieldCodec<F>>(CLAIM_BATCHING)
+            .into_inner()
+    }
+
+    /// Bind the scalar claim this batch inherits from its caller.
+    ///
+    /// # Panics
+    ///
+    /// When the batch was described as batching recorded claims instead.
+    pub fn bind_claim(&mut self, claim: EF) {
+        assert_eq!(
+            self.shape.prelude,
+            ZkPrelude::InheritedClaim,
+            "a batch described as batching recorded claims binds no inherited claim",
+        );
+
+        self.state
+            .observe_extension::<F, EF, FieldToFieldCodec<F>>(JOINT_CLAIM, &claim);
+    }
+
+    /// Bind the mask oracle and its endpoint sum, then draw the combining challenge.
+    ///
+    /// # Arguments
+    ///
+    /// - `commitment`: the batch's interleaved mask oracle.
+    /// - `mu_tilde`: sum of the mask evaluations over the boolean cube.
+    ///
+    /// # Returns
+    ///
+    /// The challenge `eps` that scales the plain piece against the masks.
+    pub fn masks<Com>(&mut self, commitment: Com, mu_tilde: EF) -> EF
+    where
+        Com: Clone,
+        C: CanObserve<Com>,
+    {
+        // The oracle is fixed before the value summed out of the masks behind it.
+        self.state.observe_opaque(MASK_COMMITMENT, commitment);
+        self.state
+            .observe_extension::<F, EF, FieldToFieldCodec<F>>(MU_TILDE, &mu_tilde);
+
+        self.state
+            .challenge_extension::<F, EF, FieldToFieldCodec<F>>(MASK_COMBINATION)
+            .into_inner()
+    }
+
+    /// Play one round: bind the transmitted coefficients, grind, and draw the challenge.
+    ///
+    /// # Returns
+    ///
+    /// - The challenge that binds this round's variable.
+    /// - The grinding witness, when the difficulty is positive.
+    ///
+    /// The caller stores both in its own proof.
+    ///
+    /// # Panics
+    ///
+    /// When the wire is not the width the batch was described with.
+    pub fn round(&mut self, wire: &[EF]) -> (EF, Option<F>) {
+        // Bind every transmitted coefficient before the challenge evaluated against them.
+        self.state
+            .observe_extensions::<F, EF, FieldToFieldCodec<F>>(ROUND_POLY, wire);
+
+        // Grinding raises the cost of searching for a favourable challenge.
+        let witness = (self.shape.pow_bits > 0)
+            .then(|| self.state.observe_pow(ROUND_POW, self.shape.pow_bits));
+
+        // Draw the challenge for the caller to fold with.
+        let challenge = self
+            .state
+            .challenge_extension::<F, EF, FieldToFieldCodec<F>>(ROUND_CHALLENGE)
+            .into_inner();
+
+        (challenge, witness)
+    }
+
+    /// Close the transcript once every described step has been played.
+    ///
+    /// # Panics
+    ///
+    /// When fewer steps were played than the batch was described with.
+    pub fn finish(self) {
+        // Nothing was written to the driver's own buffer.
+        // Closing is therefore purely the check that the description was consumed.
+        assert!(
+            self.state.finalize().is_empty(),
+            "the hiding sumcheck carries every value in its own proof",
+        );
+    }
+}
+
+/// Verifier-side transcript of one masked batch of sumcheck rounds.
+///
+/// Mirrors the prover side call for call, over the same description.
+///
+/// Every value comes from the proof rather than from a wire.
+///
+/// The described widths are what reject one the proof got wrong.
+pub struct ZkVerifierTranscript<'a, C, F: TranscriptField, EF> {
+    /// Driver walking the description and holding the borrowed sponge.
+    ///
+    /// The proof carries every value, so the driver reads an empty wire.
+    state: VerifierState<'static, &'a mut C, Alphabet<F>>,
+    /// The numbers this batch was described with.
+    shape: ZkSumcheckShape,
+    /// Index of the next round to play, used to place a round failure.
+    round: usize,
+    /// Marker for the extension field the masks and rounds carry.
+    _ef: PhantomData<EF>,
+}
+
+impl<'a, C, F, EF> ZkVerifierTranscript<'a, C, F, EF>
+where
+    F: TranscriptField,
+    EF: ExtensionField<F>,
+    C: CanObserve<F> + CanSample<F> + GrindingChallenger<Witness = F>,
+{
+    /// Seed the transcript from the shape.
+    ///
+    /// The argument matches the prover's, so both sides seed identically.
+    pub fn new(challenger: &'a mut C, shape: ZkSumcheckShape) -> Self {
+        // Seeding folds the shape fingerprint into the sponge before any step.
+        let separator = shape.domain_separator::<F, EF>();
+
+        Self {
+            state: VerifierState::new(challenger, &separator, &[]),
+            shape,
+            round: 0,
+            _ef: PhantomData,
+        }
+    }
+
+    /// Draw the challenge that weights the claims this verifier recorded.
+    ///
+    /// # Panics
+    ///
+    /// When the batch was described as inheriting its claim instead.
+    pub fn batching_challenge(&mut self) -> EF {
+        assert_eq!(
+            self.shape.prelude,
+            ZkPrelude::RecordedClaims,
+            "a batch described as inheriting its claim draws no batching challenge",
+        );
+
+        self.state
+            .challenge_extension::<F, EF, FieldToFieldCodec<F>>(CLAIM_BATCHING)
+            .into_inner()
+    }
+
+    /// Bind the scalar claim this batch inherits from its caller.
+    ///
+    /// The prover bound its own view of the same scalar.
+    /// A caller that hands over a different one moves every challenge that follows.
+    ///
+    /// # Panics
+    ///
+    /// When the batch was described as batching recorded claims instead.
+    pub fn bind_claim(&mut self, claim: EF) {
+        assert_eq!(
+            self.shape.prelude,
+            ZkPrelude::InheritedClaim,
+            "a batch described as batching recorded claims binds no inherited claim",
+        );
+
+        self.state
+            .observe_extension::<F, EF, FieldToFieldCodec<F>>(JOINT_CLAIM, &claim);
+    }
+
+    /// Bind the mask oracle and its endpoint sum, then draw the combining challenge.
+    ///
+    /// # Arguments
+    ///
+    /// - `commitment`: the mask oracle the proof carries.
+    /// - `mu_tilde`: the endpoint sum the proof carries.
+    ///
+    /// # Returns
+    ///
+    /// The challenge `eps` the prover saw.
+    pub fn masks<Com>(&mut self, commitment: Com, mu_tilde: EF) -> EF
+    where
+        Com: Clone,
+        C: CanObserve<Com>,
+    {
+        // The oracle is fixed before the value summed out of the masks behind it.
+        self.state.observe_opaque(MASK_COMMITMENT, commitment);
+        self.state
+            .observe_extension::<F, EF, FieldToFieldCodec<F>>(MU_TILDE, &mu_tilde);
+
+        self.state
+            .challenge_extension::<F, EF, FieldToFieldCodec<F>>(MASK_COMBINATION)
+            .into_inner()
+    }
+
+    /// Replay one round: bind the wire, re-check the grind, draw the challenge.
+    ///
+    /// Every value comes from the proof, so every disagreement is a rejection.
+    ///
+    /// A round that returns without error absorbed exactly `wire_len` coefficients.
+    /// The caller may index the wire on that guarantee alone.
+    ///
+    /// # Errors
+    ///
+    /// - The wire is not the width the batch was described with.
+    /// - Grinding is enabled and the round carries no witness.
+    /// - The witness misses the required difficulty.
+    pub fn round(&mut self, wire: &[EF], witness: Option<F>) -> Result<EF, SumcheckError> {
+        let round = self.round;
+        self.round += 1;
+
+        // Bind every transmitted coefficient before the challenge evaluated against them.
+        //
+        // The count comes from the proof, so a mismatch is a rejection.
+        // The driver poisons itself on the way out, which releases its own drop check.
+        self.state
+            .observe_extensions::<F, EF, FieldToFieldCodec<F>>(ROUND_POLY, wire)
+            .map_err(|_| SumcheckError::WireSizeMismatch {
+                round,
+                expected: self.shape.wire_len(),
+                actual: wire.len(),
+            })?;
+
+        // Re-run the prover's grinding step on the witness it committed to.
+        if self.shape.pow_bits > 0 {
+            // With no witness the described step cannot be played at all.
+            //
+            // Releasing the completeness check keeps this rejection the only failure.
+            let Some(witness) = witness else {
+                self.state.abort();
+                return Err(SumcheckError::MissingPowWitness {
+                    round,
+                    difficulty: self.shape.pow_bits,
+                });
+            };
+            // A failing check releases the completeness check on its own way out.
+            self.state
+                .observe_pow(ROUND_POW, self.shape.pow_bits, witness)
+                .map_err(|_| SumcheckError::InvalidPowWitness {
+                    round,
+                    difficulty: self.shape.pow_bits,
+                })?;
+        }
+
+        // Draw the same challenge the prover saw.
+        Ok(self
+            .state
+            .challenge_extension::<F, EF, FieldToFieldCodec<F>>(ROUND_CHALLENGE)
+            .into_inner())
+    }
+
+    /// Close the transcript once every described step has been played.
+    ///
+    /// # Panics
+    ///
+    /// When fewer steps were played than the batch was described with.
+    pub fn finish(self) {
+        // The proof carries every value, so no unread wire bytes can remain.
+        self.state
+            .finalize()
+            .expect("the hiding sumcheck reads an empty wire");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::{CanSample, DuplexChallenger};
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type Ch = DuplexChallenger<F, Perm, 16, 8>;
+
+    /// Commitment stand-in: the sponge absorbs it as one opaque value.
+    type Com = [F; 4];
+
+    fn fresh_challenger() -> Ch {
+        // Fixed seed so two runs differ only where the transcript makes them differ.
+        let mut rng = SmallRng::seed_from_u64(0xDEADBEEF);
+        Ch::new(Perm::new_from_rng_128(&mut rng))
+    }
+
+    /// A commitment stand-in built from one number.
+    fn commitment(tag: u32) -> Com {
+        [F::from_u32(tag), F::ZERO, F::ONE, F::TWO]
+    }
+
+    /// Baseline shape every walk below perturbs exactly one field of.
+    const fn base_shape() -> ZkSumcheckShape {
+        ZkSumcheckShape::new_batching(3, 4, 0)
+    }
+
+    /// The first challenge a shape's seed produces.
+    fn first_challenge(shape: ZkSumcheckShape) -> F {
+        let mut challenger = fresh_challenger();
+        shape.domain_separator::<F, EF>().seed(&mut challenger);
+        challenger.sample()
+    }
+
+    /// Assert that perturbing one field of the shape moves the seed.
+    fn field_moves_the_seed(name: &str, perturb: impl FnOnce(&mut ZkSumcheckShape)) {
+        let mut tweaked = base_shape();
+        perturb(&mut tweaked);
+        assert_ne!(
+            first_challenge(base_shape()),
+            first_challenge(tweaked),
+            "changing {name} left the seed where it was",
+        );
+    }
+
+    #[test]
+    fn the_same_shape_seeds_the_same_stream_twice() {
+        // Completeness: the seed is a pure function of the shape.
+        assert_eq!(first_challenge(base_shape()), first_challenge(base_shape()));
+    }
+
+    #[test]
+    fn every_number_that_shapes_a_batch_reaches_the_seed() {
+        // Walk `ZkSumcheckShape` field by field.
+        field_moves_the_seed("prelude", |s| s.prelude = ZkPrelude::InheritedClaim);
+        field_moves_the_seed("num_rounds", |s| s.num_rounds += 1);
+        field_moves_the_seed("ell_zk", |s| s.ell_zk += 1);
+        field_moves_the_seed("pow_bits", |s| s.pow_bits += 8);
+
+        // Two positive difficulties differ only inside the grinding steps.
+        assert_ne!(
+            first_challenge(ZkSumcheckShape::new_batching(3, 4, 8)),
+            first_challenge(ZkSumcheckShape::new_batching(3, 4, 9)),
+        );
+
+        // The clamp hides one mask length behind another, and the label does not.
+        //
+        //     ell_zk = 3  ->  wire_len = 2
+        //     ell_zk = 2  ->  wire_len = 2
+        assert_eq!(
+            ZkSumcheckShape::new_batching(3, 2, 0).wire_len(),
+            ZkSumcheckShape::new_batching(3, 3, 0).wire_len(),
+        );
+        assert_ne!(
+            first_challenge(ZkSumcheckShape::new_batching(3, 2, 0)),
+            first_challenge(ZkSumcheckShape::new_batching(3, 3, 0)),
+        );
+    }
+
+    #[test]
+    fn a_configuration_no_batch_can_run_under_is_rejected() {
+        // A mask shorter than the plain quadratic cannot hide it.
+        assert_eq!(
+            ZkSumcheckShape::new_batching(3, 2, 0).validate::<F>(),
+            Err(SumcheckError::MaskTooShort { ell_zk: 2 }),
+        );
+
+        // A batch of no rounds has no mask to commit and no claim to reduce.
+        assert_eq!(
+            ZkSumcheckShape::new_batching(0, 4, 0).validate::<F>(),
+            Err(SumcheckError::NoRounds),
+        );
+
+        // The baseline shape is accepted.
+        assert_eq!(base_shape().validate::<F>(), Ok(()));
+    }
+
+    /// Drive a full prover-side batch and hand back everything it produced.
+    ///
+    /// Returns the batching challenge, the combining challenge and the per-round challenges.
+    fn drive_prover(
+        challenger: &mut Ch,
+        shape: ZkSumcheckShape,
+        commitment: Com,
+        mu_tilde: EF,
+        wires: &[Vec<EF>],
+    ) -> (EF, EF, Vec<EF>, Vec<F>) {
+        let mut transcript = ZkProverTranscript::<Ch, F, EF>::new(challenger, shape);
+        let alpha = transcript.batching_challenge();
+        let eps = transcript.masks(commitment, mu_tilde);
+        let mut gammas = Vec::new();
+        let mut witnesses = Vec::new();
+        for wire in wires {
+            let (gamma, witness) = transcript.round(wire);
+            gammas.push(gamma);
+            witnesses.extend(witness);
+        }
+        transcript.finish();
+        (alpha, eps, gammas, witnesses)
+    }
+
+    /// Replay a full verifier-side batch against recorded values.
+    fn drive_verifier(
+        challenger: &mut Ch,
+        shape: ZkSumcheckShape,
+        commitment: Com,
+        mu_tilde: EF,
+        wires: &[Vec<EF>],
+        witnesses: &[F],
+    ) -> Result<(EF, EF, Vec<EF>), SumcheckError> {
+        let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(challenger, shape);
+        let alpha = transcript.batching_challenge();
+        let eps = transcript.masks(commitment, mu_tilde);
+        let mut gammas = Vec::new();
+        for (round, wire) in wires.iter().enumerate() {
+            let witness = (shape.pow_bits > 0).then(|| witnesses[round]);
+            gammas.push(transcript.round(wire, witness)?);
+        }
+        transcript.finish();
+        Ok((alpha, eps, gammas))
+    }
+
+    /// Two rounds of wire coefficients for the baseline shape.
+    fn honest_wires() -> Vec<Vec<EF>> {
+        vec![
+            vec![EF::ONE, EF::TWO, EF::from_u8(3)],
+            vec![EF::from_u8(4), EF::from_u8(5), EF::from_u8(6)],
+        ]
+    }
+
+    #[test]
+    fn both_sides_of_a_batch_draw_the_same_challenges() {
+        // Completeness: the two drivers walk one description and land on one stream.
+        //
+        // Fixture state: 2 rounds, mask length 4, no grinding.
+        let shape = ZkSumcheckShape::new_batching(2, 4, 0);
+        let wires = honest_wires();
+
+        let mut prover_challenger = fresh_challenger();
+        let (alpha, eps, gammas, witnesses) = drive_prover(
+            &mut prover_challenger,
+            shape,
+            commitment(7),
+            EF::from_u8(9),
+            &wires,
+        );
+        assert!(witnesses.is_empty(), "no grinding means no witness");
+
+        let mut verifier_challenger = fresh_challenger();
+        let (replayed_alpha, replayed_eps, replayed_gammas) = drive_verifier(
+            &mut verifier_challenger,
+            shape,
+            commitment(7),
+            EF::from_u8(9),
+            &wires,
+            &[],
+        )
+        .expect("the honest batch must replay");
+
+        assert_eq!(alpha, replayed_alpha);
+        assert_eq!(eps, replayed_eps);
+        assert_eq!(gammas, replayed_gammas);
+
+        // The sponge is handed back in one state, so the surrounding protocol stays in step.
+        assert_eq!(
+            CanSample::<F>::sample(&mut prover_challenger),
+            CanSample::<F>::sample(&mut verifier_challenger),
+        );
+    }
+
+    #[test]
+    fn a_recorded_grinding_witness_replays_to_the_same_challenges() {
+        // Completeness of the guarded path: the witness is absorbed, not merely checked.
+        //
+        // Fixture state: 2 rounds guarded by 4 bits each.
+        let shape = ZkSumcheckShape::new_batching(2, 4, 4);
+        let wires = honest_wires();
+
+        let mut prover_challenger = fresh_challenger();
+        let (_, eps, gammas, witnesses) = drive_prover(
+            &mut prover_challenger,
+            shape,
+            commitment(7),
+            EF::from_u8(9),
+            &wires,
+        );
+        assert_eq!(witnesses.len(), 2, "one witness per guarded round");
+
+        let mut verifier_challenger = fresh_challenger();
+        let (_, replayed_eps, replayed_gammas) = drive_verifier(
+            &mut verifier_challenger,
+            shape,
+            commitment(7),
+            EF::from_u8(9),
+            &wires,
+            &witnesses,
+        )
+        .expect("the recorded witnesses must replay");
+
+        assert_eq!(eps, replayed_eps);
+        assert_eq!(gammas, replayed_gammas);
+    }
+
+    /// The challenges a verifier redraws from one recorded batch.
+    fn replay(commitment: Com, mu_tilde: EF, wires: &[Vec<EF>]) -> (EF, Vec<EF>) {
+        let mut challenger = fresh_challenger();
+        let shape = ZkSumcheckShape::new_batching(wires.len(), 4, 0);
+        let (_, eps, gammas) =
+            drive_verifier(&mut challenger, shape, commitment, mu_tilde, wires, &[])
+                .expect("a well-shaped batch always replays");
+        (eps, gammas)
+    }
+
+    #[test]
+    fn a_perturbed_mask_commitment_moves_every_later_challenge() {
+        // Invariant: the masks are fixed before the challenge that combines them.
+        //
+        // Mutation: swap the committed oracle for another.
+        let wires = honest_wires();
+        assert_ne!(
+            replay(commitment(7), EF::from_u8(9), &wires),
+            replay(commitment(8), EF::from_u8(9), &wires),
+        );
+    }
+
+    #[test]
+    fn a_perturbed_mu_tilde_moves_every_later_challenge() {
+        // Invariant: the endpoint sum is bound before `eps` weighs it against the plain piece.
+        //
+        // Mutation: bump the endpoint sum by one.
+        let wires = honest_wires();
+        assert_ne!(
+            replay(commitment(7), EF::from_u8(9), &wires),
+            replay(commitment(7), EF::from_u8(10), &wires),
+        );
+    }
+
+    #[test]
+    fn a_perturbed_wire_coefficient_moves_every_later_challenge() {
+        // Invariant: the wire is bound before the challenge evaluated against it.
+        //
+        // Without that, a prover could pick the round polynomial to suit the challenge.
+        //
+        // Mutation: bump one coefficient of the first round, once per position.
+        let honest = honest_wires();
+        for position in 0..honest[0].len() {
+            let mut tampered = honest.clone();
+            tampered[0][position] += EF::ONE;
+            assert_ne!(
+                replay(commitment(7), EF::from_u8(9), &honest),
+                replay(commitment(7), EF::from_u8(9), &tampered),
+                "tampering with wire coefficient {position} left the stream where it was",
+            );
+        }
+    }
+
+    #[test]
+    fn a_perturbed_inherited_claim_moves_every_later_challenge() {
+        // Invariant: the inherited claim is a step, so the two sides cannot differ on it silently.
+        //
+        // Mutation: hand the verifier a claim one away from the prover's.
+        let shape = ZkSumcheckShape::new_inherited(1, 4, 0);
+        let wire = [EF::ONE, EF::TWO, EF::from_u8(3)];
+
+        let draw = |claim: EF| {
+            let mut challenger = fresh_challenger();
+            let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(&mut challenger, shape);
+            transcript.bind_claim(claim);
+            let eps = transcript.masks(commitment(7), EF::from_u8(9));
+            let gamma = transcript.round(&wire, None).unwrap();
+            transcript.finish();
+            (eps, gamma)
+        };
+
+        assert_ne!(draw(EF::from_u8(11)), draw(EF::from_u8(12)));
+    }
+
+    #[test]
+    fn a_wire_of_the_wrong_width_is_rejected() {
+        // Described batch: 1 round of mask length 4, so a 3-coefficient wire.
+        //
+        //     described:    Fixed(3)
+        //     proof holds:  2        -> rejected on round 0
+        //
+        // This is the path a downstream crate reaches with a proof built for another mask.
+        // A panic here would compound with the driver's own drop check and abort the process.
+        let mut challenger = fresh_challenger();
+        let shape = ZkSumcheckShape::new_batching(1, 4, 0);
+        let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(&mut challenger, shape);
+        let _ = transcript.batching_challenge();
+        let _ = transcript.masks(commitment(7), EF::from_u8(9));
+
+        let err = transcript
+            .round(&[EF::ONE, EF::TWO], None)
+            .expect_err("a wire outside the described width must error");
+
+        assert_eq!(
+            err,
+            SumcheckError::WireSizeMismatch {
+                round: 0,
+                expected: 3,
+                actual: 2,
+            },
+        );
+
+        // The rejection leaves the round half-played, with one round still described.
+        //
+        // Absorbing the width error is what releases the completeness check.
+        drop(transcript);
+    }
+
+    #[test]
+    fn a_round_missing_its_grinding_witness_is_rejected() {
+        // Described batch: 1 round guarded by 4 bits.
+        //
+        // A described grinding step cannot be replayed with no witness to feed it.
+        let mut challenger = fresh_challenger();
+        let shape = ZkSumcheckShape::new_batching(1, 4, 4);
+        let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(&mut challenger, shape);
+        let _ = transcript.batching_challenge();
+        let _ = transcript.masks(commitment(7), EF::from_u8(9));
+
+        let err = transcript
+            .round(&[EF::ONE, EF::TWO, EF::from_u8(3)], None)
+            .expect_err("a described grinding step with no witness must error");
+
+        assert_eq!(
+            err,
+            SumcheckError::MissingPowWitness {
+                round: 0,
+                difficulty: 4,
+            },
+        );
+    }
+
+    #[test]
+    fn a_grinding_witness_below_the_difficulty_is_rejected() {
+        // Described batch: 1 round guarded by 12 bits.
+        //
+        // Mutation: hand the round a witness that was never ground at all.
+        let mut challenger = fresh_challenger();
+        let shape = ZkSumcheckShape::new_batching(1, 4, 12);
+        let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(&mut challenger, shape);
+        let _ = transcript.batching_challenge();
+        let _ = transcript.masks(commitment(7), EF::from_u8(9));
+
+        let err = transcript
+            .round(&[EF::ONE, EF::TWO, EF::from_u8(3)], Some(F::ZERO))
+            .expect_err("a witness below the required difficulty must error");
+
+        assert_eq!(
+            err,
+            SumcheckError::InvalidPowWitness {
+                round: 0,
+                difficulty: 12,
+            },
+        );
+    }
+}

--- a/sumcheck/src/zk/verifier.rs
+++ b/sumcheck/src/zk/verifier.rs
@@ -2,12 +2,14 @@
 
 use alloc::vec::Vec;
 
+use p3_challenger::fs::TranscriptField;
 use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
 use p3_field::{ExtensionField, Field, HornerIter};
 use p3_multilinear_util::point::Point;
 
 use super::data::{ZkSumcheckData, ZkVerifierHandoff};
+use super::transcript::{ZkSumcheckShape, ZkVerifierTranscript};
 use crate::error::SumcheckError;
 use crate::layout::{LayoutStrategy, Verifier};
 use crate::strategy::VariableOrder;
@@ -72,32 +74,42 @@ where
         self.inner.strategy()
     }
 
+    /// Reject a proof whose counts disagree with the described shape.
+    ///
+    /// # Invariant
+    ///
+    /// Both counts a proof carries are attacker-controlled, and the round loop reads both.
+    ///
+    /// ```text
+    ///     round_coefficients.len()  ->  how many rounds the loop indexes
+    ///     pow_witnesses.len()       ->  what the guarded rounds index into
+    /// ```
+    ///
+    /// Comparing both against the configuration is what keeps every later index in bounds.
+    /// The per-round wire width needs no check here: the described step rejects a wrong one.
+    ///
+    /// # Errors
+    ///
+    /// - The configuration cannot describe a masked batch.
+    /// - The proof does not carry one wire per described round.
+    /// - The witness count is not the one the difficulty implies.
     fn validate_shape(
         zk_data: &ZkSumcheckData<F, EF>,
-        ell_zk: usize,
-        folding_factor: usize,
-        pow_bits: usize,
+        shape: ZkSumcheckShape,
     ) -> Result<(), SumcheckError> {
-        assert!(F::TWO != F::ZERO, "Lemma 6.4 requires char(F) != 2");
-        assert!(
-            ell_zk >= 3,
-            "mask degree ell_zk - 1 must cover the degree-2 plain piece (ell_zk >= 3)",
-        );
-        assert!(folding_factor >= 1, "sumcheck requires at least one round");
+        shape.validate::<F>()?;
 
-        if zk_data.ell_zk != ell_zk {
-            return Err(SumcheckError::EllZkMismatch {
-                expected: ell_zk,
-                actual: zk_data.ell_zk,
-            });
-        }
-        if zk_data.round_coefficients.len() != folding_factor {
+        if zk_data.round_coefficients.len() != shape.num_rounds {
             return Err(SumcheckError::RoundCountMismatch {
-                expected: folding_factor,
+                expected: shape.num_rounds,
                 actual: zk_data.round_coefficients.len(),
             });
         }
-        let expected_pow = if pow_bits > 0 { folding_factor } else { 0 };
+        let expected_pow = if shape.pow_bits > 0 {
+            shape.num_rounds
+        } else {
+            0
+        };
         if zk_data.pow_witnesses.len() != expected_pow {
             return Err(SumcheckError::PowWitnessCountMismatch {
                 expected: expected_pow,
@@ -105,55 +117,65 @@ where
             });
         }
 
-        let h_size = ell_zk.max(3);
-        let wire_size = h_size - 1;
-        for (idx, wire) in zk_data.round_coefficients.iter().enumerate() {
-            if wire.len() != wire_size {
-                return Err(SumcheckError::WireSizeMismatch {
-                    round: idx + 1,
-                    expected: wire_size,
-                    actual: wire.len(),
-                });
-            }
-        }
-
         Ok(())
     }
 
-    fn replay_claim_unchecked<M, Ch>(
+    /// Replay the masking prelude and the round chain of one batch.
+    ///
+    /// The transcript arrives with its prelude already played.
+    ///
+    /// The two entry points open it differently, so only what follows is shared.
+    ///
+    /// # Arguments
+    ///
+    /// - `transcript`: driver positioned just after the prelude.
+    /// - `zk_data`: the proof record, already counted against the shape.
+    /// - `mask_commitment`: the batch's interleaved mask oracle.
+    /// - `shape`: the numbers the description was built from.
+    /// - `claimed_sum`: the scalar the batch runs against.
+    ///
+    /// # Errors
+    ///
+    /// Any rejection the round replay itself raises.
+    fn replay_claim<M, Ch>(
+        transcript: &mut ZkVerifierTranscript<'_, Ch, F, EF>,
         zk_data: &ZkSumcheckData<F, EF>,
         mask_commitment: &M::Commitment,
-        folding_factor: usize,
-        pow_bits: usize,
+        shape: ZkSumcheckShape,
         claimed_sum: EF,
-        challenger: &mut Ch,
     ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
     where
+        F: TranscriptField,
         M: Mmcs<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
-        challenger.observe(mask_commitment.clone());
-        challenger.observe_algebra_element(zk_data.mu_tilde);
-        let eps: EF = challenger.sample_algebra_element();
+        let eps = transcript.masks(mask_commitment.clone(), zk_data.mu_tilde);
 
         let mut target: EF = eps * claimed_sum + zk_data.mu_tilde;
-        let mut randomness: Vec<EF> = Vec::with_capacity(folding_factor);
+        let mut randomness: Vec<EF> = Vec::with_capacity(shape.num_rounds);
 
-        for (j_idx, wire) in zk_data.round_coefficients.iter().enumerate() {
+        // Driven by the number the description was built from, not by a proof length.
+        //
+        // The two agree only because of the count check in `validate_shape`.
+        // Both indices below are in bounds by that same check.
+        for round in 0..shape.num_rounds {
+            let wire = &zk_data.round_coefficients[round];
+            let witness = (shape.pow_bits > 0).then(|| zk_data.pow_witnesses[round]);
+
+            // One call binds the wire, re-checks the grind, and draws the challenge.
+            //
+            // A rejection here releases the driver's completeness check on its way out.
+            let gamma_j = transcript.round(wire, witness)?;
+
+            // Returning without error means the wire was the described width.
+            //
+            //     wire_len = max(ell_zk, 3) - 1 >= 2
+            //
+            // Both reads below are therefore in bounds.
             let c0 = wire[0];
             let high_sum: EF = wire[1..].iter().copied().sum();
             let c1 = target - c0.double() - high_sum;
 
-            challenger.observe_algebra_slice(wire);
-
-            if pow_bits > 0 && !challenger.check_witness(pow_bits, zk_data.pow_witnesses[j_idx]) {
-                return Err(SumcheckError::InvalidPowWitness {
-                    round: j_idx,
-                    difficulty: pow_bits,
-                });
-            }
-
-            let gamma_j: EF = challenger.sample_algebra_element();
             target = core::iter::once(c0)
                 .chain(core::iter::once(c1))
                 .chain(wire[1..].iter().copied())
@@ -228,16 +250,15 @@ where
     ///
     /// # Errors
     ///
-    /// - Mismatch between the verifier-side and proof-side mask code length.
+    /// - The configuration cannot describe a masked batch.
     /// - Wrong number of rounds or PoW witnesses.
-    /// - A per-round wire of the wrong shape.
+    /// - A per-round wire of the wrong width.
     /// - A failing proof-of-work witness check.
     ///
     /// # Panics
     ///
-    /// - Base field characteristic is `2`.
-    /// - Mask code message length is below `3`.
-    /// - Folding factor is `0`.
+    /// Never on proof input.
+    /// Only when the description is left half-played, which is a caller bug.
     #[allow(clippy::too_many_arguments)]
     pub fn into_sumcheck<M, Ch>(
         self,
@@ -249,37 +270,71 @@ where
         challenger: &mut Ch,
     ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
     where
+        F: TranscriptField,
         M: Mmcs<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
         // Phase 1: shape checks (input validation before Construction 6.3 replay).
-        Self::validate_shape(zk_data, ell_zk, folding_factor, pow_bits)?;
+        //
+        // Every number here comes from this verifier's own configuration.
+        let shape = ZkSumcheckShape::new_batching(folding_factor, ell_zk, pow_bits);
+        Self::validate_shape(zk_data, shape)?;
 
-        // Phase 2: transcript prelude (matches the prover byte-for-byte; replays Construction 6.3 setup).
+        // Phase 2: transcript prelude, seeded from the shape the prover seeded with.
+        let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(challenger, shape);
 
-        // Sample alpha, then derive mu from the recorded claims.
-        let alpha: EF = challenger.sample_algebra_element();
+        // Draw alpha, then derive mu from the recorded claims.
+        let alpha = transcript.batching_challenge();
         let mu = self.inner.sum(alpha);
 
-        // Phase 3: absorb the mask commitment and mu_tilde, sample eps, and walk the round chain.
-        Self::replay_claim_unchecked::<M, _>(
-            zk_data,
-            mask_commitment,
-            folding_factor,
-            pow_bits,
-            mu,
-            challenger,
-        )
+        // Phase 3: bind the mask oracle and mu_tilde, draw eps, and walk the round chain.
+        let handoff =
+            Self::replay_claim::<M, _>(&mut transcript, zk_data, mask_commitment, shape, mu)?;
+
+        // Every described step was replayed, so the sponge goes back to the caller.
+        transcript.finish();
+
+        Ok(handoff)
     }
 
     /// Replays an HVZK sumcheck transcript for an already-batched scalar claim.
     ///
-    /// This is the verifier-side counterpart of
-    /// [`crate::strategy::SumcheckProver::into_zk_sumcheck`]. It skips the
-    /// claim-batching `alpha` prelude because the caller already supplies the
-    /// scalar claim that the masked sumcheck should prove. The scalar is
-    /// absorbed before the masking prelude so this standalone residual-claim
-    /// API is transcript-bound even without recorded layout claims.
+    /// It mirrors the prover-side run of a masked batch over an inherited claim.
+    ///
+    /// It plays the inherited-claim prelude rather than the batching one.
+    ///
+    /// The caller already supplies the scalar the masked sumcheck should prove.
+    ///
+    /// That scalar is bound ahead of the masking prelude.
+    ///
+    /// This standalone residual-claim API is therefore transcript-bound with no recorded claims.
+    ///
+    /// # Soundness
+    ///
+    /// The prover binds its own view of the same scalar.
+    ///
+    /// ```text
+    ///     prover   ->  claimed_sum + aux_claim
+    ///     verifier ->  whatever the caller hands over here
+    /// ```
+    ///
+    /// Nothing here can compare the two, so agreeing on them stays a caller obligation.
+    ///
+    /// The step is described on both sides, so a disagreement is not silent.
+    ///
+    /// It moves `eps` and every challenge after it, and the residual no longer matches.
+    ///
+    /// # Errors
+    ///
+    /// - The configuration cannot describe a masked batch.
+    /// - Wrong number of rounds or PoW witnesses.
+    /// - A per-round wire of the wrong width.
+    /// - A failing proof-of-work witness check.
+    ///
+    /// # Panics
+    ///
+    /// Never on proof input.
+    /// Only when the description is left half-played, which is a caller bug.
     #[allow(clippy::too_many_arguments)]
     pub fn verify_claim<M, Ch>(
         zk_data: &ZkSumcheckData<F, EF>,
@@ -291,19 +346,28 @@ where
         challenger: &mut Ch,
     ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
     where
+        F: TranscriptField,
         M: Mmcs<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
-        Self::validate_shape(zk_data, ell_zk, folding_factor, pow_bits)?;
-        challenger.observe_algebra_element(claimed_sum);
-        Self::replay_claim_unchecked::<M, _>(
+        // Every number here comes from the caller's own configuration.
+        let shape = ZkSumcheckShape::new_inherited(folding_factor, ell_zk, pow_bits);
+        Self::validate_shape(zk_data, shape)?;
+
+        let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(challenger, shape);
+        transcript.bind_claim(claimed_sum);
+
+        let handoff = Self::replay_claim::<M, _>(
+            &mut transcript,
             zk_data,
             mask_commitment,
-            folding_factor,
-            pow_bits,
+            shape,
             claimed_sum,
-            challenger,
-        )
+        )?;
+
+        transcript.finish();
+
+        Ok(handoff)
     }
 }
 
@@ -315,7 +379,7 @@ mod tests {
     use super::*;
     use crate::layout::{Layout, PrefixProver, SuffixProver, TableShape};
     use crate::strategy::VariableOrder;
-    use crate::zk::test_helpers::{EF, F, MyMmcs, run_prover};
+    use crate::zk::test_helpers::{EF, F, MyMmcs, ProverRun, run_prover};
 
     #[test]
     fn verifier_strategy_matches_non_private_layouts() {
@@ -437,31 +501,34 @@ mod tests {
         forged_pow_witness_rejected_case(VariableOrder::Suffix);
     }
 
-    /// Drives the `ell_zk` mismatch invariant for one binding mode.
+    /// Drives the `ell_zk` disagreement invariant for one binding mode.
     ///
     /// - Honest prover commits with `ell_zk = 4`.
     /// - Verifier replays with `ell_zk = 5`.
-    /// - Asserts the verifier rejects with [`SumcheckError::EllZkMismatch`].
+    /// - Asserts the verifier rejects the width disagreement.
     ///
-    /// # Why a dedicated error is needed
+    /// # Why the proof carries no mask length
     ///
-    /// The wire-shape check is non-injective on `{2, 3}`:
+    /// The mask length reaches the description twice.
     ///
     /// ```text
-    ///     ell_zk = 2  →  wire_size = max(2, 3) - 1 = 2
-    ///     ell_zk = 3  →  wire_size = max(3, 3) - 1 = 2
+    ///     wire step   ->  Fixed(max(ell_zk, 3) - 1)
+    ///     seed label  ->  ell_zk itself
     /// ```
     ///
-    /// A swapped mask length would slip past the shape check.
-    /// The dedicated mismatch error closes that gap.
-    fn ell_zk_mismatch_rejected_case(binding: VariableOrder) {
+    /// The clamp alone is non-injective on `{2, 3}`, which is why the label carries the number.
+    ///
+    /// A length the two sides disagree on is caught as a described-width rejection.
+    ///
+    /// No value the proof supplied takes part in that check.
+    fn ell_zk_disagreement_rejected_case(binding: VariableOrder) {
         // Fixture state:
         //
         //     n_vars       = 6
         //     folding      = 2
         //     ell_zk       = 4        (prover-side)
         //     num_virtual  = 1
-        //     pow_bits     = 0        (PoW disabled to isolate the shape check)
+        //     pow_bits     = 0        (PoW disabled to isolate the width check)
         //     seed         = 0
         //
         // Mutation: the verifier replays with `wrong_ell_zk = 5`.
@@ -494,27 +561,165 @@ mod tests {
             &mut run.verifier_challenger,
         );
 
-        // Expect the dedicated mismatch error with the exact (expected, actual) values.
-        assert!(
-            matches!(
-                result,
-                Err(SumcheckError::EllZkMismatch { expected, actual })
-                    if expected == wrong_ell_zk && actual == ell_zk
-            ),
-            "verifier should have rejected ell_zk mismatch in binding {binding:?}; got {result:?}",
+        // Described width: 4 coefficients.
+        // The proof carries 3.
+        assert_eq!(
+            result.err(),
+            Some(SumcheckError::WireSizeMismatch {
+                round: 0,
+                expected: wrong_ell_zk - 1,
+                actual: ell_zk - 1,
+            }),
+            "verifier should have rejected the mask-length disagreement in binding {binding:?}",
+        );
+    }
+
+    /// Fixture shared by the two masking-prelude tampering tests.
+    ///
+    /// Returns an honest run and the residual its verifier derives from it.
+    fn honest_run_and_residual() -> (ProverRun, EF) {
+        // Fixture state: n_vars = 6, folding = 2, ell_zk = 4, num_virtual = 1, seed = 3.
+        //
+        // PoW is disabled, so only the masking prelude is under test.
+        let run = run_prover(VariableOrder::Prefix, 6, 2, 4, 0, 1, 0, 3);
+
+        // Every replay below starts from this same post-claim sponge state.
+        let mut honest_challenger = run.verifier_challenger.clone();
+        let residual = run
+            .verifier
+            .clone()
+            .into_sumcheck::<MyMmcs, _>(
+                &run.zk_data,
+                &run.mask_commitment,
+                4,
+                2,
+                0,
+                &mut honest_challenger,
+            )
+            .expect("the honest run must replay")
+            .claimed_residual;
+
+        (run, residual)
+    }
+
+    #[test]
+    fn a_foreign_mask_commitment_changes_the_verifier_output() {
+        // Invariant: the mask oracle is bound before the challenge that combines the masks.
+        //
+        // Without that, a prover could pick its masks after seeing `eps`.
+        //
+        // Mutation: hand the verifier the mask oracle of a different run.
+        //
+        // The affine reconstruction keeps every round identity satisfied, so the replay
+        // still returns `Ok`.
+        //
+        // The residual it hands back is what must move.
+        let (run, honest_residual) = honest_run_and_residual();
+
+        // A second run under another seed commits to different masks.
+        let foreign = run_prover(VariableOrder::Prefix, 6, 2, 4, 0, 1, 0, 4);
+        assert_ne!(run.mask_commitment, foreign.mask_commitment);
+
+        let mut tampered_challenger = run.verifier_challenger.clone();
+        let tampered_residual = run
+            .verifier
+            .clone()
+            .into_sumcheck::<MyMmcs, _>(
+                &run.zk_data,
+                &foreign.mask_commitment,
+                4,
+                2,
+                0,
+                &mut tampered_challenger,
+            )
+            .expect("a well-shaped proof always replays")
+            .claimed_residual;
+
+        assert_ne!(honest_residual, tampered_residual);
+    }
+
+    #[test]
+    fn a_perturbed_mu_tilde_changes_the_verifier_output() {
+        // Invariant: the mask endpoint sum is bound before `eps` weighs it against the plain
+        // piece, and it also anchors the round-1 target.
+        //
+        // Mutation: bump `mu_tilde` by one.
+        let (run, honest_residual) = honest_run_and_residual();
+
+        let mut tampered_zk_data = run.zk_data.clone();
+        tampered_zk_data.mu_tilde += EF::ONE;
+
+        let mut tampered_challenger = run.verifier_challenger.clone();
+        let tampered_residual = run
+            .verifier
+            .clone()
+            .into_sumcheck::<MyMmcs, _>(
+                &tampered_zk_data,
+                &run.mask_commitment,
+                4,
+                2,
+                0,
+                &mut tampered_challenger,
+            )
+            .expect("a well-shaped proof always replays")
+            .claimed_residual;
+
+        assert_ne!(honest_residual, tampered_residual);
+    }
+
+    #[test]
+    fn a_configuration_no_batch_can_run_under_is_rejected() {
+        // A verifier reports a configuration failure.
+        // It never panics on one.
+        //
+        // Fixture state: an honest run at ell_zk = 4, replayed under two broken configurations.
+        let run = run_prover(VariableOrder::Prefix, 6, 2, 4, 0, 1, 0, 5);
+
+        // A mask shorter than the plain quadratic cannot hide it.
+        let mut challenger = run.verifier_challenger.clone();
+        assert_eq!(
+            run.verifier
+                .clone()
+                .into_sumcheck::<MyMmcs, _>(
+                    &run.zk_data,
+                    &run.mask_commitment,
+                    2,
+                    2,
+                    0,
+                    &mut challenger,
+                )
+                .err(),
+            Some(SumcheckError::MaskTooShort { ell_zk: 2 }),
+        );
+
+        // A batch of no rounds has no mask to commit and no claim to reduce.
+        let mut challenger = run.verifier_challenger.clone();
+        assert_eq!(
+            run.verifier
+                .clone()
+                .into_sumcheck::<MyMmcs, _>(
+                    &run.zk_data,
+                    &run.mask_commitment,
+                    4,
+                    0,
+                    0,
+                    &mut challenger,
+                )
+                .err(),
+            Some(SumcheckError::NoRounds),
         );
     }
 
     #[test]
-    fn ell_zk_mismatch_rejected_prefix() {
-        // Prefix path: verifier rejects when its `ell_zk` disagrees with the proof.
-        ell_zk_mismatch_rejected_case(VariableOrder::Prefix);
+    fn ell_zk_disagreement_rejected_prefix() {
+        // Prefix path: verifier rejects when its `ell_zk` disagrees with the prover's.
+        ell_zk_disagreement_rejected_case(VariableOrder::Prefix);
     }
 
     #[test]
-    fn ell_zk_mismatch_rejected_suffix() {
+    fn ell_zk_disagreement_rejected_suffix() {
         // Suffix path: same invariant, exercised through the suffix dispatch.
-        ell_zk_mismatch_rejected_case(VariableOrder::Suffix);
+        ell_zk_disagreement_rejected_case(VariableOrder::Suffix);
     }
 
     /// Drives the wire-tampering invariant for one binding mode.

--- a/whir/src/pcs/zk/prover/mod.rs
+++ b/whir/src/pcs/zk/prover/mod.rs
@@ -17,7 +17,9 @@ use masks::{ProverMasks, fold_limb_chunks};
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{ExtensionMmcs, Mmcs};
 use p3_dft::TwoAdicSubgroupDft;
-use p3_field::{ExtensionField, PackedValue, PrimeCharacteristicRing, TwoAdicField, dot_product};
+use p3_field::{
+    ExtensionField, PackedValue, PrimeCharacteristicRing, PrimeField64, TwoAdicField, dot_product,
+};
 use p3_matrix::Matrix;
 use p3_maybe_rayon::prelude::*;
 use p3_multilinear_util::point::Point;
@@ -122,6 +124,9 @@ where
     /// `f(point_i) = eval_i`.
     ///
     /// The claims must already be bound to the transcript by the caller.
+    ///
+    /// Each masked sumcheck batch seeds a typed sub-transcript of its own from this sponge.
+    /// The base-field bound is what lets that sub-transcript encode its seed.
     #[instrument(skip_all)]
     #[allow(clippy::too_many_lines)]
     pub fn prove<R: Rng>(
@@ -130,7 +135,10 @@ where
         claims: &[(Point<EF>, EF)],
         challenger: &mut Challenger,
         rng: &mut R,
-    ) -> ZkWhirProof<F, EF, MT> {
+    ) -> ZkWhirProof<F, EF, MT>
+    where
+        F: PrimeField64,
+    {
         let config = self.config;
         config
             .validate_initial_claims(claims.len())

--- a/whir/src/pcs/zk/verifier/mod.rs
+++ b/whir/src/pcs/zk/verifier/mod.rs
@@ -14,7 +14,7 @@ use alloc::vec::Vec;
 use masks::VerifierMasks;
 use p3_challenger::{CanObserve, CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::{ExtensionMmcs, Mmcs};
-use p3_field::{ExtensionField, TwoAdicField};
+use p3_field::{ExtensionField, PrimeField64, TwoAdicField};
 use p3_matrix::Dimensions;
 use p3_multilinear_util::point::Point;
 use p3_multilinear_util::poly::Poly;
@@ -146,6 +146,9 @@ where
     /// `f(point_i) = eval_i`.
     ///
     /// The claims must already be bound to the transcript by the caller.
+    ///
+    /// Each masked sumcheck batch seeds a typed sub-transcript of its own from this sponge.
+    /// The base-field bound is what lets that sub-transcript encode its seed.
     #[instrument(skip_all)]
     #[allow(clippy::too_many_lines)]
     pub fn verify(
@@ -154,7 +157,10 @@ where
         commitment: &MT::Commitment,
         claims: &[(Point<EF>, EF)],
         challenger: &mut Challenger,
-    ) -> Result<(), ZkVerifierError> {
+    ) -> Result<(), ZkVerifierError>
+    where
+        F: PrimeField64,
+    {
         let config = self.config;
         config.validate_initial_claims(claims.len()).map_err(|_| {
             ZkVerifierError::InitialClaimsBelowTarget {
@@ -398,7 +404,10 @@ where
         source: &mut SourceClaim<EF>,
         masks: &mut VerifierMasks<F, EF, MT>,
         challenger: &mut Challenger,
-    ) -> Result<Point<EF>, ZkVerifierError> {
+    ) -> Result<Point<EF>, ZkVerifierError>
+    where
+        F: PrimeField64,
+    {
         let ell_zk = self.config.zk.ell_zk;
         let commitment = &proof.sumcheck_mask_commitments[batch];
         let handoff = ZkVerifier::<F, EF>::verify_claim::<ExtensionMmcs<F, EF, MT>, _>(


### PR DESCRIPTION
Depends on #2102, which depends on #2081. This PR targets `feat/typed-transcript-multi-stark-statement` so the diff contains only this crate's migration; retarget after the branches below it land.

## What this changes

#2081 migrated the quadratic sumcheck. The hiding sumcheck — the HVZK masking layer that WHIR's zero-knowledge pipeline runs on — was still writing its transcript by hand, on five separate paths, and it was the last raw-challenger transcript inside `p3-sumcheck`.

There are five sequences, not one: two prover entry points, two verifier mirrors, and a simulator that has to match the prover byte for byte or the zero-knowledge claim is void.

`sumcheck::zk::transcript` now holds one description all five play, and `sumcheck/src/zk` contains zero raw challenger calls.

## The described sequence

```text
    claim_batching   alpha, a Challenge          (the batching entry points)
        or
    joint_claim      a Message                   (the inherited-claim entry points)

    mask_commitment  opaque
    mu_tilde         one extension element
    mask_combination eps, a Challenge

    per round:  round_poly  Fixed(max(ell_zk,3) - 1)
                round_pow   Fixed(pow_bits), iff pow_bits > 0
                round_challenge
```

The two preludes are a `Challenge` and a `Message` under different labels, so neither run can replay as the other and their fingerprints differ. Which one applies is fixed by the constructor the entry point picks, so a caller cannot mismatch it.

## Why the simulator is the point

`simulate_classic_unpacked` re-implemented `sample_masks` and `observe_masks_and_mu_tilde` inline instead of calling them. The simulator's transcript has to be indistinguishable from the real prover's or HVZK does not hold — and that held only because two copies of the sequence happened to agree.

Both helpers are now pure, the simulator drives the same `ZkSumcheckShape` through the same driver as the prover, and `the_simulator_and_the_prover_play_one_description` pins it: each party's recorded values are pushed through a bare driver built from the shape alone and must reproduce that party's own challenge stream. The test deliberately asserts the *wires* are not equal — Lemma 6.4 claims indistinguishability of distributions, not equality. What is shared is the description.

## Lengths that came off the wire

Four things the verifier used to read from the proof now come from the pattern:

- the round loop iterated `zk_data.round_coefficients`, so the number of transcript steps was proof-derived;
- the absorbed element count was `wire.len()`;
- `pow_witnesses[j_idx]` indexed a proof vector;
- `ZkSumcheckData::ell_zk` was **a length carried inside the proof**, never absorbed, only compared against config.

`ell_zk` is deleted. Its own doc comment explained why it needed an explicit check — wire lengths 2 and 3 share a layout, so the encoding is not injective. That non-injectivity is exactly what a fingerprint is for, and `ell_zk` now reaches the seed through both the pattern and the instance label.

## Panics removed

`replay_claim_unchecked` loses its `_unchecked`: the loop bound is config, and `wire[0]` / `wire[1..]` are read only after the driver has accepted `Length::Fixed(wire_len)`. The three `assert!`s that sat inside a `Result`-returning verifier moved into `ZkSumcheckShape::validate`, returning typed errors.

## What is bound where

| Field | Verdict |
| --- | --- |
| `prelude` | fingerprint — changes the first step's kind and label |
| `num_rounds` | fingerprint — and the only thing binding the mask oracle's column count, since an opaque step binds content, not width |
| `pow_bits` | fingerprint — step presence and its declared difficulty |
| `ell_zk` | fingerprint *and* label — `Length::Fixed(max(ell_zk,3) - 1)` is not injective |

The mask encoding's own parameters — `mask_log_inv_rate`, `randomness_len`, `domain_size`, `mask_queries`, `oracle_randomness` — are absent by design: the sumcheck verifier never receives an encoding, so it cannot know them. `ZkWhirShape`'s instance label already binds all of them.

## Compatibility

Breaking transcript change, and `ZkSumcheckData` loses a field. No fixture needed regeneration: every `.postcard` in the tree exercises plain WHIR, Circle or two-adic FRI, and `HidingWhirPcs` has no consumer outside a bench.

## Known limitation

The inherited-claim agreement is still a caller obligation. The pattern records the step and both sides bind a scalar, so a disagreement is loud — it moves `eps` and every subsequent challenge. But nothing inside `p3-sumcheck` can compare the prover's `claimed_sum() + aux_claim` against the verifier's target; that would need the auxiliary total to be a described value, which is a WHIR-side change. Documented in `verify_claim`'s `# Soundness`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
