### PR TITLE
test(challenger): assert no two protocols share a transcript seed

### DIFF
--- a/batch-stark/Cargo.toml
+++ b/batch-stark/Cargo.toml
@@ -30,6 +30,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
+p3-challenger = { path = "../challenger", features = ["test-utils"] }
 p3-circle = { path = "../circle" }
 p3-commit = { path = "../commit" }
 p3-dft = { path = "../dft" }

--- a/batch-stark/src/transcript.rs
+++ b/batch-stark/src/transcript.rs
@@ -1002,6 +1002,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
     use p3_challenger::{CanSample, DuplexChallenger};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
@@ -1039,12 +1040,11 @@ mod tests {
         }
     }
 
-    /// The first challenge a shape's seed produces.
-    fn first_challenge(shape: &BatchShape) -> F {
-        let mut challenger = fresh_challenger();
-        let separator = shape.domain_separator::<F, EF>();
-        separator.seed(&mut challenger);
-        challenger.sample()
+    /// The digest of the byte stream a shape seeds its sponge with.
+    ///
+    /// Comparing seed streams, rather than a sampled challenge, keeps the sponge out of it.
+    fn seed_of(shape: &BatchShape) -> SeedDigest {
+        seed_digest(&shape.domain_separator::<F, EF>())
     }
 
     /// One mutation of the plain shape per field a reader can set.
@@ -1095,21 +1095,22 @@ mod tests {
     }
 
     #[test]
-    fn every_configuration_knob_reaches_the_seed() {
+    fn no_two_configurations_of_the_shape_share_a_seed() {
         // A knob invisible to the seed is a knob the two sides can silently disagree on.
         //
-        // Some ride the pattern fingerprint, others the instance label.
-        // Which of the two carries a given knob is an implementation detail.
-        // That the seed moves at all is not.
-        let baseline = first_challenge(&plain_shape());
+        //     plain shape in the set  ->  every knob has to reach the seed
+        //     pairwise over the set   ->  no two knobs may land on one seed
+        //
+        // Which of the fingerprint and the label carries a given knob is an implementation detail.
+        // That every knob lands on a seed of its own is not.
+        let mut seeds = vec![("plain", seed_of(&plain_shape()))];
+        seeds.extend(
+            one_mutation_per_field()
+                .iter()
+                .map(|(field, shape)| (*field, seed_of(shape))),
+        );
 
-        for (field, mutated) in one_mutation_per_field() {
-            assert_ne!(
-                baseline,
-                first_challenge(&mutated),
-                "changing `{field}` left the seed where it was",
-            );
-        }
+        assert_seeds_pairwise_distinct(&seeds);
     }
 
     #[test]
@@ -1124,7 +1125,7 @@ mod tests {
         let mut descending = ascending.clone();
         descending.trace_widths.reverse();
 
-        assert_ne!(first_challenge(&ascending), first_challenge(&descending));
+        assert_ne!(seed_of(&ascending), seed_of(&descending));
     }
 
     #[test]
@@ -1140,7 +1141,7 @@ mod tests {
         let mut two = one.clone();
         two.num_lookup_instances = 2;
 
-        assert_ne!(first_challenge(&one), first_challenge(&two));
+        assert_ne!(seed_of(&one), seed_of(&two));
     }
 
     #[test]
@@ -1151,7 +1152,7 @@ mod tests {
         let mut ground = ungrounded.clone();
         ground.ood_pow_bits = 1;
 
-        assert_ne!(first_challenge(&ungrounded), first_challenge(&ground));
+        assert_ne!(seed_of(&ungrounded), seed_of(&ground));
     }
 
     #[test]

--- a/binary-field/Cargo.toml
+++ b/binary-field/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true, features = ["derive"] }
 tracing.workspace = true
 
 [dev-dependencies]
+p3-challenger = { workspace = true, features = ["test-utils"] }
 p3-field-testing.workspace = true
 p3-keccak.workspace = true
 

--- a/binary-field/src/transcript.rs
+++ b/binary-field/src/transcript.rs
@@ -124,28 +124,18 @@ mod tests {
     use alloc::vec;
     use alloc::vec::Vec;
 
+    use p3_challenger::testing::Recorder;
+
     use super::*;
 
     /// Width of the length field written ahead of a seed, in bytes.
     const SEED_LEN_BYTES: usize = 8;
 
-    /// Captures every absorbed element in order.
-    #[derive(Default)]
-    struct Recorder<T> {
-        seen: Vec<T>,
-    }
-
-    impl<T> CanObserve<T> for Recorder<T> {
-        fn observe(&mut self, value: T) {
-            self.seen.push(value);
-        }
-    }
-
     /// The elements one byte string packs into at a given level.
     fn packed<F: TranscriptField>(bytes: &[u8]) -> Vec<F> {
         let mut recorder = Recorder::default();
         F::observe_seed(&mut recorder, bytes);
-        recorder.seen
+        recorder.into_absorbed()
     }
 
     #[test]

--- a/binary-field/tests/transcript.rs
+++ b/binary-field/tests/transcript.rs
@@ -1,9 +1,10 @@
 use p3_binary_field::{BinaryChallenger, BinaryField128, TowerLevel};
+use p3_challenger::HashChallenger;
 use p3_challenger::fs::{
     Codec, DomainSeparator, FieldToFieldCodec, FieldUnit, Hierarchy, Interaction,
     InteractionPattern, Kind, Length, ProverState, TypeTag, Unit, VerifierState,
 };
-use p3_challenger::{CanObserve, HashChallenger};
+use p3_challenger::testing::Recorder;
 use p3_keccak::Keccak256Hash;
 use proptest::prelude::*;
 
@@ -11,19 +12,10 @@ type F = BinaryField128;
 type Ch = BinaryChallenger<F, HashChallenger<u8, Keccak256Hash, 32>>;
 type Cdc = FieldToFieldCodec<F>;
 
-#[derive(Default)]
-struct Recorder(Vec<F>);
-
-impl CanObserve<F> for Recorder {
-    fn observe(&mut self, value: F) {
-        self.0.push(value);
-    }
-}
-
 fn seed(bytes: &[u8]) -> Vec<F> {
     let mut recorder = Recorder::default();
     FieldUnit::<F>::observe_bytes(&mut recorder, bytes);
-    recorder.0
+    recorder.into_absorbed()
 }
 
 #[test]

--- a/challenger/Cargo.toml
+++ b/challenger/Cargo.toml
@@ -11,6 +11,8 @@ categories.workspace = true
 
 [features]
 parallel = ["p3-maybe-rayon/parallel"]
+# Shared transcript-seed checks, pulled in as a dev-dependency by consumers.
+test-utils = []
 
 [dependencies]
 p3-field.workspace = true

--- a/challenger/src/fs/domain_separator.rs
+++ b/challenger/src/fs/domain_separator.rs
@@ -127,9 +127,27 @@ impl<U: Unit> DomainSeparator<U> {
         &self.pattern
     }
 
-    /// Absorb the seed into the sponge.
+    /// Assemble the byte stream the seed is absorbed from.
     ///
     /// Wire layout: `[protocol_id | pattern_hash | len_be_4_bytes | label | DOMAIN_TAG]`.
+    ///
+    /// The stream is assembled before any alphabet sees it, so it does not depend on `U`.
+    /// It is the whole per-instance binding, and nothing else is absorbed at seeding time.
+    pub(crate) fn seed_bytes(&self) -> Vec<u8> {
+        let mut seed = Vec::with_capacity(PROTOCOL_ID_LEN + 32 + 4 + self.instance_label.len() + 1);
+        seed.extend_from_slice(&self.protocol_id);
+        // Pattern shape is part of the seed: distinct shapes cannot collide.
+        seed.extend_from_slice(&self.pattern.pattern_hash());
+        // Length prefix prevents two labels of different lengths from colliding.
+        let len = self.instance_label.len() as u32;
+        seed.extend_from_slice(&len.to_be_bytes());
+        seed.extend_from_slice(&self.instance_label);
+        // Terminator stops later absorbs from extending the seed.
+        seed.push(DOMAIN_TAG);
+        seed
+    }
+
+    /// Absorb the seed into the sponge.
     ///
     /// The byte stream is built first, then handed to the alphabet:
     /// a byte sponge takes it verbatim, a field sponge packs it into elements.
@@ -141,17 +159,7 @@ impl<U: Unit> DomainSeparator<U> {
     where
         C: CanObserve<U::Item>,
     {
-        let mut seed = Vec::with_capacity(PROTOCOL_ID_LEN + 32 + 4 + self.instance_label.len() + 1);
-        seed.extend_from_slice(&self.protocol_id);
-        // Pattern shape is part of the seed: distinct shapes cannot collide.
-        seed.extend_from_slice(&self.pattern.pattern_hash());
-        // Length prefix prevents two labels of different lengths from colliding.
-        let len = self.instance_label.len() as u32;
-        seed.extend_from_slice(&len.to_be_bytes());
-        seed.extend_from_slice(&self.instance_label);
-        // Terminator stops later absorbs from extending the seed.
-        seed.push(DOMAIN_TAG);
-        U::observe_bytes(challenger, &seed);
+        U::observe_bytes(challenger, &self.seed_bytes());
     }
 }
 
@@ -164,24 +172,12 @@ mod tests {
     use p3_field::PrimeCharacteristicRing;
 
     use super::*;
-    use crate::CanObserve;
     use crate::fs::pattern::{Hierarchy, Interaction, InteractionPattern, Kind, Length};
     use crate::fs::unit::FieldUnit;
+    use crate::testing::Recorder;
 
     /// Concrete field exercised in this module's tests.
     type F = BabyBear;
-
-    /// Captures every absorbed value in order.
-    #[derive(Default)]
-    struct Recorder<T> {
-        buf: Vec<T>,
-    }
-
-    impl<T> CanObserve<T> for Recorder<T> {
-        fn observe(&mut self, value: T) {
-            self.buf.push(value);
-        }
-    }
 
     fn empty_pattern() -> InteractionPattern {
         InteractionPattern::new(Vec::new()).unwrap()
@@ -241,19 +237,19 @@ mod tests {
         const LABEL: usize = LEN + 4;
 
         // Label region is 4 length bytes plus the 5 payload bytes.
-        assert_eq!(rec.buf.len(), PROTOCOL_ID_LEN + 32 + 4 + 9 + 1);
-        assert_eq!(rec.buf[0], 7);
-        assert_eq!(&rec.buf[1..3], b"p3");
-        assert!(rec.buf[3..NAME_LEN_INDEX].iter().all(|&b| b == 0));
-        assert_eq!(rec.buf[NAME_LEN_INDEX], 2);
+        assert_eq!(rec.absorbed().len(), PROTOCOL_ID_LEN + 32 + 4 + 9 + 1);
+        assert_eq!(rec.absorbed()[0], 7);
+        assert_eq!(&rec.absorbed()[1..3], b"p3");
+        assert!(rec.absorbed()[3..NAME_LEN_INDEX].iter().all(|&b| b == 0));
+        assert_eq!(rec.absorbed()[NAME_LEN_INDEX], 2);
         // Pattern fingerprint is bound automatically right after the identifier.
-        assert_eq!(&rec.buf[HASH..LEN], &expected_hash);
+        assert_eq!(&rec.absorbed()[HASH..LEN], &expected_hash);
         // Big-endian length prefix of the whole label region.
-        assert_eq!(&rec.buf[LEN..LABEL], &[0, 0, 0, 9]);
+        assert_eq!(&rec.absorbed()[LEN..LABEL], &[0, 0, 0, 9]);
         // Delimiter of the single chunk, then its payload.
-        assert_eq!(&rec.buf[LABEL..LABEL + 4], &[0, 0, 0, 5]);
-        assert_eq!(&rec.buf[LABEL + 4..LABEL + 9], b"hello");
-        assert_eq!(rec.buf[LABEL + 9], DOMAIN_TAG);
+        assert_eq!(&rec.absorbed()[LABEL..LABEL + 4], &[0, 0, 0, 5]);
+        assert_eq!(&rec.absorbed()[LABEL + 4..LABEL + 9], b"hello");
+        assert_eq!(rec.absorbed()[LABEL + 9], DOMAIN_TAG);
     }
 
     #[test]
@@ -265,7 +261,7 @@ mod tests {
         let mut rb = Recorder::<u8>::default();
         a.seed(&mut ra);
         b.seed(&mut rb);
-        assert_ne!(ra.buf, rb.buf);
+        assert_ne!(ra.absorbed(), rb.absorbed());
     }
 
     #[test]
@@ -279,7 +275,7 @@ mod tests {
         let mut rb = Recorder::<u8>::default();
         a.seed(&mut ra);
         b.seed(&mut rb);
-        assert_ne!(ra.buf, rb.buf);
+        assert_ne!(ra.absorbed(), rb.absorbed());
     }
 
     #[test]
@@ -299,7 +295,7 @@ mod tests {
         let mut rg = Recorder::<u8>::default();
         split.seed(&mut rs);
         glued.seed(&mut rg);
-        assert_ne!(rs.buf, rg.buf);
+        assert_ne!(rs.absorbed(), rg.absorbed());
     }
 
     #[test]
@@ -329,7 +325,7 @@ mod tests {
         let mut rb = Recorder::<u8>::default();
         a.seed(&mut ra);
         b.seed(&mut rb);
-        assert_ne!(ra.buf, rb.buf);
+        assert_ne!(ra.absorbed(), rb.absorbed());
     }
 
     #[test]
@@ -343,8 +339,8 @@ mod tests {
 
         // Seed is 64 + 32 + 4 + 0 + 1 = 101 bytes, packed 3 bytes per element,
         // behind one leading length element.
-        assert_eq!(rec.buf.len(), 1 + 101_usize.div_ceil(3));
-        assert_eq!(rec.buf[0], F::from_u32(101));
+        assert_eq!(rec.absorbed().len(), 1 + 101_usize.div_ceil(3));
+        assert_eq!(rec.absorbed()[0], F::from_u32(101));
     }
 
     #[test]
@@ -356,6 +352,6 @@ mod tests {
         let mut rb = Recorder::<F>::default();
         a.seed(&mut ra);
         b.seed(&mut rb);
-        assert_ne!(ra.buf, rb.buf);
+        assert_ne!(ra.absorbed(), rb.absorbed());
     }
 }

--- a/challenger/src/fs/unit.rs
+++ b/challenger/src/fs/unit.rs
@@ -73,32 +73,20 @@ impl<F: TranscriptField> Unit for FieldUnit<F> {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
-    use alloc::vec::Vec;
 
     use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
     use p3_goldilocks::Goldilocks;
 
     use super::*;
-
-    /// Records every absorbed element in order.
-    #[derive(Default)]
-    struct Recorder<T> {
-        seen: Vec<T>,
-    }
-
-    impl<T> CanObserve<T> for Recorder<T> {
-        fn observe(&mut self, value: T) {
-            self.seen.push(value);
-        }
-    }
+    use crate::testing::Recorder;
 
     #[test]
     fn byte_unit_absorbs_the_string_verbatim() {
         // A byte sponge sees exactly the bytes it was handed.
         let mut rec = Recorder::<u8>::default();
         <u8 as Unit>::observe_bytes(&mut rec, &[1, 2, 3]);
-        assert_eq!(rec.seen, vec![1u8, 2, 3]);
+        assert_eq!(rec.absorbed(), vec![1u8, 2, 3]);
     }
 
     #[test]
@@ -117,12 +105,12 @@ mod tests {
         FieldUnit::<BabyBear>::observe_bytes(&mut rec, &[0x01, 0x02, 0x03, 0x04]);
 
         // Leading element carries the byte count.
-        assert_eq!(rec.seen[0], BabyBear::from_u32(4));
+        assert_eq!(rec.absorbed()[0], BabyBear::from_u32(4));
         // First chunk is 0x030201 read little-endian.
-        assert_eq!(rec.seen[1], BabyBear::from_u32(0x03_02_01));
+        assert_eq!(rec.absorbed()[1], BabyBear::from_u32(0x03_02_01));
         // Trailing chunk holds the single remaining byte.
-        assert_eq!(rec.seen[2], BabyBear::from_u32(0x04));
-        assert_eq!(rec.seen.len(), 3);
+        assert_eq!(rec.absorbed()[2], BabyBear::from_u32(0x04));
+        assert_eq!(rec.absorbed().len(), 3);
     }
 
     #[test]
@@ -134,7 +122,7 @@ mod tests {
         let mut padded = Recorder::<BabyBear>::default();
         FieldUnit::<BabyBear>::observe_bytes(&mut short, &[0xaa]);
         FieldUnit::<BabyBear>::observe_bytes(&mut padded, &[0xaa, 0x00]);
-        assert_ne!(short.seen, padded.seen);
+        assert_ne!(short.absorbed(), padded.absorbed());
     }
 
     #[test]
@@ -142,6 +130,6 @@ mod tests {
         // Boundary: an empty payload still absorbs its length element.
         let mut rec = Recorder::<BabyBear>::default();
         FieldUnit::<BabyBear>::observe_bytes(&mut rec, &[]);
-        assert_eq!(rec.seen, vec![BabyBear::ZERO]);
+        assert_eq!(rec.absorbed(), vec![BabyBear::ZERO]);
     }
 }

--- a/challenger/src/lib.rs
+++ b/challenger/src/lib.rs
@@ -17,6 +17,8 @@ mod grinding_challenger;
 mod hash_challenger;
 mod multi_field_challenger;
 mod serializing_challenger;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod testing;
 
 use alloc::vec::Vec;
 use core::array;

--- a/challenger/src/testing.rs
+++ b/challenger/src/testing.rs
@@ -1,0 +1,221 @@
+//! Shared checks and captures for the typed Fiat-Shamir transcript layer.
+//!
+//! # Overview
+//!
+//! Two things a transcript test needs and the protocol crates cannot build for themselves.
+//!
+//! - A sponge stand-in that keeps every absorbed value, in order.
+//! - One comparable value standing for a whole transcript seed.
+//!
+//! # Comparing two seeds
+//!
+//! Domain separation is a statement about the bytes a sponge absorbs at seeding time.
+//!
+//! ```text
+//!     two seeds differ  ->  every later challenge is drawn from a different state
+//!     two seeds agree   ->  the two runs are one protocol as far as Fiat-Shamir knows
+//! ```
+//!
+//! Sampling a challenge to compare two seeds tests the sponge as well as the binding.
+//! Comparing digests of the seed streams tests the binding alone.
+
+use alloc::vec::Vec;
+use core::fmt::{Debug, Display, Formatter, Result as FmtResult};
+
+use p3_keccak::Keccak256Hash;
+use p3_symmetric::CryptographicHasher;
+
+use crate::CanObserve;
+use crate::fs::{DomainSeparator, Unit};
+
+/// Captures every value absorbed into it, in order.
+///
+/// Stands in for a sponge wherever a test needs the absorbed sequence itself.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct Recorder<T> {
+    /// Values absorbed so far, oldest first.
+    absorbed: Vec<T>,
+}
+
+impl<T> Recorder<T> {
+    /// An empty recorder.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            absorbed: Vec::new(),
+        }
+    }
+
+    /// The values absorbed so far, oldest first.
+    #[must_use]
+    pub fn absorbed(&self) -> &[T] {
+        &self.absorbed
+    }
+
+    /// Consume the recorder and yield the values it absorbed.
+    #[must_use]
+    pub fn into_absorbed(self) -> Vec<T> {
+        self.absorbed
+    }
+}
+
+impl<T> Default for Recorder<T> {
+    /// An empty recorder.
+    ///
+    /// Written by hand rather than derived, which would demand `T: Default`.
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> CanObserve<T> for Recorder<T> {
+    fn observe(&mut self, value: T) {
+        self.absorbed.push(value);
+    }
+}
+
+/// Canonical fingerprint of one transcript seed.
+///
+/// Holds the Keccak-256 digest of the byte stream absorbed at seeding time.
+/// Two separators share a digest exactly when they seed a sponge with the same bytes.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SeedDigest([u8; 32]);
+
+impl Debug for SeedDigest {
+    /// Render the digest as lowercase hex, so a failing assertion names both seeds.
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        self.0.iter().try_for_each(|byte| write!(f, "{byte:02x}"))
+    }
+}
+
+/// Digest the whole byte stream a separator seeds its sponge with.
+///
+/// The stream is `[protocol_id | pattern_hash | len_be_4_bytes | label | domain_tag]`.
+/// It is assembled before the alphabet packs it, so the digest does not depend on `U`.
+///
+/// This is the value that must be unique per protocol and configuration.
+/// Every knob a protocol claims to bind has to move it.
+#[must_use]
+pub fn seed_digest<U: Unit>(separator: &DomainSeparator<U>) -> SeedDigest {
+    SeedDigest(Keccak256Hash.hash_iter(separator.seed_bytes()))
+}
+
+/// Panic unless every labelled seed differs from every other one in the set.
+///
+/// Pairwise is the strong form of the separation claim.
+///
+/// ```text
+///     each differs from one baseline  ->  two knobs may still share a seed
+///     each differs from every other   ->  no two configurations share a seed
+/// ```
+///
+/// Labels only appear in the panic message, so any printable type serves.
+///
+/// # Panics
+///
+/// When two entries share a digest, naming both labels and the digest they share.
+pub fn assert_seeds_pairwise_distinct<L: Display>(seeds: &[(L, SeedDigest)]) {
+    for (index, (left_label, left)) in seeds.iter().enumerate() {
+        for (right_label, right) in &seeds[index + 1..] {
+            assert_ne!(
+                left, right,
+                "`{left_label}` and `{right_label}` land on the same transcript seed",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::string::String;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    use p3_baby_bear::BabyBear;
+
+    use super::*;
+    use crate::fs::{FieldUnit, InteractionPattern};
+
+    /// A separator over the byte alphabet, named and labelled by the caller.
+    fn byte_separator(name: &[u8], label: &[u8]) -> DomainSeparator<u8> {
+        let pattern = InteractionPattern::new(Vec::new()).unwrap();
+        let mut separator = DomainSeparator::new(1, name, pattern);
+        separator.instance(label);
+        separator
+    }
+
+    #[test]
+    fn a_recorder_keeps_every_absorbed_value_in_order() {
+        // A recorder starts empty and grows by one entry per absorb.
+        let mut recorder = Recorder::<u8>::new();
+        recorder.observe_slice(&[7, 8]);
+        recorder.observe(9);
+        assert_eq!(recorder.absorbed(), &[7, 8, 9]);
+        assert_eq!(recorder.into_absorbed(), vec![7, 8, 9]);
+    }
+
+    #[test]
+    fn the_digest_is_the_digest_of_the_recorded_byte_stream() {
+        // The byte alphabet absorbs the seed verbatim, so the two views must agree.
+        let separator = byte_separator(b"proto", b"instance");
+        let mut recorder = Recorder::<u8>::new();
+        separator.seed(&mut recorder);
+        let recorded = SeedDigest(Keccak256Hash.hash_iter(recorder.into_absorbed()));
+        assert_eq!(seed_digest(&separator), recorded);
+    }
+
+    #[test]
+    fn the_digest_ignores_the_sponge_alphabet() {
+        // The stream is assembled before packing, so re-keying the alphabet cannot move it.
+        let bytes: DomainSeparator<u8> = byte_separator(b"proto", b"instance");
+        let pattern = InteractionPattern::new(Vec::new()).unwrap();
+        let mut fields: DomainSeparator<FieldUnit<BabyBear>> =
+            DomainSeparator::new(1, b"proto", pattern);
+        fields.instance(b"instance");
+        assert_eq!(seed_digest(&bytes), seed_digest(&fields));
+    }
+
+    #[test]
+    fn a_differing_name_or_label_moves_the_digest() {
+        // Both halves of the seed reach the digest.
+        let base = seed_digest(&byte_separator(b"proto", b"instance"));
+        assert_ne!(base, seed_digest(&byte_separator(b"other", b"instance")));
+        assert_ne!(base, seed_digest(&byte_separator(b"proto", b"other")));
+    }
+
+    #[test]
+    fn a_set_of_distinct_seeds_passes_the_pairwise_check() {
+        // Three names, three seeds, no collision to report.
+        let seeds = [
+            ("a", seed_digest(&byte_separator(b"a", b"i"))),
+            ("b", seed_digest(&byte_separator(b"b", b"i"))),
+            ("c", seed_digest(&byte_separator(b"c", b"i"))),
+        ];
+        assert_seeds_pairwise_distinct(&seeds);
+    }
+
+    #[test]
+    #[should_panic(expected = "`second` and `third` land on the same transcript seed")]
+    fn the_pairwise_check_names_the_two_labels_that_collided() {
+        // Invariant: the report identifies which pair failed, not merely that one did.
+        //
+        //     first  : name "a"
+        //     second : name "b"
+        //     third  : name "b"   -> collides with `second`, not with `first`
+        let seeds = [
+            (
+                String::from("first"),
+                seed_digest(&byte_separator(b"a", b"i")),
+            ),
+            (
+                String::from("second"),
+                seed_digest(&byte_separator(b"b", b"i")),
+            ),
+            (
+                String::from("third"),
+                seed_digest(&byte_separator(b"b", b"i")),
+            ),
+        ];
+        assert_seeds_pairwise_distinct(&seeds);
+    }
+}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -42,11 +42,13 @@ rand.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
-p3-challenger = { path = "../challenger" }
+p3-batch-stark = { path = "../batch-stark" }
+p3-challenger = { path = "../challenger", features = ["test-utils"] }
 p3-commit = { path = "../commit", features = ["test-utils"] }
 p3-dft = { path = "../dft" }
 p3-koala-bear = { path = "../koala-bear" }
 p3-matrix = { path = "../matrix" }
+p3-multi-stark = { path = "../multi-stark" }
 p3-poseidon1 = { path = "../poseidon1" }
 p3-sumcheck = { path = "../sumcheck" }
 p3-util = { path = "../util" }

--- a/examples/tests/transcript_separation.rs
+++ b/examples/tests/transcript_separation.rs
@@ -1,0 +1,707 @@
+//! Cross-protocol domain separation for the typed Fiat-Shamir layer.
+//!
+//! # Overview
+//!
+//! Fifteen protocols in this workspace seed their transcript from a domain separator.
+//!
+//! The version byte is a format version each protocol owns, so names carry the separation.
+//!
+//! ```text
+//!     protocol_id = [ 1 | NAME | 0 .. 0 | NAME.len() ]
+//!                     ^     ^                 ^
+//!                     |     |                 disambiguates zero-padded prefixes
+//!                     |     the only field that differs between protocols
+//!                     the same byte for all fifteen
+//! ```
+//!
+//! Separation therefore rests entirely on `NAME`, and this file is where that is checked.
+//!
+//! # Placement
+//!
+//! Every protocol crate depends on `p3-challenger`, so the check cannot live there.
+//! `p3-examples` is a leaf: nothing depends on it, and it already pulls in most of the fifteen.
+
+use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+use p3_batch_stark::BatchShape;
+use p3_challenger::DuplexChallenger;
+use p3_challenger::fs::{DomainSeparator, FieldUnit, PROTOCOL_ID_LEN};
+use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
+use p3_circle::CirclePcsShape;
+use p3_field::extension::BinomialExtensionField;
+use p3_fri::{FriShape, PcsShape};
+use p3_multi_stark::fractional_gkr::FractionGkrShape;
+use p3_multi_stark::lookup::transcript::{LookupInstanceShape, LookupShape};
+use p3_multi_stark::rounds::AirDegrees;
+use p3_multi_stark::transcript::{MultiStarkInstanceShape, MultiStarkShape};
+use p3_multi_stark::zerocheck::transcript::ZerocheckShape;
+use p3_stir::{SecurityAssumption, StirInstanceShape, StirRoundShape, StirShape};
+use p3_sumcheck::generic_degree::GenericDegreeShape;
+use p3_sumcheck::strategy::Basis;
+use p3_sumcheck::transcript::SumcheckShape;
+use p3_sumcheck::zk::ZkSumcheckShape;
+use p3_uni_stark::StarkShape;
+use p3_whir::{
+    FoldingFactor, ProtocolParameters, WhirConfig, WhirShape, ZkParameters, ZkWhirConfig,
+    ZkWhirShape,
+};
+
+/// Base field every separator below is derived over.
+///
+/// One field for all fifteen, so nothing is separated by the field choice.
+type F = BabyBear;
+
+/// Extension field every separator below draws its challenges from.
+type EF = BinomialExtensionField<F, 4>;
+
+/// Permutation the WHIR configurations are parameterised by.
+type Perm = Poseidon2BabyBear<16>;
+
+/// Challenger the WHIR configurations are parameterised by.
+///
+/// WHIR carries the challenger in its config type, but seeding never touches a sponge.
+type Ch = DuplexChallenger<F, Perm, 16, 8>;
+
+/// Sponge alphabet every protocol in the workspace seeds through.
+type Alphabet = FieldUnit<F>;
+
+/// One labelled configuration of one protocol, reduced to the separator it derives.
+type Case = (String, DomainSeparator<Alphabet>);
+
+/// Number of protocols on the typed transcript layer.
+///
+/// A protocol added without an entry below leaves its name unchecked against the others.
+const NUM_PROTOCOLS: usize = 15;
+
+/// Configurations swept per protocol: one default, then two single-field moves of it.
+///
+/// The pairwise check is quadratic, so the sweep is a budget rather than a maximum.
+///
+/// ```text
+///     15 protocols x 3 configurations = 45 seeds -> 990 pairs
+/// ```
+const CASES_PER_PROTOCOL: usize = 3;
+
+/// Variable count both WHIR pipelines are configured at.
+const WHIR_NUM_VARIABLES: usize = 16;
+
+/// Log-inverse rate of the first committed WHIR codeword.
+const WHIR_STARTING_LOG_INV_RATE: usize = 1;
+
+/// Label one configuration of one protocol.
+fn case(protocol: &str, configuration: &str, separator: DomainSeparator<Alphabet>) -> Case {
+    (format!("{protocol}/{configuration}"), separator)
+}
+
+/// The protocol name stored inside an identifier, stripped of its zero padding.
+fn protocol_name(separator: &DomainSeparator<Alphabet>) -> &[u8] {
+    let id = separator.protocol_id();
+    // The final byte is the name length, and the name starts right after the version.
+    let len = usize::from(id[PROTOCOL_ID_LEN - 1]);
+    &id[1..1 + len]
+}
+
+/// The uni-STARK cases: a plain single-table proof, then two single-field moves.
+fn uni_stark_cases() -> Vec<Case> {
+    let plain = StarkShape {
+        log_ext_degree: 5,
+        log_degree: 5,
+        main_width: 2,
+        preprocessed_width: 0,
+        num_public_values: 1,
+        num_periodic_columns: 0,
+        num_quotient_chunks: 2,
+        opens_main_next_row: true,
+        opens_preprocessed_next_row: false,
+        has_randomization: false,
+        ood_pow_bits: 0,
+    };
+
+    let mut wider = plain.clone();
+    wider.main_width += 1;
+
+    let mut randomized = plain.clone();
+    randomized.has_randomization = true;
+
+    [("plain", plain), ("main_width", wider), ("zk", randomized)]
+        .into_iter()
+        .map(|(name, shape)| case("p3-uni-stark", name, shape.domain_separator::<F, EF>()))
+        .collect()
+}
+
+/// The batch-STARK cases: a two-instance batch, then two single-field moves.
+fn batch_stark_cases() -> Vec<Case> {
+    let plain = BatchShape {
+        trace_widths: vec![2, 3],
+        public_value_counts: vec![0, 1],
+        preprocessed_widths: vec![0, 0],
+        has_preprocessed_commitment: false,
+        num_lookup_instances: 0,
+        lookup_pow_bits: 0,
+        has_randomization_commitment: false,
+        ood_pow_bits: 0,
+    };
+
+    let mut wider = plain.clone();
+    wider.trace_widths[0] += 1;
+
+    let mut preprocessed = plain.clone();
+    preprocessed.has_preprocessed_commitment = true;
+
+    [
+        ("plain", plain),
+        ("trace_widths", wider),
+        ("preprocessed", preprocessed),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-batch-stark", name, shape.domain_separator::<F, EF>()))
+    .collect()
+}
+
+/// The FRI low-degree-test cases: three commit rounds, then two single-field moves.
+fn fri_cases() -> Vec<Case> {
+    let plain = FriShape {
+        log_arities: vec![3, 3, 2],
+        final_poly_len: 1,
+        commit_pow_bits: 0,
+        query_pow_bits: 0,
+        num_queries: 2,
+        index_bits: 8,
+        log_blowup: 1,
+        max_log_arity: 3,
+    };
+
+    let mut wider_blowup = plain.clone();
+    wider_blowup.log_blowup += 1;
+
+    let mut more_queries = plain.clone();
+    more_queries.num_queries += 1;
+
+    [
+        ("plain", plain),
+        ("log_blowup", wider_blowup),
+        ("num_queries", more_queries),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-fri", name, shape.domain_separator::<F, EF>()))
+    .collect()
+}
+
+/// The FRI PCS cases: one commitment opened twice, then two single-field moves.
+fn fri_pcs_cases() -> Vec<Case> {
+    let plain = PcsShape {
+        claimed_evaluation_counts: vec![vec![vec![3, 1]]],
+        batch_pow_bits: 0,
+    };
+
+    let mut ground = plain.clone();
+    ground.batch_pow_bits += 1;
+
+    let mut wider = plain.clone();
+    wider.claimed_evaluation_counts[0][0][0] += 1;
+
+    [
+        ("plain", plain),
+        ("batch_pow_bits", ground),
+        ("claim_widths", wider),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-fri-pcs", name, shape.domain_separator::<F, EF>()))
+    .collect()
+}
+
+/// The Circle PCS cases: one commit round, then two single-field moves.
+fn circle_pcs_cases() -> Vec<Case> {
+    let plain = CirclePcsShape {
+        opened_widths: vec![vec![vec![3, 1]]],
+        num_commit_rounds: 1,
+        commit_pow_bits: 0,
+        query_pow_bits: 0,
+        num_queries: 2,
+        index_bits: 8,
+        log_blowup: 1,
+    };
+
+    let mut longer = plain.clone();
+    longer.num_commit_rounds += 1;
+
+    let mut wider_blowup = plain.clone();
+    wider_blowup.log_blowup += 1;
+
+    [
+        ("plain", plain),
+        ("num_commit_rounds", longer),
+        ("log_blowup", wider_blowup),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-circle-pcs", name, shape.domain_separator::<F, EF>()))
+    .collect()
+}
+
+/// The STIR cases: one instance running one round, then two single-field moves.
+fn stir_cases() -> Vec<Case> {
+    let round = StirRoundShape {
+        folding_pow_bits: 0,
+        num_ood_samples: 1,
+        pow_bits: 0,
+        num_queries: 3,
+        log_fold_domain_size: 6,
+        log_degree: 8,
+        log_domain_size: 9,
+        log_folding_factor: 3,
+        domain_shift: 31,
+        eta_bits: 0.25_f64.to_bits(),
+    };
+    let instance = StirInstanceShape {
+        rounds: vec![round],
+        final_folding_pow_bits: 0,
+        final_poly_len: 2,
+        final_pow_bits: 0,
+        final_queries: 2,
+        final_log_domain_size: 5,
+        log_starting_degree: 8,
+        log_blowup: 1,
+        log_folding_factor: 3,
+        log_starting_folding_factor: 3,
+        log_final_degree: 1,
+        security_level: 100,
+        max_pow_bits: 20,
+        soundness_type: SecurityAssumption::JohnsonBound,
+        final_eta_bits: 0.125_f64.to_bits(),
+        max_log_final_poly_len: None,
+    };
+    let plain = StirShape {
+        commits_initial: true,
+        instances: vec![instance],
+    };
+
+    let mut committed_elsewhere = plain.clone();
+    committed_elsewhere.commits_initial = false;
+
+    let mut wider_blowup = plain.clone();
+    wider_blowup.instances[0].log_blowup += 1;
+
+    [
+        ("plain", plain),
+        ("commits_initial", committed_elsewhere),
+        ("log_blowup", wider_blowup),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-stir", name, shape.domain_separator::<F, EF>()))
+    .collect()
+}
+
+/// One code rate per intermediate round, growing with the folding schedule.
+fn whir_round_rates(folding_factor: &FoldingFactor, starting_rate: usize) -> Vec<usize> {
+    let schedule = folding_factor
+        .compute_folding_schedule(WHIR_NUM_VARIABLES)
+        .expect("the fixture schedule is valid");
+    let mut rate = starting_rate;
+    schedule[..schedule.len() - 1]
+        .iter()
+        .map(|folding| {
+            rate += folding - 1;
+            rate
+        })
+        .collect()
+}
+
+/// Baseline WHIR user parameters, shared by the plain and hiding pipelines.
+fn whir_params() -> ProtocolParameters {
+    let folding_factor = FoldingFactor::Constant(4);
+    ProtocolParameters {
+        security_level: 32,
+        pow_bits: 12,
+        round_log_inv_rates: whir_round_rates(&folding_factor, WHIR_STARTING_LOG_INV_RATE),
+        folding_factor,
+        soundness_type: SecurityAssumption::CapacityBound,
+        starting_log_inv_rate: WHIR_STARTING_LOG_INV_RATE,
+    }
+}
+
+/// The plain WHIR cases: the baseline parameters, then two single-field moves.
+fn whir_cases() -> Vec<Case> {
+    let mut stronger = whir_params();
+    stronger.security_level += 1;
+
+    let mut less_grinding = whir_params();
+    less_grinding.pow_bits -= 1;
+
+    [
+        ("plain", whir_params()),
+        ("security_level", stronger),
+        ("pow_bits", less_grinding),
+    ]
+    .into_iter()
+    .map(|(name, params)| {
+        let config = WhirConfig::<EF, F, Ch>::new(WHIR_NUM_VARIABLES, params)
+            .expect("the fixture parameters are valid");
+        case(
+            "p3-whir",
+            name,
+            WhirShape::new(&config, WHIR_NUM_OPENING_CLAIMS).domain_separator::<F, EF>(),
+        )
+    })
+    .collect()
+}
+
+/// The hiding WHIR cases: the same plain parameters, then two moves of the mask.
+fn zk_whir_cases() -> Vec<Case> {
+    let plain = ZkParameters {
+        ell_zk: 4,
+        mask_log_inv_rate: 1,
+    };
+
+    let mut longer_mask = plain.clone();
+    longer_mask.ell_zk += 1;
+
+    let mut sparser_mask = plain.clone();
+    sparser_mask.mask_log_inv_rate += 1;
+
+    [
+        ("plain", plain),
+        ("ell_zk", longer_mask),
+        ("mask_log_inv_rate", sparser_mask),
+    ]
+    .into_iter()
+    .map(|(name, zk)| {
+        let config = ZkWhirConfig::<EF, F, Ch>::new(WHIR_NUM_VARIABLES, whir_params(), zk)
+            .expect("the fixture parameters are valid");
+        case(
+            "p3-whir-hvzk",
+            name,
+            ZkWhirShape::new(&config).domain_separator::<F, EF>(),
+        )
+    })
+    .collect()
+}
+
+/// The multi-STARK zerocheck cases: two AIRs, then two single-field moves.
+fn zerocheck_cases() -> Vec<Case> {
+    let plain = ZerocheckShape {
+        log_height: 10,
+        lookup_point_len: 2,
+        pow_bits: 4,
+        air_degrees: vec![
+            AirDegrees {
+                constraints: 3,
+                interactions: 2,
+            },
+            AirDegrees {
+                constraints: 2,
+                interactions: 0,
+            },
+        ],
+    };
+
+    let mut taller = plain.clone();
+    taller.log_height += 1;
+
+    let mut ground = plain.clone();
+    ground.pow_bits += 1;
+
+    [
+        ("plain", plain),
+        ("log_height", taller),
+        ("pow_bits", ground),
+    ]
+    .into_iter()
+    .map(|(name, shape)| {
+        case(
+            "p3-multi-stark-zerocheck",
+            name,
+            shape.domain_separator::<F, EF>(),
+        )
+    })
+    .collect()
+}
+
+/// The multi-STARK lookup cases: two instances over two buses, then two single-field moves.
+fn lookup_cases() -> Vec<Case> {
+    let plain = LookupShape {
+        num_variables: 7,
+        max_width: 3,
+        num_buses: 2,
+        instances: vec![
+            LookupInstanceShape {
+                air_index: 0,
+                num_variables: 5,
+                base_offset: 0,
+                bus_ids: vec![0, 1],
+            },
+            LookupInstanceShape {
+                air_index: 2,
+                num_variables: 4,
+                base_offset: 64,
+                bus_ids: vec![1],
+            },
+        ],
+    };
+
+    let mut more_buses = plain.clone();
+    more_buses.num_buses += 1;
+
+    let mut wider = plain.clone();
+    wider.max_width += 1;
+
+    [
+        ("plain", plain),
+        ("num_buses", more_buses),
+        ("max_width", wider),
+    ]
+    .into_iter()
+    .map(|(name, shape)| {
+        case(
+            "p3-multi-stark-lookup",
+            name,
+            shape.domain_separator::<F, EF>(),
+        )
+    })
+    .collect()
+}
+
+/// The multi-STARK fractional-GKR cases: three layer counts.
+fn fraction_gkr_cases() -> Vec<Case> {
+    [3, 4, 5]
+        .into_iter()
+        .map(|num_variables| {
+            let shape = FractionGkrShape { num_variables };
+            (
+                format!("p3-multi-stark-fraction-gkr/num_variables={num_variables}"),
+                shape.domain_separator::<F, EF>(),
+            )
+        })
+        .collect()
+}
+
+/// The generic-degree sumcheck cases: four rounds of degree three, then two moves.
+fn sumcheck_generic_degree_cases() -> Vec<Case> {
+    [
+        ("plain", GenericDegreeShape::new(4, 3, 0)),
+        ("num_rounds", GenericDegreeShape::new(5, 3, 0)),
+        ("degree", GenericDegreeShape::new(4, 4, 0)),
+    ]
+    .into_iter()
+    .map(|(name, shape)| {
+        case(
+            "p3-sumcheck-generic-degree",
+            name,
+            shape.domain_separator::<F, EF>(),
+        )
+    })
+    .collect()
+}
+
+/// The quadratic sumcheck cases: four rounds in the evaluation basis, then two moves.
+fn sumcheck_quadratic_cases() -> Vec<Case> {
+    [
+        ("plain", SumcheckShape::new(4, 0, Basis::Evaluation)),
+        ("num_rounds", SumcheckShape::new(5, 0, Basis::Evaluation)),
+        ("basis", SumcheckShape::new(4, 0, Basis::Projective)),
+    ]
+    .into_iter()
+    .map(|(name, shape)| {
+        case(
+            "p3-sumcheck-quadratic",
+            name,
+            shape.domain_separator::<F, EF>(),
+        )
+    })
+    .collect()
+}
+
+/// Every protocol's cases, the default configuration first in each group.
+/// Number of opening claims the WHIR fixture runs with.
+///
+/// One point is drawn and one evaluation batch absorbed per claim.
+const WHIR_NUM_OPENING_CLAIMS: usize = 1;
+
+/// The multi-STARK statement cases: a two-instance batch, then two single-field moves.
+fn multi_stark_cases() -> Vec<Case> {
+    let plain = MultiStarkShape {
+        instances: vec![
+            MultiStarkInstanceShape {
+                num_variables: 8,
+                main_width: 3,
+                preprocessed_width: 0,
+                num_public_values: 2,
+            },
+            MultiStarkInstanceShape {
+                num_variables: 6,
+                main_width: 5,
+                preprocessed_width: 2,
+                num_public_values: 1,
+            },
+        ],
+        pow_bits: 0,
+    };
+
+    let mut wider = plain.clone();
+    wider.instances[0].main_width += 1;
+
+    let mut ground = plain.clone();
+    ground.pow_bits += 1;
+
+    [
+        ("plain", plain),
+        ("main_width", wider),
+        ("pow_bits", ground),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-multi-stark", name, shape.domain_separator::<F>()))
+    .collect()
+}
+
+/// The hiding sumcheck cases: a plain masked batch, then two single-field moves.
+fn zk_sumcheck_cases() -> Vec<Case> {
+    let plain = ZkSumcheckShape::new_batching(3, 4, 0);
+    let longer_mask = ZkSumcheckShape::new_batching(3, 5, 0);
+    let ground = ZkSumcheckShape::new_batching(3, 4, 1);
+
+    [
+        ("plain", plain),
+        ("ell_zk", longer_mask),
+        ("pow_bits", ground),
+    ]
+    .into_iter()
+    .map(|(name, shape)| case("p3-sumcheck-hvzk", name, shape.domain_separator::<F, EF>()))
+    .collect()
+}
+
+fn protocols() -> Vec<Vec<Case>> {
+    vec![
+        uni_stark_cases(),
+        batch_stark_cases(),
+        fri_cases(),
+        fri_pcs_cases(),
+        circle_pcs_cases(),
+        stir_cases(),
+        whir_cases(),
+        zk_whir_cases(),
+        zerocheck_cases(),
+        lookup_cases(),
+        fraction_gkr_cases(),
+        sumcheck_generic_degree_cases(),
+        sumcheck_quadratic_cases(),
+        multi_stark_cases(),
+        zk_sumcheck_cases(),
+    ]
+}
+
+/// One default configuration per protocol.
+fn default_cases() -> Vec<Case> {
+    protocols()
+        .into_iter()
+        .map(|group| {
+            group
+                .into_iter()
+                .next()
+                .expect("every protocol lists at least its default configuration")
+        })
+        .collect()
+}
+
+/// Every configuration of every protocol.
+fn all_cases() -> Vec<Case> {
+    protocols().into_iter().flatten().collect()
+}
+
+/// Digest every case's seed, keeping its label.
+fn digested(cases: Vec<Case>) -> Vec<(String, SeedDigest)> {
+    cases
+        .into_iter()
+        .map(|(label, separator)| (label, seed_digest(&separator)))
+        .collect()
+}
+
+#[test]
+fn every_protocol_is_listed_here() {
+    // This compares two hand-maintained numbers against each other, and nothing wider.
+    //
+    //     builder added, count not bumped  ->  caught here
+    //     count bumped, builder missing    ->  caught here
+    //     new protocol, neither touched    ->  not caught
+    //
+    // A protocol on the typed layer that never joins the list is never compared at all.
+    //
+    // Enumerating them across a workspace at compile time has no clean form.
+    //
+    // So the list is a convention this test keeps consistent, not one it discovers.
+    assert_eq!(default_cases().len(), NUM_PROTOCOLS);
+}
+
+#[test]
+fn the_protocol_name_is_the_only_field_that_separates_two_protocols() {
+    // The version byte is a format version, owned by one protocol and bumped by it alone.
+    //
+    //     [version | name | 0 .. 0 | name_len]
+    //                ^^^^            ^^^^^^^^
+    //                the only fields that may part two protocols
+    //
+    // So two protocols must stay apart with every version byte forced to agree.
+    // A pair that only differs in that byte would collide the day either one bumps.
+    let normalized: Vec<(String, [u8; PROTOCOL_ID_LEN])> = default_cases()
+        .into_iter()
+        .map(|(label, separator)| {
+            let mut id = *separator.protocol_id();
+            id[0] = 0;
+            (label, id)
+        })
+        .collect();
+
+    for (index, (left_label, left)) in normalized.iter().enumerate() {
+        for (right_label, right) in &normalized[index + 1..] {
+            assert_ne!(
+                left, right,
+                "`{left_label}` and `{right_label}` are parted only by their version byte",
+            );
+        }
+    }
+}
+
+#[test]
+fn a_shared_name_prefix_is_separated_by_the_name_length_byte() {
+    // Two pairs of names stand in a prefix relation:
+    //
+    //     [1 | p3-fri       | 0 .. 0 |  6]
+    //     [1 | p3-fri-pcs   | 0 .. 0 | 10]
+    //
+    //     [1 | p3-whir      | 0 .. 0 |  7]
+    //     [1 | p3-whir-hvzk | 0 .. 0 | 12]
+    //
+    // Zero padding alone cannot tell a short name from a longer one starting with it.
+    // The final byte holds the name length, and it is what keeps the two apart.
+    let pairs = [
+        (fri_cases(), fri_pcs_cases()),
+        (whir_cases(), zk_whir_cases()),
+    ];
+
+    for (short_cases, long_cases) in pairs {
+        let short = &short_cases[0].1;
+        let long = &long_cases[0].1;
+
+        // The prefix relation is real, so the name bytes alone do not separate them.
+        let short_name = protocol_name(short);
+        let long_name = protocol_name(long);
+        assert!(long_name.starts_with(short_name));
+
+        // The length byte differs, which is what makes the two identifiers differ.
+        assert_ne!(
+            short.protocol_id()[PROTOCOL_ID_LEN - 1],
+            long.protocol_id()[PROTOCOL_ID_LEN - 1],
+        );
+    }
+}
+
+#[test]
+fn no_two_configurations_of_any_two_protocols_share_a_seed() {
+    // Invariant: the seed is unique across the whole cross-product, not merely across defaults.
+    //
+    // Each protocol contributes its default plus two single-field moves of it.
+    // Pairwise over the union asks both questions at once:
+    //
+    //     within one protocol  ->  does each knob reach the seed, separately from the others
+    //     across two protocols ->  can any configuration of one reach another's seed
+    let seeds = digested(all_cases());
+    assert_eq!(seeds.len(), CASES_PER_PROTOCOL * NUM_PROTOCOLS);
+    assert_seeds_pairwise_distinct(&seeds);
+}

--- a/fri/Cargo.toml
+++ b/fri/Cargo.toml
@@ -31,6 +31,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
+p3-challenger = { path = "../challenger", features = ["test-utils"] }
 p3-circle = { path = "../circle" }
 p3-commit = { path = "../commit", features = ["test-utils"] }
 p3-dft = { path = "../dft" }

--- a/fri/src/pcs_transcript.rs
+++ b/fri/src/pcs_transcript.rs
@@ -537,6 +537,7 @@ mod tests {
     use alloc::vec;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
     use p3_challenger::{CanSample, DuplexChallenger};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
@@ -571,12 +572,11 @@ mod tests {
         shape_with(vec![vec![vec![3, 1]]])
     }
 
-    /// The first challenge a shape's seed produces.
-    fn first_challenge(shape: &PcsShape) -> F {
-        let mut challenger = fresh_challenger();
-        let separator = shape.domain_separator::<F, EF>();
-        separator.seed(&mut challenger);
-        challenger.sample()
+    /// The digest of the byte stream a shape seeds its sponge with.
+    ///
+    /// Comparing seed streams, rather than a sampled challenge, keeps the sponge out of it.
+    fn seed_of(shape: &PcsShape) -> SeedDigest {
+        seed_digest(&shape.domain_separator::<F, EF>())
     }
 
     /// Every field of the shape, each moved one step away from `plain_shape`.
@@ -623,21 +623,21 @@ mod tests {
     }
 
     #[test]
-    fn every_field_of_the_shape_reaches_the_seed() {
-        // Baseline: the plain shape, seeded and sampled once.
-        let baseline = first_challenge(&plain_shape());
-
-        // Each mutation moves exactly one field one step.
+    fn no_two_configurations_of_the_shape_share_a_seed() {
+        // Invariant: the knobs are separated from each other, not merely from a baseline.
         //
-        // A field the fingerprint covers moves the seed through the step sequence.
-        // A field it does not must move it through the instance label instead.
-        for (field, shape) in one_step_from_plain() {
-            assert_ne!(
-                baseline,
-                first_challenge(&shape),
-                "changing `{field}` left the seed where it was",
-            );
-        }
+        //     plain shape in the set  ->  every knob has to reach the seed
+        //     pairwise over the set   ->  no two knobs may land on one seed
+        //
+        // Two knobs bound as one number differ from the baseline and still agree with each other.
+        let mut seeds = vec![("plain", seed_of(&plain_shape()))];
+        seeds.extend(
+            one_step_from_plain()
+                .iter()
+                .map(|(field, shape)| (*field, seed_of(shape))),
+        );
+
+        assert_seeds_pairwise_distinct(&seeds);
     }
 
     #[test]
@@ -648,8 +648,8 @@ mod tests {
         //     one commitment, one matrix, two points         ->  [3, 3]
         //
         // Only the instance label separates them, so it must carry the grouping.
-        let two_matrices = first_challenge(&shape_with(vec![vec![vec![3], vec![3]]]));
-        let two_points = first_challenge(&shape_with(vec![vec![vec![3, 3]]]));
+        let two_matrices = seed_of(&shape_with(vec![vec![vec![3], vec![3]]]));
+        let two_points = seed_of(&shape_with(vec![vec![vec![3, 3]]]));
 
         assert_ne!(two_matrices, two_points);
     }
@@ -660,8 +660,8 @@ mod tests {
         //
         //     two commitments of one matrix   ->  [3, 3]
         //     one commitment of two matrices  ->  [3, 3]
-        let two_commitments = first_challenge(&shape_with(vec![vec![vec![3]], vec![vec![3]]]));
-        let one_commitment = first_challenge(&shape_with(vec![vec![vec![3], vec![3]]]));
+        let two_commitments = seed_of(&shape_with(vec![vec![vec![3]], vec![vec![3]]]));
+        let one_commitment = seed_of(&shape_with(vec![vec![vec![3], vec![3]]]));
 
         assert_ne!(two_commitments, one_commitment);
     }
@@ -679,7 +679,7 @@ mod tests {
         let mut ground_harder = ground.clone();
         ground_harder.batch_pow_bits = 2;
 
-        assert_ne!(first_challenge(&ground), first_challenge(&ground_harder));
+        assert_ne!(seed_of(&ground), seed_of(&ground_harder));
     }
 
     #[test]

--- a/fri/src/transcript.rs
+++ b/fri/src/transcript.rs
@@ -496,8 +496,9 @@ mod tests {
     use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::DuplexChallenger;
     use p3_challenger::fs::TypeTag;
-    use p3_challenger::{CanSample, DuplexChallenger};
+    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use rand::SeedableRng;
@@ -537,12 +538,11 @@ mod tests {
         shape_with(vec![3, 3, 2])
     }
 
-    /// The first challenge a shape's seed produces.
-    fn first_challenge(shape: &FriShape) -> F {
-        let mut challenger = fresh_challenger();
-        let separator = shape.domain_separator::<F, EF>();
-        separator.seed(&mut challenger);
-        challenger.sample()
+    /// The digest of the byte stream a shape seeds its sponge with.
+    ///
+    /// Comparing seed streams, rather than a sampled challenge, keeps the sponge out of it.
+    fn seed_of(shape: &FriShape) -> SeedDigest {
+        seed_digest(&shape.domain_separator::<F, EF>())
     }
 
     /// Every field of the shape, each moved one step away from `plain_shape`.
@@ -628,39 +628,21 @@ mod tests {
     }
 
     #[test]
-    fn every_field_of_the_shape_reaches_the_seed() {
-        // Baseline: the plain shape, seeded and sampled once.
-        let baseline = first_challenge(&plain_shape());
-
-        // Each mutation moves exactly one field one step.
+    fn no_two_configurations_of_the_shape_share_a_seed() {
+        // Invariant: the knobs are separated from each other, not merely from a baseline.
         //
-        // A field the fingerprint covers moves the seed through the step sequence.
-        // A field it does not must move it through the instance label instead.
-        for (field, shape) in one_step_from_plain() {
-            assert_ne!(
-                baseline,
-                first_challenge(&shape),
-                "changing `{field}` left the seed where it was",
-            );
-        }
-    }
-
-    #[test]
-    fn no_two_one_step_mutations_collide() {
-        // Invariant: the knobs are separated from each other, not merely from the baseline.
+        //     plain shape in the set  ->  every knob has to reach the seed
+        //     pairwise over the set   ->  no two knobs may land on one seed
         //
-        // Two knobs bound as one number would agree here while both differing from the baseline.
-        let mutations = one_step_from_plain();
+        // Two knobs bound as one number differ from the baseline and still agree with each other.
+        let mut seeds = vec![("plain", seed_of(&plain_shape()))];
+        seeds.extend(
+            one_step_from_plain()
+                .iter()
+                .map(|(field, shape)| (*field, seed_of(shape))),
+        );
 
-        for (i, (left_field, left)) in mutations.iter().enumerate() {
-            for (right_field, right) in &mutations[i + 1..] {
-                assert_ne!(
-                    first_challenge(left),
-                    first_challenge(right),
-                    "`{left_field}` and `{right_field}` land on the same seed",
-                );
-            }
-        }
+        assert_seeds_pairwise_distinct(&seeds);
     }
 
     #[test]
@@ -676,14 +658,14 @@ mod tests {
         let mut commit_two = commit_one.clone();
         commit_two.commit_pow_bits = 2;
 
-        assert_ne!(first_challenge(&commit_one), first_challenge(&commit_two));
+        assert_ne!(seed_of(&commit_one), seed_of(&commit_two));
 
         let mut query_one = plain_shape();
         query_one.query_pow_bits = 1;
         let mut query_two = query_one.clone();
         query_two.query_pow_bits = 2;
 
-        assert_ne!(first_challenge(&query_one), first_challenge(&query_two));
+        assert_ne!(seed_of(&query_one), seed_of(&query_two));
     }
 
     #[test]

--- a/uni-stark/Cargo.toml
+++ b/uni-stark/Cargo.toml
@@ -29,7 +29,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 p3-baby-bear = { path = "../baby-bear" }
-p3-challenger = { path = "../challenger" }
+p3-challenger = { path = "../challenger", features = ["test-utils"] }
 p3-circle = { path = "../circle" }
 p3-commit = { path = "../commit", features = ["test-utils"] }
 p3-dft = { path = "../dft" }

--- a/uni-stark/src/transcript.rs
+++ b/uni-stark/src/transcript.rs
@@ -705,7 +705,10 @@ pub enum StarkTranscriptFailure {
 
 #[cfg(test)]
 mod tests {
+    use alloc::vec;
+
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
     use p3_challenger::{CanSample, DuplexChallenger};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
@@ -774,12 +777,11 @@ mod tests {
         }
     }
 
-    /// The first challenge a shape's seed produces.
-    fn first_challenge(shape: &StarkShape) -> F {
-        let mut challenger = fresh_challenger();
-        let separator = shape.domain_separator::<F, EF>();
-        separator.seed(&mut challenger);
-        challenger.sample()
+    /// The digest of the byte stream a shape seeds its sponge with.
+    ///
+    /// Comparing seed streams, rather than a sampled challenge, keeps the sponge out of it.
+    fn seed_of(shape: &StarkShape) -> SeedDigest {
+        seed_digest(&shape.domain_separator::<F, EF>())
     }
 
     /// Every field of the shape, each bumped by one step away from `plain_shape`.
@@ -836,39 +838,21 @@ mod tests {
     }
 
     #[test]
-    fn every_field_of_the_shape_reaches_the_seed() {
-        // Baseline: the plain shape, seeded and sampled once.
-        let baseline = first_challenge(&plain_shape());
-
-        // Each mutation moves exactly one field one step.
+    fn no_two_configurations_of_the_shape_share_a_seed() {
+        // Invariant: the knobs are separated from each other, not merely from a baseline.
         //
-        // A field the fingerprint covers moves the seed through the step sequence.
-        // A field it does not must move it through the instance label instead.
-        for (field, shape) in one_step_from_plain() {
-            assert_ne!(
-                baseline,
-                first_challenge(&shape),
-                "changing `{field}` left the seed where it was",
-            );
-        }
-    }
-
-    #[test]
-    fn no_two_one_step_mutations_collide() {
-        // Invariant: the knobs are separated from each other, not merely from the baseline.
+        //     plain shape in the set  ->  every knob has to reach the seed
+        //     pairwise over the set   ->  no two knobs may land on one seed
         //
-        // Two knobs bound as one number would agree here while both differing from the baseline.
-        let mutations = one_step_from_plain();
+        // Two knobs bound as one number differ from the baseline and still agree with each other.
+        let mut seeds = vec![("plain", seed_of(&plain_shape()))];
+        seeds.extend(
+            one_step_from_plain()
+                .iter()
+                .map(|(field, shape)| (*field, seed_of(shape))),
+        );
 
-        for (i, (left_field, left)) in mutations.iter().enumerate() {
-            for (right_field, right) in &mutations[i + 1..] {
-                assert_ne!(
-                    first_challenge(left),
-                    first_challenge(right),
-                    "`{left_field}` and `{right_field}` land on the same seed",
-                );
-            }
-        }
+        assert_seeds_pairwise_distinct(&seeds);
     }
 
     #[test]
@@ -886,25 +870,25 @@ mod tests {
         };
 
         let shape_of = |air: &ShapeAir| StarkShape::new::<F, _>(air, 0, 6, 6, 2, false, 0);
-        let baseline = first_challenge(&shape_of(&base));
+        let baseline = seed_of(&shape_of(&base));
 
         // A wider trace.
         let wider = ShapeAir { width: 5, ..base };
-        assert_ne!(baseline, first_challenge(&shape_of(&wider)));
+        assert_ne!(baseline, seed_of(&shape_of(&wider)));
 
         // One more public value.
         let more_public = ShapeAir {
             num_public_values: 3,
             ..base
         };
-        assert_ne!(baseline, first_challenge(&shape_of(&more_public)));
+        assert_ne!(baseline, seed_of(&shape_of(&more_public)));
 
         // One periodic column instead of none.
         let periodic = ShapeAir {
             num_periodic_columns: 1,
             ..base
         };
-        assert_ne!(baseline, first_challenge(&shape_of(&periodic)));
+        assert_ne!(baseline, seed_of(&shape_of(&periodic)));
     }
 
     #[test]
@@ -946,7 +930,7 @@ mod tests {
         let mut ground = ungrounded.clone();
         ground.ood_pow_bits = 1;
 
-        assert_ne!(first_challenge(&ungrounded), first_challenge(&ground));
+        assert_ne!(seed_of(&ungrounded), seed_of(&ground));
     }
 
     #[test]


### PR DESCRIPTION
Depends on #2107 and the branches below it. This PR targets `test/fri-shape-seed-coverage`; retarget after they land.

## What this changes

Fifteen protocols now derive a `DomainSeparator` from a shape type. The fingerprint and the seed are the entire domain-separation argument of the campaign — and nothing asserted that any two of them differ.

This turns that argument into a checked property, and adds the shared harness the check needs.

## What separation actually rests on

Every protocol passes the same version byte, because the version is a *format* version each protocol owns. So the **name carries the whole burden**, and nothing was comparing names.

The sharpest latent risk is naming discipline. `p3-fri` / `p3-fri-pcs` and `p3-whir` / `p3-whir-hvzk` stand in a genuine prefix relation, and are separated only because the name length lives at `protocol_id[63]`. That safety was an implementation detail nobody tested at the protocol level; there is now a test that names the mechanism.

## The harness — `p3-challenger`, `test-utils` feature

Follows the precedent `p3-commit` already sets: a feature-gated `pub mod testing`, pulled in as a dev-dependency.

```rust
pub fn seed_digest<U: Unit>(separator: &DomainSeparator<U>) -> SeedDigest;
pub fn assert_seeds_pairwise_distinct<L: Display>(seeds: &[(L, SeedDigest)]);
pub struct Recorder<T>;   // promoted from four hand-written copies
```

`seed_digest` digests the byte stream rather than a sampled challenge. That needed one non-test change: extracting `seed_bytes()` out of `DomainSeparator::seed()`, which now delegates to it — behaviour-preserving, and the existing wire-layout test pins it. The stream is assembled before the alphabet packs it, so the digest is alphabet-independent, and a caller needs no sponge, no permutation and no RNG seed to compare two seeds. That means the test exercises the *binding* rather than the challenger.

`SeedDigest` is opaque and only comparable — no accessor, since nothing needs one — with a hex `Debug` so a failed assertion prints something readable.

The harness is `no_std`-clean and absent from the default surface.

## The cross-protocol test lives in a leaf crate

It has to. Every protocol crate depends on `p3-challenger`, so a test there that imports them is a dependency cycle. `p3-examples` is a genuine leaf and already dev-depends on `p3-commit` with `test-utils` and on most of the protocol crates.

It needed **no new public constants**: every shape type is already publicly reachable and `domain_separator()` is already a public method.

Four assertions, over 15 protocols × 3 configurations = 45 seeds and 990 pairs:

1. `every_protocol_is_listed_here` — a further protocol must join the list, or its name is never compared against the others.
2. `the_protocol_name_is_the_only_field_that_separates_two_protocols` — normalises every version byte and asserts the identifiers stay pairwise distinct. Two protocols parted *only* by that byte would collide the day either one bumps it.
3. `a_shared_name_prefix_is_separated_by_the_name_length_byte` — pins the mechanism for both prefix pairs, not just the outcome.
4. `no_two_configurations_of_any_two_protocols_share_a_seed` — the full pairwise cross-product.

**No collision exists.** All 15 identifiers and all 45 seeds are pairwise distinct, verified rather than assumed.

## Proving it bites

Pointing `p3-fri-pcs` at `p3-fri`:

```
assertion `left != right` failed: `p3-fri/plain` and `p3-fri-pcs/plain`
  are parted only by their version byte
```

Worth reporting honestly: under a shared name the *seed* test still passed, because the two patterns differ. A name collision is not yet a seed collision — it removes the only field designed to prevent one. That is exactly why the identifier assertion exists separately from the seed assertion.

## Conversions

Four crates whose mutation fixtures already live in a labelled table — `fri`, `fri/pcs`, `uni-stark`, `batch-stark` — move onto the harness, and their per-field walk plus pairwise test fold into one strictly stronger test. The rest are left alone and the PR says why: `stir` and `circle` drive their walks from mutator tables or bespoke assertions, and `whir`, `multi-stark` and `sumcheck` use a closure-per-field helper. There is no `Vec` of configurations to hand the harness in those, so converting means rewriting the fixture — churn, not de-duplication. The cross-protocol sweep covers their defaults plus two moves each regardless.

## Known limitation

Name uniqueness is checked by a test in a leaf crate, not by a compile-time or runtime registry. A protocol crate can still be published in isolation with a duplicate name; the workspace test is what catches it, and `every_protocol_is_listed_here` is what catches someone forgetting to add themselves to the workspace test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
