### PR TITLE
fix(security): reject non-canonical grinding witnesses at zero difficulty

### DIFF
--- a/batch-stark/src/proof.rs
+++ b/batch-stark/src/proof.rs
@@ -27,14 +27,15 @@ pub struct BatchProof<SC: StarkGenericConfig> {
     /// sampled.
     ///
     /// `None` exactly when no instance declares a lookup, since the batch then
-    /// samples no such challenge. Trivially valid (but still present) when
-    /// [`p3_uni_stark::StarkGenericConfig::lookup_proof_of_work_bits`] is `0`
-    /// and the batch has lookups.
+    /// samples no such challenge.
+    ///
+    /// Zero at a zero difficulty, where the search is free and returns one value.
+    /// The verifier rejects any other value, so the field is unique at every difficulty.
     pub lookup_pow_witness: Option<Val<SC>>,
     /// Proof of work for the phase before the out-of-domain point is sampled.
     ///
-    /// Trivially valid (and unread) when
-    /// [`p3_uni_stark::StarkGenericConfig::ood_proof_of_work_bits`] is `0`.
+    /// Zero at a zero difficulty, where the search is free and returns one value.
+    /// The verifier rejects any other value, so the field is unique at every difficulty.
     pub ood_pow_witness: Val<SC>,
 }
 

--- a/batch-stark/src/transcript.rs
+++ b/batch-stark/src/transcript.rs
@@ -57,6 +57,9 @@
 //! A prover who learns `zeta` first fits the quotient to agree at that one point.
 //!
 //! Each grind prices one retry of such a search at `2^bits`.
+//!
+//! A grind of zero bits prices nothing, and absorbs nothing either.
+//! Its witness is pinned to the one value a free search returns, so the field stays unique.
 
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -155,12 +158,37 @@ pub enum BatchTranscriptFailure {
     /// A batch that samples no lookup challenge still carries a witness for one.
     #[error("a batch with no lookups carries a lookup PoW witness")]
     UnexpectedLookupPowWitness,
+    /// The lookup witness is not the value a zero-difficulty step admits.
+    ///
+    /// A free search has one answer, and the proof carries a different one.
+    //
+    // Why: a zero-difficulty step absorbs nothing and compares nothing.
+    //
+    //     bits = 0 -> the witness is skipped, alpha and beta follow -> the value floats free
+    //     bits > 0 -> absorbed, bits resampled                      -> the grind pins it
+    //
+    // The step is described whatever the difficulty, so the pattern pins the bit count.
+    // A bit count is not a value, so any value rides along and the proof still verifies.
+    #[error("lookup phase PoW witness is nonzero at zero difficulty, expected zero")]
+    NonCanonicalLookupPowWitness,
     /// The witness guarding the out-of-domain point misses its difficulty.
     #[error("out-of-domain phase PoW witness does not meet the required {bits} bits")]
     OodPowWitness {
         /// Grinding difficulty the step requires.
         bits: usize,
     },
+    /// The out-of-domain witness is not the value a zero-difficulty step admits.
+    ///
+    /// A free search has one answer, and the proof carries a different one.
+    //
+    // Why: a zero-difficulty step absorbs nothing and compares nothing.
+    //
+    //     bits = 0 -> the witness is skipped, zeta follows -> the value floats free
+    //     bits > 0 -> absorbed, bits resampled             -> the grind pins it
+    //
+    // Left unpinned, the field is a second encoding of one and the same statement.
+    #[error("out-of-domain phase PoW witness is nonzero at zero difficulty, expected zero")]
+    NonCanonicalOodPowWitness,
 }
 
 /// Numbers that fix the transcript of one batch-STARK run.
@@ -795,6 +823,7 @@ where
     /// - The batch declares a lookup and the proof carries no witness.
     /// - The batch declares none and the proof carries one anyway.
     /// - The witness misses the difficulty its step requires.
+    /// - The difficulty is zero and the witness is not the value a free search returns.
     pub fn lookup_phase<LG, L>(
         &mut self,
         all_lookups: &[L],
@@ -826,6 +855,19 @@ where
             self.state.abort();
             return Err(BatchTranscriptFailure::MissingLookupPowWitness { bits });
         };
+
+        // A zero-difficulty step reads the witness without absorbing or comparing it.
+        //
+        //     bits = 0 -> prover emits zero, nothing is absorbed -> pin the value here
+        //     bits > 0 -> prover grinds,     bits are resampled  -> the grind pins it
+        //
+        // The check sits ahead of the step, so nothing has entered the sponge yet.
+        // Releasing the completeness check keeps this rejection the only failure.
+        if bits == 0 && witness != F::ZERO {
+            self.state.abort();
+            return Err(BatchTranscriptFailure::NonCanonicalLookupPowWitness);
+        }
+
         self.state
             .observe_pow(LOOKUP_POW, bits, witness)
             .map_err(|_| BatchTranscriptFailure::LookupPowWitness { bits })?;
@@ -888,9 +930,22 @@ where
     ///
     /// # Errors
     ///
