### PR TITLE
fix(binary-pcs): reject a non-canonical grinding witness at zero difficulty

### DIFF
--- a/binary-pcs/src/error.rs
+++ b/binary-pcs/src/error.rs
@@ -1,5 +1,6 @@
 //! Typed reasons an opening proof was rejected.
 
+use p3_binary_field::BinaryField128;
 use thiserror::Error;
 
 /// Why an opening proof was rejected.
@@ -101,4 +102,18 @@ pub enum BinaryPcsError<MmcsError> {
     /// `pow_witnesses` for the same reason.
     #[error("the sumcheck data carries {actual} PoW witnesses, expected none")]
     NonEmptyPowWitnesses { actual: usize },
+
+    /// The grinding witness is not the value a zero difficulty budget admits.
+    ///
+    /// Checked before any transcript operation, like every other proof-shape check here.
+    //
+    // Why: at `pow_bits = 0` neither side touches the sponge.
+    //
+    //     prover  : grind(0)            -> returns zero, absorbs nothing
+    //     verifier: check_witness(0, w) -> returns true, absorbs nothing
+    //
+    // `pow_witness` is then bound to nothing: any value rides along and still verifies.
+    // Zero is the only value an honest prover emits, so zero is the only value accepted.
+    #[error("the grinding witness is {actual} at zero difficulty, expected zero")]
+    NonCanonicalPowWitness { actual: BinaryField128 },
 }

--- a/binary-pcs/src/pcs.rs
+++ b/binary-pcs/src/pcs.rs
@@ -29,7 +29,9 @@ use crate::error::BinaryPcsError;
 use crate::params::BinaryPcsConfig;
 use crate::proof::BinaryPcsProof;
 use crate::prover::{BinaryPcsProverData, commit, fold_rounds, open_queries};
-use crate::verifier::{check_round_and_final_lengths, verify_query_paths};
+use crate::verifier::{
+    check_canonical_pow_witness, check_round_and_final_lengths, verify_query_paths,
+};
 
 /// A multilinear polynomial commitment scheme over `BinaryField128`: an additive-domain
 /// Reed-Solomon codeword folded in lockstep with a residual sumcheck.
@@ -100,15 +102,24 @@ where
     /// via [`Verifier::add_claim_at`], `None` samples the point from the transcript via
     /// [`Verifier::add_claim`], mirroring the prover's `eval_at`/`eval` choice.
     ///
-    /// `OpeningBatchCountMismatch`, both round-count checks, `FinalCodewordLengthMismatch` and
-    /// `NonEmptyPowWitnesses` run before this function performs any transcript operation of its
-    /// own, so a malformed proof is rejected rather than indexed out of bounds or used to
-    /// desync the replay. That does not mean the challenger itself is untouched: `verify`
-    /// observes the commitment before calling here, and `verify_at`'s contract requires the
-    /// caller to have done the same. `OpeningBatchSizeMismatch`, by contrast, is checked once
-    /// per claim inside the claim-recording loop below, after every earlier claim in the same
-    /// proof has already been absorbed — it is ordered only relative to its own claim, not to
-    /// the transcript as a whole.
+    /// The proof-shape checks below all run before this function performs any transcript
+    /// operation of its own:
+    ///
+    /// - `OpeningBatchCountMismatch`
+    /// - both round-count checks
+    /// - `FinalCodewordLengthMismatch`
+    /// - `NonEmptyPowWitnesses`
+    /// - `NonCanonicalPowWitness`
+    ///
+    /// A malformed proof is rejected there, rather than indexed out of bounds or used to
+    /// desync the replay.
+    ///
+    /// The challenger is not untouched by then: `verify` observes the commitment before
+    /// calling here, and `verify_at`'s contract requires the caller to have done the same.
+    ///
+    /// `OpeningBatchSizeMismatch` sits outside that group: it is checked once per claim inside
+    /// the claim-recording loop below, ordered only against its own claim and not against the
+    /// transcript as a whole.
     ///
     /// The per-round sumcheck replay is interleaved with each intermediate round's commitment
     /// observation, one `SumcheckData::verify_rounds` call per fold round, because a single