-    /// When the witness misses the difficulty its step requires.
+    /// - The witness misses the difficulty its step requires.
+    /// - The difficulty is zero and the witness is not the value a free search returns.
     pub fn ood_phase(&mut self, witness: F) -> Result<EF, BatchTranscriptFailure> {
         let bits = self.shape.ood_pow_bits;
+
+        // A zero-difficulty step reads the witness without absorbing or comparing it.
+        //
+        //     bits = 0 -> prover emits zero, nothing is absorbed -> pin the value here
+        //     bits > 0 -> prover grinds,     bits are resampled  -> the grind pins it
+        //
+        // The check sits ahead of the step, so zeta is not drawn on a rejected proof.
+        // Releasing the completeness check keeps this rejection the only failure.
+        if bits == 0 && witness != F::ZERO {
+            self.state.abort();
+            return Err(BatchTranscriptFailure::NonCanonicalOodPowWitness);
+        }
 
         self.state
             .observe_pow(OOD_POW, bits, witness)
@@ -1139,6 +1194,30 @@ mod tests {
     }
 
     #[test]
+    fn a_lookup_witness_at_zero_difficulty_must_be_the_canonical_zero() {
+        // Described run: two instances, one declaring a lookup, and a free grind.
+        //
+        //     required:  the one witness a search of zero bits returns
+        //     supplied:  a value no search could have produced
+        //
+        // The step is described here whatever the difficulty, so the count is already bound.
+        // A count is not a value, so the value is checked on its own.
+        let mut shape = plain_shape();
+        shape.num_lookup_instances = 1;
+        assert_eq!(shape.lookup_pow_bits, 0);
+
+        let mut challenger = fresh_challenger();
+        let mut transcript =
+            BatchVerifierTranscript::<Ch, F, EF, [F; 8]>::new(&mut challenger, shape);
+
+        let err = transcript
+            .lookup_phase(&NO_LOOKUPS, &LogUpGadget::new(), Some(F::ONE))
+            .expect_err("a nonzero witness at zero difficulty must error");
+
+        assert_eq!(err, BatchTranscriptFailure::NonCanonicalLookupPowWitness);
+    }
+
+    #[test]
     fn an_out_of_domain_witness_below_its_difficulty_is_rejected() {
         // Described run: two instances and a grind of 12 bits before the point is drawn.
         //
@@ -1165,6 +1244,35 @@ mod tests {
             .expect_err("a witness below the required difficulty must error");
 
         assert_eq!(err, BatchTranscriptFailure::OodPowWitness { bits: 12 });
+    }
+
+    #[test]
+    fn an_out_of_domain_witness_at_zero_difficulty_must_be_the_canonical_zero() {
+        // Described run: two instances and a free grind before the point is drawn.
+        //
+        //     required:  the one witness a search of zero bits returns
+        //     supplied:  a value no search could have produced
+        let shape = plain_shape();
+        assert_eq!(shape.ood_pow_bits, 0);
+
+        let mut challenger = fresh_challenger();
+        let mut transcript =
+            BatchVerifierTranscript::<Ch, F, EF, [F; 8]>::new(&mut challenger, shape);
+
+        transcript.instance_bindings(&[4, 5]);
+        transcript.main_phase([F::ONE; 8], &[&[] as &[F], &[F::ONE]]);
+        transcript.preprocessed_phase(None);
+        transcript
+            .lookup_phase(&NO_LOOKUPS, &LogUpGadget::new(), None)
+            .expect("a batch with no lookups replays with no witness");
+        let _alpha = transcript.permutation_phase(None, &[]);
+        transcript.quotient_phase([F::ZERO; 8], None);
+
+        let err = transcript
+            .ood_phase(F::ONE)
+            .expect_err("a nonzero witness at zero difficulty must error");
+
+        assert_eq!(err, BatchTranscriptFailure::NonCanonicalOodPowWitness);
     }
 
     #[test]

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -2233,6 +2233,43 @@ fn batch_without_lookups_carries_no_witness() {
     );
 }
 
+#[test]
+fn a_noncanonical_lookup_pow_witness_at_zero_difficulty_is_rejected() {
+    // Invariant: a zero-difficulty lookup grind binds the bit count, never the witness.
+    //
+    //     bits = 0 -> nothing absorbed, alpha and beta follow -> the value floats free
+    //     bits > 0 -> absorbed, bits resampled                -> the grind pins it
+    //
+    // The step is described whatever the difficulty, so the pattern covers the count.
+    // A count is not a value, so the value is pinned to the one an honest prover emits.
+    //
+    // Fixture state: two instances that declare lookups, lookup grinding at 0 bits.
+    let config = make_config(2024);
+    assert_eq!(config.lookup_proof_of_work_bits(), 0);
+    let airs = lookup_grinding_airs();
+
+    lookup_grinding_case(&config, &config, &airs, |proof| {
+        assert_eq!(proof.lookup_pow_witness, Some(Val::ZERO));
+    })
+    .expect("an unground proof verifies");
+
+    // Mutation: Some(0) -> Some(1), a second encoding of the very same statement.
+    let err = lookup_grinding_case(&config, &config, &airs, |proof| {
+        proof.lookup_pow_witness = Some(Val::ONE);
+    })
+    .expect_err("a rewritten lookup witness must be rejected");
+
+    assert!(
+        matches!(
+            err,
+            BatchVerificationError::Transcript(
+                BatchTranscriptFailure::NonCanonicalLookupPowWitness
+            )
+        ),
+        "wrong error variant: {err:?}"
+    );
+}
+
 /// Difficulty small enough to grind instantly, large enough that a wrong
 /// witness is rejected with overwhelming probability.
 const OOD_POW_BITS: usize = 8;
@@ -2286,6 +2323,40 @@ fn ood_pow_difficulty_mismatch_is_rejected() {
         matches!(
             err,
             BatchVerificationError::Transcript(BatchTranscriptFailure::OodPowWitness { bits: 24 })
+        ),
+        "wrong error variant: {err:?}"
+    );
+}
+
+#[test]
+fn a_noncanonical_ood_pow_witness_at_zero_difficulty_is_rejected() {
+    // Invariant: a zero-difficulty out-of-domain grind binds the bit count, never the witness.
+    //
+    //     bits = 0 -> nothing absorbed, zeta follows -> the value floats free
+    //     bits > 0 -> absorbed, bits resampled       -> the grind pins it
+    //
+    // Left unpinned, a third party rewrites the field and keeps a verifying proof.
+    //
+    // Fixture state: two instances, out-of-domain grinding at 0 bits.
+    let config = make_config(2024);
+    assert_eq!(config.ood_proof_of_work_bits(), 0);
+    let airs = lookup_grinding_airs();
+
+    lookup_grinding_case(&config, &config, &airs, |proof| {
+        assert_eq!(proof.ood_pow_witness, Val::ZERO);
+    })
+    .expect("an unground proof verifies");
+
+    // Mutation: 0 -> 1, a second encoding of the very same statement.
+    let err = lookup_grinding_case(&config, &config, &airs, |proof| {
+        proof.ood_pow_witness = Val::ONE;
+    })
+    .expect_err("a rewritten out-of-domain witness must be rejected");
+
+    assert!(
+        matches!(
+            err,
+            BatchVerificationError::Transcript(BatchTranscriptFailure::NonCanonicalOodPowWitness)
         ),
         "wrong error variant: {err:?}"
     );

--- a/circle/src/pcs.rs
+++ b/circle/src/pcs.rs
@@ -1199,7 +1199,7 @@ mod tests {
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_fri::FriParameters;
-    use p3_fri::verifier::FriError;
+    use p3_fri::verifier::{FriError, PowPhase};
     use p3_keccak::Keccak256Hash;
     use p3_merkle_tree::MerkleTreeMmcs;
     use p3_mersenne_31::Mersenne31;
@@ -1263,6 +1263,26 @@ mod tests {
         Vec<Vec<Vec<Vec<Challenge>>>>,
         CirclePcsProof<Val, Challenge, ValMmcs, ChallengeMmcs, Val>,
     ) {
+        setup_valid_proof_at(1, 1)
+    }
+
+    /// The same fixture at caller-chosen commit- and query-phase difficulties.
+    ///
+    /// Both numbers reach the transcript's description, so prover and verifier must be
+    /// built from the same pair for the replay to line up.
+    #[allow(clippy::type_complexity)]
+    fn setup_valid_proof_at(
+        commit_pow_bits: usize,
+        query_pow_bits: usize,
+    ) -> (
+        TestPcs,
+        ByteHash,
+        <ValMmcs as Mmcs<Val>>::Commitment,
+        CircleDomain<Val>,
+        Challenge,
+        Vec<Vec<Vec<Vec<Challenge>>>>,
+        CirclePcsProof<Val, Challenge, ValMmcs, ChallengeMmcs, Val>,
+    ) {
         let mut rng = SmallRng::seed_from_u64(0);
 
         // Build the hash stack: field hasher → compression → Merkle tree.
@@ -1275,7 +1295,9 @@ mod tests {
         let challenge_mmcs = ChallengeMmcs::new(val_mmcs.clone());
 
         // Minimal FRI parameters for fast test execution.
-        let fri_params = FriParameters::new_testing(challenge_mmcs, 0);
+        let mut fri_params = FriParameters::new_testing(challenge_mmcs, 0);
+        fri_params.commit_proof_of_work_bits = commit_pow_bits;
+        fri_params.query_proof_of_work_bits = query_pow_bits;
 
         let pcs = TestPcs {
             mmcs: val_mmcs,
@@ -2021,6 +2043,60 @@ mod tests {
 
         try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
             .expect_err("a tampered query grinding witness must be rejected");
+    }
+
+    #[test]
+    fn reject_noncanonical_pow_witnesses_at_zero_difficulty() {
+        // Invariant: at zero difficulty only a canonical-value check binds the witness.
+        //
+        //     bits = 0 -> check_witness returns true, the step is elided -> unbound
+        //     bits > 0 -> absorbed, bits resampled                       -> grind binds
+        //
+        // The commit-phase mutation moves one element and leaves the length alone: the
+        // length has its own rejection, and a count check is not a value check.
+        let (pcs, byte_hash, comm, d, zeta, values, proof) = setup_valid_proof_at(0, 0);
+
+        // The honest prover writes zero into every slot it pays no work for.
+        assert!(
+            proof
+                .fri_proof
+                .commit_pow_witnesses
+                .iter()
+                .all(|w| *w == Val::ZERO)
+        );
+        assert_eq!(proof.fri_proof.pow_witness, Val::ZERO);
+
+        // The untouched proof still verifies, so the mutations below are the only change.
+        try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &proof)
+            .expect("an ungrounded proof must verify");
+
+        let mut mutated = proof.clone();
+        mutated.fri_proof.commit_pow_witnesses[0] = Val::ONE;
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &mutated)
+            .expect_err("a rewritten commit-phase witness must be rejected");
+        assert!(
+            matches!(
+                err,
+                FriError::NonCanonicalPowWitness {
+                    phase: PowPhase::CommitPhase
+                }
+            ),
+            "expected NonCanonicalPowWitness for the commit phase, got {err:?}"
+        );
+
+        let mut mutated = proof;
+        mutated.fri_proof.pow_witness = Val::ONE;
+        let err = try_verify(&pcs, byte_hash, &comm, d, zeta, &values, &mutated)
+            .expect_err("a rewritten query witness must be rejected");
+        assert!(
+            matches!(
+                err,
+                FriError::NonCanonicalPowWitness {
+                    phase: PowPhase::Query
+                }
+            ),
+            "expected NonCanonicalPowWitness for the query phase, got {err:?}"
+        );
     }
 
     #[test]

--- a/circle/src/verifier.rs
+++ b/circle/src/verifier.rs
@@ -5,7 +5,7 @@ use itertools::{Itertools, izip};
 use p3_commit::Mmcs;
 use p3_field::extension::ComplexExtendable;
 use p3_field::{ExtensionField, Field};
-use p3_fri::verifier::FriError;
+use p3_fri::verifier::{FriError, PowPhase};
 use p3_fri::{FriFoldingStrategy, FriParameters};
 use p3_matrix::Dimensions;
 
@@ -38,6 +38,7 @@ use crate::{CircleCommitPhaseMultiStep, CircleFriProof};
 /// - The proof declares a round count the configuration does not fix.
 /// - A per-round list does not carry one entry per round, or one entry per query.
 /// - A round declares an arity outside `1..=max_log_arity`.
+/// - A grinding witness is not the value its zero difficulty admits.
 pub(crate) fn validate_proof_shape<Challenge, M, Witness, InputProof, InputErr>(
     params: &FriParameters<M>,
     proof: &CircleFriProof<Challenge, M, Witness, InputProof>,
@@ -46,6 +47,7 @@ pub(crate) fn validate_proof_shape<Challenge, M, Witness, InputProof, InputErr>(
 where
     Challenge: Field,
     M: Mmcs<Challenge>,
+    Witness: Field,
     InputErr: core::fmt::Debug,
 {
     // Reject a vacuous instance before any transcript work.
@@ -91,6 +93,33 @@ where
         return Err(FriError::CommitPowWitnessCountMismatch {
             expected: num_commit_rounds,
             got: proof.commit_pow_witnesses.len(),
+        });
+    }
+
+    // A zero difficulty leaves both witnesses unread, so their values are pinned here
+    // rather than by their grinds.
+    //
+    // Why: `check_witness` returns `true` at zero bits without absorbing, and the
+    // transcript elides the step, so nothing downstream compares the field to anything.
+    //
+    //     bits = 0 -> prover emits zero, verifier reads nothing -> pin the field here
+    //     bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+    //
+    // Every commit-round entry is pinned, not only the count checked just above: a count
+    // check is not a value check.
+    if params.commit_proof_of_work_bits == 0
+        && proof
+            .commit_pow_witnesses
+            .iter()
+            .any(|w| *w != Witness::ZERO)
+    {
+        return Err(FriError::NonCanonicalPowWitness {
+            phase: PowPhase::CommitPhase,
+        });
+    }
+    if params.query_proof_of_work_bits == 0 && proof.pow_witness != Witness::ZERO {
+        return Err(FriError::NonCanonicalPowWitness {
+            phase: PowPhase::Query,
         });
     }
 

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -665,6 +665,15 @@ where
         proof: &Self::Proof,
         challenger: &mut Challenger,
     ) -> Result<(), Self::Error> {
+        // A zero grinding budget leaves the witness unread, so every field is pinned here
+        // rather than by its grind.
+        //
+        //     bits = 0 -> prover emits zero, verifier reads nothing -> pin the field here
+        //     bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+        //
+        // The FRI verifier repeats the check for the two phases it owns.
+        verifier::check_canonical_pow_witnesses(&self.fri, proof)?;
+
         // Describe the transcript from the claims, which are this verifier's own input.
         //
         // The prover built the identical description from the matrices it opened.
@@ -928,6 +937,14 @@ mod tests {
     ///
     /// The challenger is advanced past the commitment, ready for `Pcs::verify`.
     fn make_pcs_fixture() -> (MyPcs, Claims, MyProof, Challenger) {
+        make_pcs_fixture_at(BATCH_POW_BITS)
+    }
+
+    /// The same roundtrip at a caller-chosen batch difficulty.
+    ///
+    /// The difficulty reaches the transcript's description, so prover and verifier must
+    /// be built from the same number for the replay to line up.
+    fn make_pcs_fixture_at(batch_pow_bits: usize) -> (MyPcs, Claims, MyProof, Challenger) {
         // Fixed seed keeps the roundtrip deterministic.
         let mut rng = SmallRng::seed_from_u64(42);
 
@@ -944,7 +961,7 @@ mod tests {
             log_final_poly_len: 0,
             max_log_arity: 1,
             num_queries: 2,
-            batch_proof_of_work_bits: BATCH_POW_BITS,
+            batch_proof_of_work_bits: batch_pow_bits,
             commit_proof_of_work_bits: 0,
             query_proof_of_work_bits: 0,
             mmcs: challenge_mmcs,
@@ -1073,6 +1090,29 @@ mod tests {
 
         match err {
             FriError::InvalidPowWitness(PowPhase::Batch) => {}
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn a_noncanonical_batch_grinding_witness_at_zero_difficulty_is_rejected() {
+        // Invariant: at zero difficulty only a canonical-value check binds the witness.
+        //
+        //     bits = 0 -> check_witness returns true, the step is elided -> unbound
+        //     bits > 0 -> absorbed, bits resampled                       -> grind binds
+        let (pcs, claims, mut proof, mut challenger) = make_pcs_fixture_at(0);
+
+        // The honest prover writes zero when it pays no work.
+        assert_eq!(proof.batch_pow_witness, F::ZERO);
+        proof.batch_pow_witness = F::ONE;
+
+        let err = run_pcs_verify(&pcs, claims, &proof, &mut challenger)
+            .expect_err("a rewritten batch grinding witness must be rejected");
+
+        match err {
+            FriError::NonCanonicalPowWitness {
+                phase: PowPhase::Batch,
+            } => {}
             other => panic!("wrong error variant: {other:?}"),
         }
     }

--- a/fri/src/verifier.rs
+++ b/fri/src/verifier.rs
@@ -203,6 +203,22 @@ where
     FinalPolyMismatch,
     #[error("invalid proof-of-work witness for the {0} phase")]
     InvalidPowWitness(PowPhase),
+    /// A grinding witness that is not the value a zero difficulty budget admits.
+    ///
+    /// Checked with the other proof-shape rejections, before any transcript work.
+    //
+    // Why: at zero bits neither side touches the sponge.
+    //
+    //     prover  : grind(0)  -> returns zero, absorbs nothing
+    //     verifier: the Pow step is elided, so no witness is read at all
+    //
+    // The field is then bound to nothing: any value rides along and still verifies.
+    // Zero is the only value an honest prover emits, so zero is the only value accepted.
+    #[error("non-canonical grinding witness for the {phase} phase at zero difficulty")]
+    NonCanonicalPowWitness {
+        /// Phase whose witness is not the canonical zero.
+        phase: PowPhase,
+    },
     /// A query point coincides with an opening point, so the quotient denominator is zero.
     #[error(
         "batch {batch}, matrix {matrix}, point {point}: query point coincides with the opening point"
@@ -291,6 +307,56 @@ where
 /// FRI folds and rolls. The first element of each pair indicates the round of
 /// fri in which the input should be rolled in. The second element is the opening.
 pub type FriOpenings<F> = Vec<(usize, F)>;
+
+/// Checks that every grinding witness a zero difficulty leaves unread carries the one
+/// value a zero budget admits, before any transcript operation.
+///
+/// A positive budget needs no check for its own phase: there the witness is absorbed and
+/// its sampled bits are compared, so the difficulty itself pins the field.
+///
+/// The three phases are checked independently, because their difficulties are independent.
+//
+// Why: `GrindingChallenger::check_witness` returns `true` at `bits == 0` without
+// absorbing, and the typed transcript elides the step altogether, which leaves the
+// witness compared against nothing and free to be any value.
+//
+//     bits = 0 -> prover emits zero, verifier reads nothing -> pin the field here
+//     bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+//
+// The commit phase carries one witness per round, so every entry is pinned rather than
+// only the vector's length: a count check is not a value check.
+pub(crate) fn check_canonical_pow_witnesses<Val, Challenge, FriMmcs, InputErr, InputProof>(
+    params: &FriParameters<FriMmcs>,
+    proof: &FriProof<Challenge, FriMmcs, Val, InputProof>,
+) -> Result<(), FriError<FriMmcs::Error, InputErr>>
+where
+    Val: Field,
+    Challenge: Field,
+    FriMmcs: Mmcs<Challenge>,
+    InputErr: core::fmt::Debug,
+{
+    if params.batch_proof_of_work_bits == 0 && proof.batch_pow_witness != Val::ZERO {
+        return Err(FriError::NonCanonicalPowWitness {
+            phase: PowPhase::Batch,
+        });
+    }
+
+    if params.commit_proof_of_work_bits == 0
+        && proof.commit_pow_witnesses.iter().any(|w| *w != Val::ZERO)
+    {
+        return Err(FriError::NonCanonicalPowWitness {
+            phase: PowPhase::CommitPhase,
+        });
+    }
+
+    if params.query_proof_of_work_bits == 0 && proof.query_pow_witness != Val::ZERO {
+        return Err(FriError::NonCanonicalPowWitness {
+            phase: PowPhase::Query,
+        });
+    }
+
+    Ok(())
+}
 
 /// Verifies a FRI proof.
 ///
@@ -472,6 +538,10 @@ where
             got: proof.commit_pow_witnesses.len(),
         });
     }
+
+    // A zero grinding budget leaves the witness unread, so the three fields are pinned
+    // here rather than by their grinds.
+    check_canonical_pow_witnesses(params, proof)?;
 
     // Ensure that the final polynomial has the expected degree.
     //
@@ -2610,6 +2680,64 @@ mod tests {
 
         match err {
             FriError::InvalidPowWitness(PowPhase::CommitPhase) => {}
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn noncanonical_pow_witnesses_at_zero_difficulty_are_rejected() {
+        // Invariant: at zero difficulty only a canonical-value check binds the witness.
+        //
+        //     bits = 0 -> check_witness returns true without absorbing -> unbound
+        //     bits > 0 -> absorbed, bits resampled                     -> the grind binds
+        //
+        // The commit-phase mutation moves one element and leaves the length alone: the
+        // length has its own rejection, and a count check is not a value check.
+        let f = make_test_fixture();
+        assert_eq!(f.fri_params.commit_proof_of_work_bits, 0);
+        assert_eq!(f.fri_params.query_proof_of_work_bits, 0);
+
+        // The honest prover writes zero into every slot it pays no work for.
+        assert!(f.proof.commit_pow_witnesses.iter().all(|w| *w == Val::ZERO));
+        assert_eq!(f.proof.query_pow_witness, Val::ZERO);
+
+        // One commit round's witness, with the vector's length left untouched.
+        let mut proof = f.proof.clone();
+        proof.commit_pow_witnesses[0] = Val::ONE;
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+            f.alpha,
+        )
+        .expect_err("a rewritten commit-phase witness must be rejected");
+        match err {
+            FriError::NonCanonicalPowWitness {
+                phase: PowPhase::CommitPhase,
+            } => {}
+            other => panic!("wrong error variant: {other:?}"),
+        }
+
+        // The query witness, which is a scalar rather than a vector entry.
+        let mut proof = f.proof.clone();
+        proof.query_pow_witness = Val::ONE;
+        let mut challenger = f.challenger.clone();
+        let err = run_verify_fri(
+            &f.fri_params,
+            &proof,
+            &mut challenger,
+            &f.commitments_with_opening_points,
+            &f.input_mmcs,
+            f.alpha,
+        )
+        .expect_err("a rewritten query witness must be rejected");
+        match err {
+            FriError::NonCanonicalPowWitness {
+                phase: PowPhase::Query,
+            } => {}
             other => panic!("wrong error variant: {other:?}"),
         }
     }

--- a/stir/src/error.rs
+++ b/stir/src/error.rs
@@ -147,6 +147,27 @@ pub enum ProofShapeError {
         stage: GrindStage,
     },
 
+    /// A grinding witness is not the value its site's zero difficulty admits.
+    ///
+    /// Checked before the replication check, which only forces the batched copies of a
+    /// shared site to agree with each other.
+    //
+    // Why: at zero difficulty neither side touches the sponge.
+    //
+    //     prover  : the grind returns zero and absorbs nothing
+    //     verifier: `replay_pow` returns `Ok(())` without reading the witness
+    //
+    // Agreement alone therefore admits a whole batch rewritten to one shared wrong value.
+    // Pinning zero per instance is what closes that: zero is the only value an honest
+    // prover emits, so zero is the only value accepted.
+    #[error("{round}: {stage} PoW witness is nonzero at zero difficulty, expected zero")]
+    NonCanonicalPowWitness {
+        /// Round whose grinding site asks for no work.
+        round: RoundLabel,
+        /// Site inside that round the unread witness belongs to.
+        stage: GrindStage,
+    },
+
     /// The opening proof carries one STIR instance per distinct shared LDE height.
     #[error("expected {expected} LDE-height buckets, got {got}")]
     BucketCount { expected: usize, got: usize },

--- a/stir/src/verifier.rs
+++ b/stir/src/verifier.rs
@@ -1145,10 +1145,12 @@ where
     // A proof carrying a different one is rejected before the description is built.
     check_described_lengths(config, proof, None)?;
 
-    let mut transcript = VerifierTranscript::<Challenger, F, EF>::new(
-        challenger,
-        StirShape::single(config, !initial_is_external),
-    );
+    // A zero-difficulty site leaves its witness unread, so the values are pinned before
+    // the transcript is seeded.
+    let shape = StirShape::single(config, !initial_is_external);
+    check_canonical_pow_witnesses(&shape, &[proof])?;
+
+    let mut transcript = VerifierTranscript::<Challenger, F, EF>::new(challenger, shape);
 
     // Single release point for the driver's completeness check.
     //
@@ -1373,6 +1375,12 @@ where
         check_described_lengths(configs[i], proofs[i], Some(i))?;
     }
 
+    // A zero-difficulty site leaves its witness unread, so the values are pinned before
+    // the agreement check below, which on its own would admit a whole batch rewritten to
+    // one shared wrong value.
+    let shape = StirShape::new(configs, !initial_is_external);
+    check_canonical_pow_witnesses(&shape, proofs)?;
+
     // A shared grind is checked once, so every active instance must carry the same witness.
     check_replicated_witnesses(configs, proofs)?;
 
@@ -1390,10 +1398,7 @@ where
         }
     };
 
-    let mut transcript = VerifierTranscript::<Challenger, F, EF>::new(
-        challenger,
-        StirShape::new(configs, !initial_is_external),
-    );
+    let mut transcript = VerifierTranscript::<Challenger, F, EF>::new(challenger, shape);
 
     // Single release point for the driver's completeness check.
     //
@@ -1412,6 +1417,91 @@ where
             Err(err)
         }
     }
+}
+
+/// Require every witness a zero-difficulty site leaves unread to carry zero.
+///
+/// A site's difficulty is the largest any instance active there asks for, so the check
+/// reads it from the shape the transcript is described with rather than from one config.
+///
+/// A positive difficulty needs no check: there the witness is absorbed and its bits are
+/// resampled, so the grind itself pins the field.
+///
+/// # Errors
+///
+/// When an instance carries a nonzero witness at a site that asks for no work.
+//
+// Why: at zero difficulty neither side touches the sponge.
+//
+//     bits = 0 -> prover emits zero, `replay_pow` returns Ok without reading -> pin here
+//     bits > 0 -> prover grinds,     the sponge resamples the witness's bits -> grind pins
+//
+// Invariant: this runs before `check_replicated_witnesses`, and pins each instance
+// against zero rather than against its neighbours.
+//
+//     agreement only -> a batch rewritten to one shared wrong value passes
+//     zero per copy  -> every rewrite is caught, agreeing or not
+fn check_canonical_pow_witnesses<F, EF, M, IE>(
+    shape: &StirShape,
+    proofs: &[&StirProof<EF, M, F>],
+) -> Result<(), StirError<M::Error, IE>>
+where
+    F: Field,
+    EF: Field,
+    M: Mmcs<EF>,
+{
+    // Intermediate rounds: right-aligned, so only the instances active at a global round
+    // carry a witness for it.
+    for round in 0..shape.max_rounds() {
+        for (stage, bits) in [
+            (GrindStage::Folding, shape.folding_pow_bits(round)),
+            (GrindStage::Query, shape.query_pow_bits(round)),
+        ] {
+            if bits > 0 {
+                continue;
+            }
+            for instance in shape.active(round) {
+                let round_proof =
+                    &proofs[instance].round_proofs[shape.local_round(round, instance)];
+                let witness = match stage {
+                    GrindStage::Folding => round_proof.folding_pow_witness,
+                    GrindStage::Query => round_proof.pow_witness,
+                };
+                if witness != F::ZERO {
+                    return Err(ProofShapeError::NonCanonicalPowWitness {
+                        round: RoundLabel::Round(round),
+                        stage,
+                    }
+                    .into());
+                }
+            }
+        }
+    }
+
+    // The final round is the one global step every instance reaches.
+    for (stage, bits) in [
+        (GrindStage::Folding, shape.final_folding_pow_bits()),
+        (GrindStage::Query, shape.final_pow_bits()),
+    ] {
+        if bits > 0 {
+            continue;
+        }
+        for proof in proofs {
+            let witness = match stage {
+                GrindStage::Folding => proof.final_folding_pow_witness,
+                GrindStage::Query => proof.final_pow_witness,
+            };
+            if witness != F::ZERO {
+                return Err(ProofShapeError::NonCanonicalPowWitness {
+                    round: RoundLabel::Final,
+                    stage,
+                }
+                .into());
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Require every active instance's replicated grinding witness to agree.

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -3727,6 +3727,106 @@ mod babybear_stir_multi {
         }
     }
 
+    #[test]
+    fn a_batch_mixing_ground_and_ungrounded_instances_still_verifies() {
+        // A shared grind runs at the largest difficulty among the instances active at its site.
+        //
+        //     instance A  max_pow_bits 0   -> derives 0 bits
+        //     instance B  max_pow_bits 12  -> derives > 0 bits
+        //     shared site                  -> max(0, >0) = > 0 bits
+        //
+        // So instance A legitimately carries a nonzero witness for a site it asked no work at.
+        // Pinning a witness against its own instance's bits would reject this honest prover.
+        // The canonical check reads the shared shape instead, and skips a site the batch grinds.
+        let (idle_params, dft, challenger) = make_params(1, 2, 32, 0);
+        let (ground_params, _, _) = make_params(1, 2, 32, 12);
+
+        let log_degree = 8usize;
+        let mut rng = seeded_rng();
+        let configs = [&idle_params, &ground_params]
+            .map(|params| StirConfig::<F, EF, MyMmcs, Challenger>::new(log_degree, params.clone()))
+            .to_vec();
+
+        // The grinding instance must actually grind, or the batch proves nothing.
+        assert!(
+            configs[1].round_configs.iter().any(|rc| rc.pow_bits > 0)
+                || configs[1].final_pow_bits > 0,
+            "the second instance must derive a positive difficulty for this batch to be mixed",
+        );
+        assert!(
+            configs[0].round_configs.iter().all(|rc| rc.pow_bits == 0)
+                && configs[0].final_pow_bits == 0,
+            "the first instance must derive no difficulty for this batch to be mixed",
+        );
+
+        let polys: Vec<Vec<EF>> = (0..2)
+            .map(|_| (0..1usize << log_degree).map(|_| rng.random()).collect())
+            .collect();
+        let config_refs: Vec<&StirConfig<F, EF, MyMmcs, Challenger>> = configs.iter().collect();
+
+        let mut p_ch = challenger.clone();
+        let results = prove_stir_multi(&config_refs, polys, &dft, &mut p_ch);
+        let proofs: Vec<_> = results.iter().map(|(proof, _)| proof).collect();
+
+        // Completeness: the honest mixed batch verifies, canonical check and all.
+        let mut v_ch = challenger;
+        verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proofs, &mut v_ch)
+            .expect("an honest batch mixing ground and ungrounded instances must verify");
+    }
+
+    #[test]
+    fn test_multi_noncanonical_replicated_pow_witnesses_are_rejected() {
+        // Why: `check_replicated_witnesses` compares the copies of a shared site only
+        // against each other, and at zero difficulty nothing else reads them at all.
+        //
+        //     agree, both wrong -> the agreement check passes  -> unbound
+        //     pinned to zero    -> every rewrite is caught     -> bound
+        let (params, dft, challenger) = make_params(1, 2, 16, 0);
+        let log_degrees = [8usize, 6];
+        let (configs, polys) = make_instances(&params, &log_degrees);
+        let config_refs: Vec<&StirConfig<F, EF, MyMmcs, Challenger>> = configs.iter().collect();
+
+        let mut p_ch = challenger.clone();
+        let results = prove_stir_multi(&config_refs, polys, &dft, &mut p_ch);
+        let mut proofs: Vec<_> = results.into_iter().map(|(proof, _)| proof).collect();
+
+        // Every site asks for no work, so the honest prover wrote zero into all of them.
+        for proof in &proofs {
+            assert!(
+                proof
+                    .round_proofs
+                    .iter()
+                    .all(|rp| rp.folding_pow_witness == F::ZERO && rp.pow_witness == F::ZERO)
+            );
+            assert_eq!(proof.final_folding_pow_witness, F::ZERO);
+            assert_eq!(proof.final_pow_witness, F::ZERO);
+        }
+
+        // Rewrite every replicated copy to one shared wrong value, so the instances still
+        // agree and the replication check has nothing to catch.
+        for proof in &mut proofs {
+            for rp in &mut proof.round_proofs {
+                rp.folding_pow_witness = F::ONE;
+                rp.pow_witness = F::ONE;
+            }
+            proof.final_folding_pow_witness = F::ONE;
+            proof.final_pow_witness = F::ONE;
+        }
+
+        let proof_refs: Vec<_> = proofs.iter().collect();
+        let mut v_ch = challenger;
+        let err =
+            verify_stir_multi::<F, EF, MyMmcs, Challenger>(&config_refs, &proof_refs, &mut v_ch)
+                .expect_err("rewritten replicated witnesses must be rejected");
+        assert!(
+            matches!(
+                err,
+                StirError::InvalidProofShape(ProofShapeError::NonCanonicalPowWitness { .. })
+            ),
+            "expected NonCanonicalPowWitness, got {err:?}"
+        );
+    }
+
     /// The result an external fiber source returns.
     type FiberResult = Result<Vec<Vec<EF>>, StirError<<MyMmcs as Mmcs<EF>>::Error>>;
 

--- a/uni-stark/src/error.rs
+++ b/uni-stark/src/error.rs
@@ -108,6 +108,19 @@ pub enum InvalidProofShapeError {
     /// Opened values (trace, quotient, random) don't match expected dimensions.
     #[error("opened values do not match expected dimensions")]
     OpenedValuesDimensionMismatch,
+    /// The out-of-domain grinding witness is not the value a zero difficulty admits.
+    ///
+    /// Checked with the other proof-shape rejections, before any transcript work.
+    //
+    // Why: at `ood_pow_bits = 0` neither side touches the sponge.
+    //
+    //     prover  : grind(0)            -> returns zero, absorbs nothing
+    //     verifier: the Pow step is elided, so no witness is read at all
+    //
+    // `ood_pow_witness` is then bound to nothing: any value rides along and still verifies.
+    // Zero is the only value an honest prover emits, so zero is the only value accepted.
+    #[error("out-of-domain grinding witness is nonzero at zero difficulty, expected zero")]
+    NonCanonicalOodPowWitness,
 }
 
 /// Reasons a periodic column cannot be evaluated.

--- a/uni-stark/src/verifier.rs
+++ b/uni-stark/src/verifier.rs
@@ -543,6 +543,15 @@ where
         return Err(InvalidProofShapeError::OpenedValuesDimensionMismatch.into());
     }
 
+    // A zero grinding budget leaves the out-of-domain witness unread, so its value is
+    // pinned here rather than by the grind.
+    //
+    //     bits = 0 -> prover emits zero, verifier reads nothing -> pin the field here
+    //     bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+    if config.ood_proof_of_work_bits() == 0 && *ood_pow_witness != Val::<SC>::ZERO {
+        return Err(InvalidProofShapeError::NonCanonicalOodPowWitness.into());
+    }
+
     // A preprocessed commitment is bound only when the width in force is positive.
     let preprocessed_commit = preprocessed_commit.filter(|_| preprocessed_width > 0);
 

--- a/uni-stark/tests/grinding.rs
+++ b/uni-stark/tests/grinding.rs
@@ -23,8 +23,8 @@ use p3_merkle_tree::MerkleTreeMmcs;
 use p3_security::grinding::GrindingSites;
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{
-    ProvenSecurity, StarkConfig, StarkGenericConfig, StarkSecurityParams, VerificationError, prove,
-    verify,
+    InvalidProofShapeError, ProvenSecurity, StarkConfig, StarkGenericConfig, StarkSecurityParams,
+    VerificationError, prove, verify,
 };
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
@@ -145,6 +145,32 @@ fn tampered_ood_pow_witness_is_rejected() {
     match verify(&config, &SquareAir, &proof, &[]) {
         Err(VerificationError::InvalidOodPowWitness) => {}
         other => panic!("expected InvalidOodPowWitness, got {other:?}"),
+    }
+}
+
+#[test]
+fn a_noncanonical_ood_pow_witness_at_zero_difficulty_is_rejected() {
+    // Why: `check_witness` short-circuits at zero bits, and the step is elided.
+    //
+    //     ood_pow_bits = 0 -> the witness never reaches the sponge -> unbound
+    //     ood_pow_bits > 0 -> absorbed, bits resampled             -> the grind binds it
+    //
+    // Left unbound, a third party rewrites the field and keeps a verifying proof.
+    let config = make_config(0, 0);
+    let trace = generate_square_trace::<Val>(1 << 3);
+    let mut proof = prove(&config, &SquareAir, trace, &[]);
+
+    // The honest prover writes zero when it pays no work, so zero is canonical.
+    assert_eq!(proof.ood_pow_witness, Val::ZERO);
+
+    // Any other value is a second encoding of the same statement.
+    proof.ood_pow_witness = Val::ONE;
+
+    match verify(&config, &SquareAir, &proof, &[]) {
+        Err(VerificationError::InvalidProofShape(
+            InvalidProofShapeError::NonCanonicalOodPowWitness,
+        )) => {}
+        other => panic!("expected NonCanonicalOodPowWitness, got {other:?}"),
     }
 }
 

--- a/whir/src/pcs/tests.rs
+++ b/whir/src/pcs/tests.rs
@@ -762,6 +762,7 @@ mod error_variant_tests {
     use alloc::vec;
 
     use p3_commit::{Mmcs, MultilinearPcs};
+    use p3_field::PrimeCharacteristicRing;
     use p3_multilinear_util::poly::Poly;
     use p3_sumcheck::layout::{Layout, SuffixProver, Table};
     use p3_sumcheck::{OpeningBatch, OpeningProtocol, SumcheckError, TableShape, TableSpec};
@@ -1180,6 +1181,46 @@ mod error_variant_tests {
                 assert_eq!(a, expected - 1);
             }
             other => panic!("expected InitialOodAnswerCountMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_noncanonical_pow_witnesses_at_zero_difficulty() {
+        // Invariant: at zero difficulty the grind reads nothing, so only a
+        // canonical-value check can bind the witness fields.
+        //
+        //     pow_bits = 0  ->  check_witness returns true without absorbing
+        //     pow_bits > 0  ->  the witness is absorbed and its bits resampled
+        //
+        // Fixture state: `pow_bits: 0`, so every round's site asks for no work.
+        //
+        // Mutation: rewrite one round's witness, then the final round's, each on its own.
+        let (pcs, commitment, proof, protocol) = commit_and_open();
+        assert!(
+            !proof.whir.rounds.is_empty(),
+            "fixture should produce at least one WHIR round"
+        );
+        let rounds = proof.whir.rounds.len();
+
+        // The honest prover writes zero into every slot it pays no work for.
+        assert!(proof.whir.rounds.iter().all(|r| r.pow_witness == F::ZERO));
+        assert_eq!(proof.whir.final_pow_witness, F::ZERO);
+
+        let mut mutated = proof.clone();
+        mutated.whir.rounds[0].pow_witness = F::ONE;
+        let err = verify(&pcs, &commitment, &mutated, protocol.clone()).unwrap_err();
+        match err {
+            VerifierError::NonCanonicalPowWitness { round } => assert_eq!(round, 0),
+            other => panic!("expected NonCanonicalPowWitness, got {other:?}"),
+        }
+
+        // The final round is labelled by the intermediate round count, as elsewhere here.
+        let mut mutated = proof;
+        mutated.whir.final_pow_witness = F::ONE;
+        let err = verify(&pcs, &commitment, &mutated, protocol).unwrap_err();
+        match err {
+            VerifierError::NonCanonicalPowWitness { round } => assert_eq!(round, rounds),
+            other => panic!("expected NonCanonicalPowWitness, got {other:?}"),
         }
     }
 

--- a/whir/src/pcs/verifier/errors.rs
+++ b/whir/src/pcs/verifier/errors.rs
@@ -68,6 +68,21 @@ pub enum VerifierError {
     #[error("Invalid proof-of-work witness")]
     InvalidPowWitness,
 
+    /// A grinding witness is not the value its zero difficulty admits.
+    ///
+    /// Raised with the other shape checks, before any transcript work.
+    ///
+    /// The final round is labelled by the intermediate round count.
+    //
+    // Why: at `pow_bits = 0` neither side touches the sponge.
+    //
+    //     prover  : grind is skipped     -> zero on the wire
+    //     verifier: check_witness(0, w)  -> returns true, absorbs nothing
+    //
+    // The field is then bound to nothing: any value rides along and still verifies.
+    #[error("Non-canonical proof-of-work witness in round {round} at zero difficulty")]
+    NonCanonicalPowWitness { round: usize },
+
     /// Proof is missing the Merkle commitment for a round.
     #[error("Proof is missing the Merkle commitment for round {round}")]
     MissingRoundCommitment { round: usize },

--- a/whir/src/pcs/verifier/mod.rs
+++ b/whir/src/pcs/verifier/mod.rs
@@ -128,6 +128,26 @@ where
             });
         }
 
+        // A zero-difficulty site leaves its witness unread, so the value is pinned here
+        // rather than by the grind.
+        //
+        // Why: `check_witness` returns `true` at zero bits without absorbing anything.
+        //
+        //     pow_bits = 0 -> prover emits zero, verifier reads nothing -> pin it here
+        //     pow_bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+        //
+        // Each round carries its own difficulty, so each is compared against its own.
+        for (round, round_proof) in proof.rounds.iter().enumerate() {
+            if self.round_parameters[round].pow_bits == 0 && round_proof.pow_witness != F::ZERO {
+                return Err(VerifierError::NonCanonicalPowWitness { round });
+            }
+        }
+        if self.final_round_config().pow_bits == 0 && proof.final_pow_witness != F::ZERO {
+            return Err(VerifierError::NonCanonicalPowWitness {
+                round: expected_rounds,
+            });
+        }
+
         // One driver spans the whole run, so the description is walked exactly once.
         let shape = WhirShape::new(self.config, num_opening_claims);
         let mut transcript = WhirVerifierTranscript::<Challenger, F, EF>::new(challenger, shape);

--- a/whir/src/pcs/zk/base_case/error.rs
+++ b/whir/src/pcs/zk/base_case/error.rs
@@ -29,6 +29,19 @@ pub enum BaseCaseZkError {
     #[error("invalid proof-of-work witness")]
     InvalidPowWitness,
 
+    /// The proof-of-work witness is not the value a zero difficulty admits.
+    ///
+    /// Raised with the length checks, before any transcript work.
+    //
+    // Why: at `pow_bits = 0` neither side touches the sponge.
+    //
+    //     prover  : grind is skipped     -> zero on the wire
+    //     verifier: check_witness(0, w)  -> returns true, absorbs nothing
+    //
+    // The field is then bound to nothing: any value rides along and still verifies.
+    #[error("non-canonical proof-of-work witness at zero difficulty")]
+    NonCanonicalPowWitness,
+
     /// The joint linear target check failed.
     #[error("base-case target check failed")]
     TargetCheckFailed,

--- a/whir/src/pcs/zk/base_case/verifier.rs
+++ b/whir/src/pcs/zk/base_case/verifier.rs
@@ -41,7 +41,7 @@ where
     /// # Checks
     ///
     /// ```text
-    ///     0. pin every length of the statement and the proof
+    ///     0. pin every length, and the witness a zero difficulty leaves unread
     ///     1. replay the transcript    commitments, mu_g, gamma, reveals
     ///     2. target check             claim transfers onto the reveals
     ///     3. proof of work
@@ -138,6 +138,14 @@ where
                 mask.randomness.len(),
                 shape.randomness_len,
             )?;
+        }
+
+        // Still check 0: a zero-difficulty grind leaves the witness unread, so pin it.
+        //
+        //     pow_bits = 0 -> prover emits zero, verifier reads nothing -> pin it here
+        //     pow_bits > 0 -> prover grinds,     verifier resamples     -> check 3 pins it
+        if self.config.pow_bits == 0 && proof.pow_witness != F::ZERO {
+            return Err(BaseCaseZkError::NonCanonicalPowWitness);
         }
 
         // Check 1: replay the prover's moves into the Fiat-Shamir sponge.

--- a/whir/src/pcs/zk/tests.rs
+++ b/whir/src/pcs/zk/tests.rs
@@ -517,6 +517,37 @@ fn zk_whir_rejects_tampered_pow_witness() {
 }
 
 #[test]
+fn zk_whir_rejects_noncanonical_pow_witnesses_at_zero_difficulty() {
+    // Fixture state: the canonical shape grinds nowhere, so every site asks for no work.
+    //
+    //     pow_bits = 0  ->  check_witness returns true without absorbing
+    //     pow_bits > 0  ->  the witness is absorbed and its bits resampled
+    //
+    // Mutation: rewrite the code-switching round's witness, then the base case's.
+    // Neither reaches the sponge, so only a canonical-value check can reject them.
+    let proven = Setup::new(22).prove();
+
+    // The honest prover writes zero into every slot it pays no work for.
+    assert!(proven.proof.rounds.iter().all(|r| r.pow_witness == F::ZERO));
+    assert_eq!(proven.proof.base_case.pow_witness, F::ZERO);
+    proven.verify().expect("an ungrounded proof must verify");
+
+    let mut mutated = Setup::new(22).prove();
+    mutated.proof.rounds[0].pow_witness = F::ONE;
+    assert_eq!(
+        mutated.verify().unwrap_err(),
+        ZkVerifierError::NonCanonicalPowWitness { round: 0 }
+    );
+
+    let mut mutated = Setup::new(22).prove();
+    mutated.proof.base_case.pow_witness = F::ONE;
+    assert_eq!(
+        mutated.verify().unwrap_err(),
+        ZkVerifierError::BaseCase(BaseCaseZkError::NonCanonicalPowWitness)
+    );
+}
+
+#[test]
 fn zk_whir_rejects_tampered_sumcheck_wire() {
     // Mutation: shift one coefficient of the first sumcheck wire.
     //

--- a/whir/src/pcs/zk/verifier/mod.rs
+++ b/whir/src/pcs/zk/verifier/mod.rs
@@ -97,6 +97,19 @@ pub enum ZkVerifierError {
     /// A round failed its proof-of-work check.
     #[error("invalid proof-of-work witness in round {round}")]
     InvalidPowWitness { round: usize },
+
+    /// A round's grinding witness is not the value its zero difficulty admits.
+    ///
+    /// Raised with the other structural checks, before any transcript work.
+    //
+    // Why: at `pow_bits = 0` neither side touches the sponge.
+    //
+    //     prover  : grind is skipped     -> zero on the wire
+    //     verifier: check_witness(0, w)  -> returns true, absorbs nothing
+    //
+    // The field is then bound to nothing: any value rides along and still verifies.
+    #[error("non-canonical proof-of-work witness in round {round} at zero difficulty")]
+    NonCanonicalPowWitness { round: usize },
 }
 
 /// The commitment a code-switch round opens against.
@@ -190,6 +203,21 @@ where
                 expected: n_rounds + 1,
                 actual: proof.sumcheck_mask_commitments.len(),
             });