@@ -160,6 +171,10 @@ where
         }
 
         check_round_and_final_lengths(&self.config, proof)?;
+
+        // At a zero grinding budget the witness never reaches the sponge, so its value is
+        // pinned here rather than by the grind.
+        check_canonical_pow_witness(&self.config, proof)?;
 
         // From here on the transcript is touched: every remaining check runs against the
         // replayed randomness, not the proof's raw bytes.

--- a/binary-pcs/src/verifier.rs
+++ b/binary-pcs/src/verifier.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 use p3_binary_field::BinaryField128;
 use p3_challenger::{CanSampleUniformBits, FieldChallenger, GrindingChallenger};
 use p3_commit::Mmcs;
-use p3_field::Field;
+use p3_field::{Field, PrimeCharacteristicRing};
 use p3_matrix::Dimensions;
 use p3_util::log2_strict_usize;
 
@@ -188,6 +188,37 @@ where
     Ok(())
 }
 
+/// Checks that a zero-difficulty proof carries the one grinding witness a zero budget admits,
+/// before any transcript operation.
+///
+/// A positive budget needs no check here: the witness is absorbed and its sampled bits are
+/// compared, so the difficulty itself pins the field.
+//
+// Why: `GrindingChallenger::check_witness` returns `true` at `bits == 0` without absorbing,
+// which leaves `proof.pow_witness` compared against nothing and free to be any value.
+//
+//     pow_bits = 0 -> prover emits zero, verifier reads nothing -> pin the field here
+//     pow_bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+//
+// Assumption: the honest prover's grind at zero bits is pinned to the zero witness.
+// A grinding path that leaves the zero-bit witness unconstrained needs this check revisited.
+// The pin is asserted by `zero_difficulty_grinding_is_pinned_to_the_zero_witness` below.
+pub(crate) fn check_canonical_pow_witness<MT>(
+    config: &BinaryPcsConfig,
+    proof: &BinaryPcsProof<MT>,
+) -> Result<(), BinaryPcsError<MT::Error>>
+where
+    MT: Mmcs<BinaryField128>,
+{
+    if config.pow_bits() == 0 && proof.pow_witness != BinaryField128::ZERO {
+        return Err(BinaryPcsError::NonCanonicalPowWitness {
+            actual: proof.pow_witness,
+        });
+    }
+
+    Ok(())
+}
+
 /// Verifies the query phase of an opening proof: the single grind, the sampled query
 /// indices, every round's Merkle multiproof, and the fold-consistency chain tying each round
 /// to the next.
@@ -223,6 +254,7 @@ where
     // Structural checks: every one derivable from `config` and the proof's own declared
     // lengths, none needing the transcript.
     check_round_and_final_lengths(config, proof)?;
+    check_canonical_pow_witness(config, proof)?;
 
     let domain_size = config.domain_size();
     let target_queries = config
@@ -322,7 +354,7 @@ mod tests {
     use p3_binary_field::BinaryField128;
     use p3_challenger::{CanObserve, FieldChallenger, GrindingChallenger};
     use p3_commit::Mmcs;
-    use p3_field::PrimeCharacteristicRing;
+    use p3_field::{Field, PrimeCharacteristicRing};
     use p3_matrix::dense::RowMajorMatrix;
     use p3_multilinear_util::poly::Poly;
     use p3_sumcheck::layout::{Layout, SuffixProver, Table};
@@ -348,6 +380,35 @@ mod tests {
             pow_bits: 4,
             security_level: 40,
         }
+    }
+
+    #[test]
+    fn zero_difficulty_grinding_is_pinned_to_the_zero_witness() {
+        // Invariant: this crate's challenger grinds to the zero witness at a zero budget.
+        //
+        //              grind                     check
+        //     0 bits   zero, absorbing nothing   true, absorbing nothing
+        //     4 bits   a search that absorbs     resamples and compares
+        //
+        // Zero is therefore the only witness an honest prover emits at a zero budget.
+        //
+        // Nothing in the transcript binds the field there, so the check above has to.
+        assert_eq!(challenger().grind(0), F::ZERO);
+
+        // The complementary half: a zero-bit witness check accepts every value handed to it.
+        for witness in [F::ZERO, F::ONE, F::GENERATOR] {
+            assert!(challenger().check_witness(0, witness));
+        }
+
+        // A positive budget needs no such check, because there the difficulty pins the field.
+        assert!(challenger().check_witness(4, challenger().grind(4)));
+
+        // Excluded case: the uniform-grinding pair, which inverts both facts above.
+        // Its grind has no zero-bit shortcut, so at zero bits an arbitrary candidate wins.
+        // Its check absorbs at every difficulty, so there the transcript binds the witness.
+        //
+        // A challenger whose zero-bit grind is unconstrained fails the first assertion here.
+        // Moving the query phase's single grind onto that pair needs the check revisited too.
     }
 
     #[test]

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -422,6 +422,37 @@ fn corrupted_pow_witness_is_rejected() {
     );
 }
 