+        }
+
+        // A zero-difficulty site leaves its witness unread, so the value is pinned here
+        // rather than by the grind.
+        //
+        //     pow_bits = 0 -> prover emits zero, verifier reads nothing -> pin it here
+        //     pow_bits > 0 -> prover grinds,     verifier resamples     -> the grind pins it
+        //
+        // Each round carries its own difficulty, so each is compared against its own.
+        //
+        // The base case pins its own witness the same way.
+        for (round, round_proof) in proof.rounds.iter().enumerate() {
+            if config.round_parameters[round].pow_bits == 0 && round_proof.pow_witness != F::ZERO {
+                return Err(ZkVerifierError::NonCanonicalPowWitness { round });
+            }
         }
 
         // Reject malformed statements before any folding arithmetic runs.


### PR DESCRIPTION
Depends on #2105 and the branches below it. This PR targets `fix/binary-pcs-canonical-pow-witness`; retarget after they land.

## The finding

The defect #2105 fixes in `binary-pcs` is **systemic**. Every proof-of-work witness field in the repository is unbound at zero difficulty, in five more crates.

```text
    check_witness(0, w)  ->  true, absorbs nothing
    Kind::Pow step       ->  elided entirely when the difficulty is zero
    proof witness field  ->  carried unconditionally, prover writes ZERO
```

| Crate | Unbound fields |
| --- | --- |
| uni-STARK | `ood_pow_witness` |
| FRI | `batch_pow_witness`, `query_pow_witness`, and every element of `commit_pow_witnesses` |
| Circle | `pow_witness`, and every element of `commit_pow_witnesses` |
| WHIR | four scalars across the plain, HVZK and base-case pipelines |
| STIR | four scalars, replicated per batched instance |

**This is reachable in configurations the repo ships.** `fri/src/config.rs` sets `batch_proof_of_work_bits: 0` or `commit_proof_of_work_bits: 0` in seven places across `new_testing`, `new_benchmark` and their zk variants; WHIR's own constructors set zero; STIR's tests run all three budgets at zero. uni-STARK's `ood_pow_bits` is a caller-supplied `usize` with no lower bound — and its proof field's doc comment reads *"Trivially valid (and unread) when … is `0`"*, documenting the hole without recognising it as one.

Two cases are worse than a scalar comparison:

- **FRI and Circle carry vectors**, and the verifier checked only `.len()` against the round count. A count check is not a value check — every element was free.
- **STIR replicates**, and `check_replicated_witnesses` only forces the batched copies to agree *with each other*. Rewriting all of them to the same wrong value passed. The before-state is the load-bearing evidence: with all eight slots across two instances rewritten, `verify_stir_multi` returned `Ok(...)`.