+#[test]
+fn a_noncanonical_pow_witness_at_zero_difficulty_is_rejected() {
+    // Fixture state: pow_bits = 0, so the grind is a no-op on both sides.
+    let (pcs, commitment, mut proof, protocol) =
+        run_lifecycle(NUM_VARIABLES, LOG_INV_RATE, 0, SECURITY_LEVEL, 12);
+
+    // Invariant: a zero budget makes zero the one witness an honest prover emits.
+    assert_eq!(proof.pow_witness, F::ZERO);
+
+    // Mutation: any other value.
+    //
+    //     prover  : grind at 0 bits -> zero witness, sponge untouched
+    //     verifier: check at 0 bits -> accepts,      sponge untouched
+    //
+    // Nothing in the transcript binds the field, so only a canonical-value check rejects
+    // this second encoding of the same statement.
+    proof.pow_witness = F::ONE;
+
+    let mut verifier_challenger = challenger();
+    let err = pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BinaryPcsError::NonCanonicalPowWitness { actual } if actual == F::ONE
+        ),
+        "expected NonCanonicalPowWitness, got {err:?}"
+    );
+}
+
 /// A proof carrying PoW witnesses is rejected outright: every fold round replays with a
 /// freshly built, always-empty `pow_witnesses` vector (see `BinaryPcs::verify_opening`), so
 /// nothing in the proof's own transcript reads or binds the ones this test appends. Without


### PR DESCRIPTION
Depends on #2104, #2103, #2102, #2081. This PR targets `feat/typed-transcript-whir-driver`; retarget after the branches below it land.

## The bug

`binary-pcs` accepts proofs that are not uniquely encoded. At zero grinding difficulty the proof-of-work witness is completely unbound.

```text
    check_witness(0, w)  ->  returns true, absorbs nothing     (grinding_challenger.rs)
    grind(0)             ->  returns ZERO, absorbs nothing     (binary-field challenger)
    proof.pow_witness    ->  carried unconditionally, written by the prover
```

So at `pow_bits == 0` the field is written, transmitted, and never compared against anything. A third party who intercepts a valid proof can rewrite it and the proof still verifies.

`pow_bits` is a public field on `BinaryPcsParams` with no lower bound, and `tests/end_to_end.rs` already exercises a zero-budget round trip — so the configuration is reachable, not hypothetical.

## Severity

**Proof malleability, not a soundness break.** Nobody can prove a false statement. What breaks is unique encoding: two distinct byte strings verify against the same statement. That matters wherever proof bytes are hashed, deduplicated, used as an identifier, or recursed over.

## The prior art this matches

The crate already treats this exact class as a defect worth a typed error, one field over: `pcs.rs` rejects a spurious `proof.sumcheck.pow_witnesses` with `NonEmptyPowWitnesses`, and that variant's doc comment states the reasoning verbatim. There was simply no analogous check for `proof.pow_witness`. `p3-sumcheck` does the same for all three of its witness vectors.

## The test that proves it

Before the fix, mutating the witness and asserting rejection fails on an `Ok`:

```
thread '...' panicked at binary-pcs/tests/end_to_end.rs:387:
called `Result::unwrap_err()` on an `Ok` value: ()
```

After, it is `NonCanonicalPowWitness { actual }`. The rejection runs before any transcript operation, in the same block as the existing shape checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