`batch-stark` is the only crate that already got this right, and it did so differently — it always describes the `Pow` step, zero included, so the witness is absorbed at every difficulty.

## Severity

**Proof malleability, not a soundness break.** No attacker can prove a false statement; proofs simply are not uniquely encoded. That matters wherever proof bytes are hashed, deduplicated, used as an identifier, or recursed over. This is the same reasoning already written on `binary-pcs`'s `NonEmptyPowWitnesses`.

## The remedy, and the two stronger ones not taken

This pins the canonical value: at zero difficulty the honest witness is `ZERO`, so anything else is rejected with a typed error before any transcript operation. It **changes no transcript and no serialized proof shape**, so every `.postcard` fixture passes unchanged — confirmed, no fixture byte moved.

Two stronger remedies exist and are deliberately deferred:

- **Always describe the `Pow` step, zero included** — `batch-stark`'s choice, and the recommended follow-up. It expresses the rule once in the transcript layer instead of fifteen hand-written comparisons a future field or crate can forget, and makes the binding structural: the witness is absorbed at every difficulty, so a rewrite desynchronises Fiat-Shamir and is caught by ordinary machinery. Its cost is an `observe_pow` semantics change touching every protocol plus a breaking transcript change in five crates, but that cost is paid once and can be sequenced behind a single `p3-challenger` change.
- **Make the field absent at zero difficulty** (`Option<Witness>`). Most type-honest, but it buys strictly less than the above for a comparable price: it removes the field, yet says nothing about whether a witness that *is* present was ever absorbed.

## The STIR subtlety

A shared grind runs at the **max** difficulty over the instances active at that site. So an instance configured at 0 bits legitimately carries a nonzero witness when batched with one at 20 bits, and pinning per-instance against that instance's own bits would reject honest provers. The check reads the shared `StirShape` the transcript is described with, and skips any site the batch actually grinds — so agreement becomes a consequence of canonicality rather than a substitute for it.

`a_batch_mixing_ground_and_ungrounded_instances_still_verifies` pins that completeness property. With naive per-site pinning it fails:

```
an honest batch mixing ground and ungrounded instances must verify:
  InvalidProofShape(NonCanonicalPowWitness { round: Round(0), stage: Folding })
```

## Tests

One mutation test per crate, each failing before the fix and passing after; the vector cases mutate a single element and leave the length alone, so a passing typed rejection proves the element check fired rather than the count check. Round trips at both zero and positive difficulty per crate confirm the honest path is intact.

## Known limitation

None of the five error enums is `#[non_exhaustive]`, so adding a variant is technically breaking for a downstream exhaustive `match` — unlike `binary-pcs` in #2105, whose enum is. In practice these are `thiserror` verification errors that callers propagate or print, and the alternative would lose the typed distinction. Worth a reviewer's eye. WHIR needed three variants rather than one, because its three sub-protocols each own an error enum and the base-case witness must be rejected by the base-case verifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
