### PR TITLE
feat(security): check recorded grinding difficulties against the security model

### DIFF
--- a/batch-stark/src/transcript.rs
+++ b/batch-stark/src/transcript.rs
@@ -1000,13 +1000,20 @@ where
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use core::str::from_utf8;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
+    use p3_challenger::testing::{
+        SeedDigest, assert_seeds_pairwise_distinct, pow_difficulties, seed_digest,
+    };
     use p3_challenger::{CanSample, DuplexChallenger};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use p3_lookup::logup::LogUpGadget;
+    use p3_security::grinding::{
+        GRINDING_VOCABULARY, GrindingBudget, GrindingSite, GrindingSites, RecordedGrind,
+        ZeroBitConvention, grinding_step,
+    };
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
@@ -1328,5 +1335,84 @@ mod tests {
         let verifier_next: F = verifier_challenger.sample();
         let prover_next: F = prover_challenger.sample();
         assert_eq!(verifier_next, prover_next);
+    }
+    /// This protocol's name, as the vocabulary table keys it.
+    fn protocol() -> &'static str {
+        from_utf8(NAME).expect("the protocol name is ASCII")
+    }
+
+    /// Every grind `shape` describes, keyed for the security model's check.
+    fn recorded_grinds(shape: &BatchShape) -> Vec<RecordedGrind> {
+        pow_difficulties(&shape.pattern::<F, EF>())
+            .into_iter()
+            .map(|(label, bits)| RecordedGrind::new(protocol(), label, bits))
+            .collect()
+    }
+
+    #[test]
+    fn the_grinding_vocabulary_maps_both_grinds_this_protocol_describes() {
+        // The out-of-domain step is described whatever its difficulty.
+        let ood = grinding_step(protocol(), OOD_POW).expect("the out-of-domain grind is mapped");
+        assert_eq!(ood.site, GrindingSite::OutOfDomain);
+        assert_eq!(ood.zero_bits, ZeroBitConvention::Always);
+
+        // The lookup step is described only while the lookup phase runs.
+        let lookup = grinding_step(protocol(), LOOKUP_POW).expect("the lookup grind is mapped");
+        assert_eq!(lookup.site, GrindingSite::LookupChallenge);
+        assert_eq!(lookup.zero_bits, ZeroBitConvention::WhenPhaseRuns);
+
+        // Two grinds described, so two rows.
+        assert_eq!(
+            GRINDING_VOCABULARY
+                .iter()
+                .filter(|step| step.protocol == protocol())
+                .count(),
+            2,
+        );
+    }
+
+    #[test]
+    fn both_grinds_carry_the_difficulties_the_model_credits() {
+        // Invariant: the two conventions this protocol uses both hold.
+        //
+        //     ood_pow     always described, zero included
+        //     lookup_pow  described iff an instance declares a lookup
+        for ood_pow_bits in [0, 1, 8] {
+            for lookup_pow_bits in [0, 1, 12] {
+                for num_lookup_instances in [0, 2] {
+                    let shape = BatchShape {
+                        num_lookup_instances,
+                        lookup_pow_bits,
+                        ood_pow_bits,
+                        ..plain_shape()
+                    };
+
+                    GrindingBudget::from_sites(&GrindingSites {
+                        out_of_domain: ood_pow_bits,
+                        lookup_challenge: lookup_pow_bits,
+                        ..GrindingSites::NONE
+                    })
+                    .check(&[protocol()], &recorded_grinds(&shape))
+                    .unwrap_or_else(|mismatch| panic!("{mismatch}"));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn a_zero_bit_out_of_domain_grind_is_described_rather_than_elided() {
+        // Why: the witness travels in the proof whatever the difficulty.
+        //
+        // The step is therefore described at zero bits, unlike every elided site.
+        // Reading its absence as zero bits would be reading the wrong convention.
+        let shape = BatchShape {
+            ood_pow_bits: 0,
+            ..plain_shape()
+        };
+
+        assert_eq!(
+            recorded_grinds(&shape),
+            vec![RecordedGrind::new(protocol(), OOD_POW, 0)],
+        );
     }
 }

--- a/batch-stark/tests/simple.rs
+++ b/batch-stark/tests/simple.rs
@@ -14,14 +14,16 @@ use config::{
 use p3_air::{Air, AirBuilder, BaseAir, PermutationAirBuilder, WindowAccess};
 use p3_batch_stark::proof::{BatchProof, OpenedValuesWithLookups};
 use p3_batch_stark::{
-    BatchTranscriptFailure, BatchVerificationError, ProverData, StarkGenericConfig, StarkInstance,
-    VerificationError, prove_batch, verify_batch,
+    BatchShape, BatchTranscriptFailure, BatchVerificationError, ProverData, StarkGenericConfig,
+    StarkInstance, VerificationError, prove_batch, verify_batch,
 };
+use p3_challenger::testing::pow_difficulties;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64, TwoAdicField};
-use p3_fri::FriParameters;
+use p3_fri::{FriParameters, FriShape, PcsShape};
 use p3_lookup::{Count, InteractionBuilder, LookupError, LookupTerminal};
 use p3_matrix::Matrix;
 use p3_matrix::dense::RowMajorMatrix;
+use p3_security::grinding::{GrindingBudget, GrindingSites, RecordedGrind};
 use p3_uni_stark::{InvalidProofShapeError, OpeningShape, PeriodicColumnError};
 use p3_util::log2_strict_usize;
 
@@ -3290,4 +3292,134 @@ fn from_airs_and_degrees_with_lookup_budgets_rejects_overshooting_the_blowup() {
         &[usize::MAX],
         1,
     );
+}
+
+/// The three protocols a batch-STARK proof over `p3-fri` layers, outermost first.
+///
+/// Each brackets the next, and each seeds its own transcript, so the same step
+/// label in two of them is two different steps.
+const BATCH_STARK_STACK: [&str; 3] = ["p3-batch-stark", "p3-fri-pcs", "p3-fri"];
+
+/// Every grinding difficulty the three transcripts of one configuration demand.
+///
+/// Fixture state: two traces of width 2 and 3, one preprocessed commitment.
+///
+/// Nothing but the difficulties and whether the lookup phase runs reaches the result.
+fn demanded_grinding(
+    fri: &FriParameters<()>,
+    num_lookup_instances: usize,
+    lookup_pow_bits: usize,
+    ood_pow_bits: usize,
+) -> Vec<RecordedGrind> {
+    let batch = BatchShape {
+        trace_widths: vec![2, 3],
+        public_value_counts: vec![0, 3],
+        preprocessed_widths: vec![0, 1],
+        has_preprocessed_commitment: true,
+        num_lookup_instances,
+        lookup_pow_bits,
+        has_randomization_commitment: false,
+        ood_pow_bits,
+    };
+    let opening = PcsShape {
+        claimed_evaluation_counts: vec![vec![vec![3]]],
+        batch_pow_bits: fri.batch_proof_of_work_bits,
+    };
+    let ldt = FriShape::with_schedule(fri, vec![2, 2], 8);
+
+    let patterns = [
+        batch.pattern::<Val, Challenge>(),
+        opening.pattern::<Val, Challenge>(),
+        ldt.pattern::<Val, Challenge>(),
+    ];
+
+    BATCH_STARK_STACK
+        .iter()
+        .zip(&patterns)
+        .flat_map(|(protocol, pattern)| {
+            pow_difficulties(pattern)
+                .into_iter()
+                .map(|(label, bits)| RecordedGrind::new(protocol, label, bits))
+        })
+        .collect()
+}
+
+#[test]
+fn recorded_grinding_matches_what_the_security_model_credits() {
+    // Property: recorded difficulty == credited difficulty, at every site.
+    //
+    // A batch-STARK exercises all three zero-bit conventions in one stack:
+    //
+    //     ood_pow     ->  always described
+    //     lookup_pow  ->  described only while the lookup phase runs
+    //     FRI sites   ->  elided at zero
+    //
+    // Reading an absent step as zero bits would therefore be wrong twice over.
+
+    // The parameters the config feeds its PCS, with the commitment scheme
+    // dropped: only the difficulties matter here.
+    let base = FriParameters::new_testing((), 2);
+
+    for batch_pow_bits in [0, 10] {
+        for lookup_pow_bits in [0, 12] {
+            for ood_pow_bits in [0, 8] {
+                for num_lookup_instances in [0, 2] {
+                    let fri = FriParameters {
+                        batch_proof_of_work_bits: batch_pow_bits,
+                        ..base
+                    };
+
+                    // The FRI sites, plus the two the batch itself enforces.
+                    let credited = GrindingBudget::from_sites(&GrindingSites {
+                        out_of_domain: ood_pow_bits,
+                        lookup_challenge: lookup_pow_bits,
+                        ..fri.grinding_sites()
+                    })
+                    .with_fri(&fri.security_regime());
+
+                    credited
+                        .check(
+                            &BATCH_STARK_STACK,
+                            &demanded_grinding(
+                                &fri,
+                                num_lookup_instances,
+                                lookup_pow_bits,
+                                ood_pow_bits,
+                            ),
+                        )
+                        .unwrap_or_else(|mismatch| {
+                            panic!(
+                                "batch={batch_pow_bits} lookup={lookup_pow_bits} \
+                                 ood={ood_pow_bits} instances={num_lookup_instances}: {mismatch}"
+                            )
+                        });
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn the_lookup_grinding_configuration_is_accounted_for() {
+    // The config the lookup-grinding tests prove with is itself accounted for.
+    //
+    // The numbers it hands the prover are the numbers a security report is built from.
+    let config = make_config(2024).with_lookup_proof_of_work_bits(LOOKUP_POW_BITS);
+    let fri = FriParameters::new_testing((), 2);
+
+    let lookup_pow_bits = config.lookup_proof_of_work_bits();
+    let ood_pow_bits = config.ood_proof_of_work_bits();
+    assert_eq!((lookup_pow_bits, ood_pow_bits), (LOOKUP_POW_BITS, 0));
+
+    GrindingBudget::from_sites(&GrindingSites {
+        out_of_domain: ood_pow_bits,
+        lookup_challenge: lookup_pow_bits,
+        ..fri.grinding_sites()
+    })
+    .with_fri(&fri.security_regime())
+    .check(
+        &BATCH_STARK_STACK,
+        &demanded_grinding(&fri, 2, lookup_pow_bits, ood_pow_bits),
+    )
+    .unwrap_or_else(|mismatch| panic!("{mismatch}"));
 }

--- a/challenger/src/testing.rs
+++ b/challenger/src/testing.rs
@@ -6,6 +6,7 @@
 //!
 //! - A sponge stand-in that keeps every absorbed value, in order.
 //! - One comparable value standing for a whole transcript seed.
+//! - The grinding difficulties a recorded transcript description demands.
 //!
 //! # Comparing two seeds
 //!
@@ -26,7 +27,7 @@ use p3_keccak::Keccak256Hash;
 use p3_symmetric::CryptographicHasher;
 
 use crate::CanObserve;
-use crate::fs::{DomainSeparator, Unit};
+use crate::fs::{DomainSeparator, InteractionPattern, Kind, Label, Length, Unit};
 
 /// Captures every value absorbed into it, in order.
 ///
@@ -98,6 +99,35 @@ impl Debug for SeedDigest {
 #[must_use]
 pub fn seed_digest<U: Unit>(separator: &DomainSeparator<U>) -> SeedDigest {
     SeedDigest(Keccak256Hash.hash_iter(separator.seed_bytes()))
+}
+
+/// Every grinding step a pattern describes, in transcript order.
+///
+/// A proof-of-work step carries its difficulty as a fixed length.
+///
+/// A grind repeated once per round is one entry per round.
+///
+/// This is the transcript half of a grinding-accounting check.
+///
+/// The security half reads the same difficulties out of a parameter set.
+///
+/// # Panics
+///
+/// When a proof-of-work step carries any other length variant.
+#[must_use]
+pub fn pow_difficulties(pattern: &InteractionPattern) -> Vec<(Label, usize)> {
+    pattern
+        .interactions()
+        .iter()
+        .filter(|interaction| interaction.kind() == Kind::Pow)
+        .map(|interaction| match interaction.length() {
+            Length::Fixed(bits) => (interaction.label(), bits),
+            other => panic!(
+                "the `{}` proof-of-work step carries `{other}`, not a `Fixed` difficulty",
+                interaction.label(),
+            ),
+        })
+        .collect()
 }
 
 /// Panic unless every labelled seed differs from every other one in the set.

--- a/fri/src/pcs_transcript.rs
+++ b/fri/src/pcs_transcript.rs
@@ -535,16 +535,25 @@ pub enum PcsTranscriptFailure {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use core::str::from_utf8;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
+    use p3_challenger::testing::{
+        SeedDigest, assert_seeds_pairwise_distinct, pow_difficulties, seed_digest,
+    };
     use p3_challenger::{CanSample, DuplexChallenger};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_security::grinding::{
+        GRINDING_VOCABULARY, GrindingBudget, GrindingSite, RecordedGrind, ZeroBitConvention,
+        grinding_step,
+    };
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
     use super::*;
+    use crate::FriShape;
+    use crate::transcript::NAME as LDT_NAME;
 
     type F = BabyBear;
     type EF = BinomialExtensionField<F, 4>;
@@ -767,5 +776,123 @@ mod tests {
         let bracketed_next: F = bracketed_challenger.sample();
         let plain_next: F = plain_challenger.sample();
         assert_eq!(bracketed_next, plain_next);
+    }
+    /// This protocol's name, as the vocabulary table keys it.
+    fn protocol() -> &'static str {
+        from_utf8(NAME).expect("the protocol name is ASCII")
+    }
+
+    /// The low-degree test this protocol brackets, as the table keys it.
+    fn low_degree_test() -> &'static str {
+        from_utf8(LDT_NAME).expect("the protocol name is ASCII")
+    }
+
+    #[test]
+    fn the_grinding_vocabulary_maps_the_one_grind_this_protocol_describes() {
+        // The security model keys its table on the name and the label bound here.
+        let batch = grinding_step(protocol(), BATCH_POW).expect("the batching grind is mapped");
+        assert_eq!(batch.site, GrindingSite::BatchCombination);
+        assert_eq!(batch.zero_bits, ZeroBitConvention::Elided);
+
+        // One grind described, so one row.
+        assert_eq!(
+            GRINDING_VOCABULARY
+                .iter()
+                .filter(|step| step.protocol == protocol())
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn the_two_halves_of_one_parameter_set_account_for_every_grind_it_describes() {
+        // Invariant: `grinding_sites` and `security_regime` partition the grinds.
+        //
+        //     grinding_sites  ->  batch_pow, described here
+        //     security_regime ->  commit_pow and query_pow, described in the bracket
+        //
+        // Neither may omit a site, and neither may claim the other's.
+        for batch_proof_of_work_bits in [0, 1, 10] {
+            for commit_proof_of_work_bits in [0, 4] {
+                for query_proof_of_work_bits in [0, 16] {
+                    let params = FriParameters {
+                        log_blowup: 1,
+                        log_final_poly_len: 0,
+                        max_log_arity: 3,
+                        num_queries: 64,
+                        batch_proof_of_work_bits,
+                        commit_proof_of_work_bits,
+                        query_proof_of_work_bits,
+                        mmcs: (),
+                    };
+
+                    // One opening, then the bracketed low-degree test over two rounds.
+                    let opening = PcsShape {
+                        claimed_evaluation_counts: vec![vec![vec![3]]],
+                        batch_pow_bits: params.batch_proof_of_work_bits,
+                    };
+                    let ldt = FriShape::with_schedule(&params, vec![2, 2], 8);
+
+                    let recorded: Vec<_> = [
+                        (protocol(), opening.pattern::<F, EF>()),
+                        (low_degree_test(), ldt.pattern::<F, EF>()),
+                    ]
+                    .iter()
+                    .flat_map(|(name, pattern)| {
+                        pow_difficulties(pattern)
+                            .into_iter()
+                            .map(|(label, bits)| RecordedGrind::new(name, label, bits))
+                    })
+                    .collect();
+
+                    GrindingBudget::from_sites(&params.grinding_sites())
+                        .with_fri(&params.security_regime())
+                        .check(&[protocol(), low_degree_test()], &recorded)
+                        .unwrap_or_else(|mismatch| panic!("{mismatch}"));
+                }
+            }
+        }
+    }
+    #[test]
+    fn every_parameter_set_this_crate_ships_is_fully_accounted_for() {
+        // A named constructor is a parameter set someone deploys unread.
+        //
+        // Each is checked here so that raising a difficulty in one of them
+        // cannot land without the site that credits it moving too.
+        let sets: [(&str, FriParameters<()>); 5] = [
+            ("new_testing", FriParameters::new_testing((), 0)),
+            ("new_testing_zk", FriParameters::new_testing_zk(())),
+            ("new_benchmark", FriParameters::new_benchmark(())),
+            (
+                "new_benchmark_high_arity",
+                FriParameters::new_benchmark_high_arity(()),
+            ),
+            ("new_benchmark_zk", FriParameters::new_benchmark_zk(())),
+        ];
+
+        for (name, params) in sets {
+            let opening = PcsShape {
+                claimed_evaluation_counts: vec![vec![vec![3]]],
+                batch_pow_bits: params.batch_proof_of_work_bits,
+            };
+            let ldt = FriShape::with_schedule(&params, vec![2, 2], 8);
+
+            let recorded: Vec<_> = [
+                (protocol(), opening.pattern::<F, EF>()),
+                (low_degree_test(), ldt.pattern::<F, EF>()),
+            ]
+            .iter()
+            .flat_map(|(who, pattern)| {
+                pow_difficulties(pattern)
+                    .into_iter()
+                    .map(|(label, bits)| RecordedGrind::new(who, label, bits))
+            })
+            .collect();
+
+            GrindingBudget::from_sites(&params.grinding_sites())
+                .with_fri(&params.security_regime())
+                .check(&[protocol(), low_degree_test()], &recorded)
+                .unwrap_or_else(|mismatch| panic!("`{name}`: {mismatch}"));
+        }
     }
 }

--- a/fri/src/transcript.rs
+++ b/fri/src/transcript.rs
@@ -45,7 +45,10 @@ use crate::{FriParameters, fold_schedule};
 const VERSION: u8 = 1;
 
 /// Protocol name bound into the transcript seed.
-const NAME: &[u8] = b"p3-fri";
+///
+/// Visible to the crate so the opening argument that brackets this protocol can
+/// name it when checking their two halves of one `FriParameters` together.
+pub(crate) const NAME: &[u8] = b"p3-fri";
 
 /// Step label of a commit-phase commitment.
 const COMMITMENT: &str = "commit_phase_commitment";
@@ -492,15 +495,22 @@ pub enum TranscriptFailure {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use core::str::from_utf8;
     #[cfg(panic = "unwind")]
     use std::panic::{AssertUnwindSafe, catch_unwind};
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
     use p3_challenger::fs::TypeTag;
-    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
+    use p3_challenger::testing::{
+        SeedDigest, assert_seeds_pairwise_distinct, pow_difficulties, seed_digest,
+    };
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_security::grinding::{
+        GRINDING_VOCABULARY, GrindingBudget, GrindingSite, RecordedGrind, ZeroBitConvention,
+        grinding_step,
+    };
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
@@ -765,5 +775,65 @@ mod tests {
                 got: 3
             }
         );
+    }
+    /// This protocol's name, as the vocabulary table keys it.
+    fn protocol() -> &'static str {
+        from_utf8(NAME).expect("the protocol name is ASCII")
+    }
+
+    #[test]
+    fn the_grinding_vocabulary_maps_both_grinds_this_protocol_describes() {
+        // The security model keys its table on the name and the labels bound here.
+        let commit = grinding_step(protocol(), COMMIT_POW).expect("the folding grind is mapped");
+        assert_eq!(commit.site, GrindingSite::LdtCommitPhase);
+        assert_eq!(commit.zero_bits, ZeroBitConvention::Elided);
+
+        let query = grinding_step(protocol(), QUERY_POW).expect("the query grind is mapped");
+        assert_eq!(query.site, GrindingSite::LdtQueryPhase);
+        assert_eq!(query.zero_bits, ZeroBitConvention::Elided);
+
+        // Two grinds described, so two rows: a third would credit bits nothing pays.
+        assert_eq!(
+            GRINDING_VOCABULARY
+                .iter()
+                .filter(|step| step.protocol == protocol())
+                .count(),
+            2,
+        );
+    }
+
+    #[test]
+    fn every_described_grind_carries_the_difficulty_the_regime_credits() {
+        // Invariant: `security_regime` and the pattern read one number twice.
+        //
+        //     FriParameters  --security_regime-->  FriRegime      --> credited bits
+        //                    --FriShape::pattern-->  Kind::Pow    --> recorded bits
+        //
+        // Three rounds, so the commit-phase grind is described three times.
+        for commit_proof_of_work_bits in [0, 1, 12] {
+            for query_proof_of_work_bits in [0, 1, 16] {
+                let params = FriParameters {
+                    log_blowup: 1,
+                    log_final_poly_len: 0,
+                    max_log_arity: 3,
+                    num_queries: 64,
+                    batch_proof_of_work_bits: 0,
+                    commit_proof_of_work_bits,
+                    query_proof_of_work_bits,
+                    mmcs: (),
+                };
+                let shape = FriShape::with_schedule(&params, vec![3, 3, 2], 8);
+
+                let recorded: Vec<_> = pow_difficulties(&shape.pattern::<F, EF>())
+                    .into_iter()
+                    .map(|(label, bits)| RecordedGrind::new(protocol(), label, bits))
+                    .collect();
+
+                GrindingBudget::NONE
+                    .with_fri(&params.security_regime())
+                    .check(&[protocol()], &recorded)
+                    .unwrap_or_else(|mismatch| panic!("{mismatch}"));
+            }
+        }
     }
 }

--- a/security/src/grinding.rs
+++ b/security/src/grinding.rs
@@ -10,10 +10,44 @@
 //! Which round a grind boosts therefore depends on **where** the protocol
 //! grinds. [`GrindingSites`] enumerates those sites so a protocol states them
 //! as data instead of the crate hardcoding one placement per protocol.
+//!
+//! # Vocabulary
+//!
+//! The same proof-of-work phase carries three names in three places.
+//!
+//! | transcript step | this crate's field    | report term         |
+//! | --------------- | --------------------- | ------------------- |
+//! | `ood_pow`       | `out_of_domain`       | `deep-ali`          |
+//! | `batch_pow`     | `batch_combination`   | `batch-combination` |
+//! | `lookup_pow`    | `lookup_challenge`    | `logup-fingerprint` |
+//! | `commit_pow`    | FRI `commit_pow_bits` | `ldt-commit-phase`  |
+//! | `query_pow`     | FRI `query_pow_bits`  | `ldt-query-phase`   |
+//!
+//! A site is the one identity behind all three names.
+//!
+//! The same table is carried as data, keyed on the protocol name and the step label.
+//!
+//! # Two places, one number
+//!
+//! Grinding bits are read twice for two different purposes.
+//!
+//! ```text
+//!     transcript  ->  how much work the prover actually pays
+//!     this crate  ->  how many bits the parameter set is reported to buy
+//! ```
+//!
+//! A parameter set where the two disagree is a misreported security level.
+//!
+//! The check in this module compares them.
+
+use core::fmt::{Display, Formatter, Result as FmtResult};
 
 use serde::Serialize;
 
 use crate::error::ErrorBits;
+use crate::fri::FriRegime;
+use crate::logup::LOGUP_LABEL;
+use crate::report::{BATCH_LABEL, DEEP_LABEL, LDT_COMMIT_LABEL, LDT_QUERY_LABEL};
 
 /// Bits added to the soundness budget by a `pow_bits`-bit grinding round.
 /// Equal to `pow_bits` when grinding is honest; provided as a function
@@ -92,6 +126,505 @@ impl GrindingSites {
     };
 }
 
+/// One proof-of-work phase of a FRI-backed STARK, named once and for all.
+///
+/// The transcript, this crate, and the security report each have their own word for one phase.
+///
+/// A site is the identity the phase keeps across all three.
+///
+/// That is what lets the mapping between the vocabularies be written down rather than remembered.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum GrindingSite {
+    /// Grinding before the DEEP out-of-domain point is sampled.
+    OutOfDomain,
+    /// Grinding before the polynomial commitment scheme's opening-batching challenge.
+    BatchCombination,
+    /// Grinding before the LogUp argument's `(alpha, beta)` pair is sampled.
+    LookupChallenge,
+    /// Grinding before each of the low-degree test's folding challenges.
+    LdtCommitPhase,
+    /// Grinding before the low-degree test's query indices are sampled.
+    LdtQueryPhase,
+}
+
+impl GrindingSite {
+    /// Every site, in the order a grinding budget indexes them.
+    pub const ALL: [Self; 5] = [
+        Self::OutOfDomain,
+        Self::BatchCombination,
+        Self::LookupChallenge,
+        Self::LdtCommitPhase,
+        Self::LdtQueryPhase,
+    ];
+
+    /// Label of the security-report term this site's bits are added to.
+    ///
+    /// A site boosts exactly one term.
+    ///
+    /// That is what makes the boost an addition rather than a re-derivation.
+    #[must_use]
+    pub const fn report_label(self) -> &'static str {
+        match self {
+            Self::OutOfDomain => DEEP_LABEL,
+            Self::BatchCombination => BATCH_LABEL,
+            Self::LookupChallenge => LOGUP_LABEL,
+            Self::LdtCommitPhase => LDT_COMMIT_LABEL,
+            Self::LdtQueryPhase => LDT_QUERY_LABEL,
+        }
+    }
+
+    /// Position of this site in the canonical site order.
+    const fn index(self) -> usize {
+        match self {
+            Self::OutOfDomain => 0,
+            Self::BatchCombination => 1,
+            Self::LookupChallenge => 2,
+            Self::LdtCommitPhase => 3,
+            Self::LdtQueryPhase => 4,
+        }
+    }
+}
+
+impl Display for GrindingSite {
+    /// Render the site by its own name, not by any of its three aliases.
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::OutOfDomain => write!(f, "out-of-domain"),
+            Self::BatchCombination => write!(f, "batch-combination"),
+            Self::LookupChallenge => write!(f, "lookup-challenge"),
+            Self::LdtCommitPhase => write!(f, "ldt-commit-phase"),
+            Self::LdtQueryPhase => write!(f, "ldt-query-phase"),
+        }
+    }
+}
+
+/// Whether a protocol describes a grinding step whose difficulty is zero.
+///
+/// A zero-bit grind is free to produce and vacuous to check.
+///
+/// Whether it is described at all is therefore a per-protocol choice.
+///
+/// The choice is not uniform across this workspace, so an absent step cannot be read as zero bits everywhere.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum ZeroBitConvention {
+    /// The step is described only when the difficulty is positive.
+    ///
+    /// ```text
+    ///     bits == 0  ->  no step at all
+    ///     bits >  0  ->  one step carrying `bits`
+    /// ```
+    Elided,
+    /// The step is described whatever the difficulty, zero included.
+    ///
+    /// Used where the witness travels in the proof unconditionally.
+    ///
+    /// The proof layout then does not depend on the difficulty.
+    Always,
+    /// The step is described, carrying its exact difficulty, only while its challenge's phase runs at all.
+    ///
+    /// An absent step then means the phase did not run, so nothing was ground.
+    ///
+    /// Nothing is credited either: the term the site would boost is itself absent from the report.
+    ///
+    /// The lookup argument is the case in point: with no interactions it contributes no term.
+    WhenPhaseRuns,
+}
+
+/// One row of the grinding vocabulary.
+///
+/// A row is a protocol's step label, the site that label names, and how the protocol records it at zero bits.
+///
+/// Rows are keyed on `(protocol, label)` rather than on the label alone.
+///
+/// ```text
+///     "query_pow"  ->  p3-fri, p3-circle, p3-whir, p3-stir all use it
+///     "ood_pow"    ->  p3-uni-stark and p3-batch-stark, under two conventions
+/// ```
+///
+/// Labels are namespaced by the protocol name in the transcript seed, so this is not a soundness problem.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GrindingStep {
+    /// Protocol name bound into the transcript seed, such as `"p3-fri"`.
+    pub protocol: &'static str,
+    /// Label the protocol's proof-of-work step carries.
+    pub label: &'static str,
+    /// Phase this step grinds for.
+    pub site: GrindingSite,
+    /// How this protocol records the step at zero difficulty.
+    pub zero_bits: ZeroBitConvention,
+}
+
+/// Every proof-of-work step of every protocol whose security this crate models.
+///
+/// This is the mapping table between the three vocabularies, as data.
+///
+/// | protocol         | label        | site              | zero bits           |
+/// | ---------------- | ------------ | ----------------- | ------------------- |
+/// | `p3-uni-stark`   | `ood_pow`    | out-of-domain     | elided              |
+/// | `p3-batch-stark` | `ood_pow`    | out-of-domain     | always              |
+/// | `p3-batch-stark` | `lookup_pow` | lookup-challenge  | when the phase runs |
+/// | `p3-fri-pcs`     | `batch_pow`  | batch-combination | elided              |
+/// | `p3-fri`         | `commit_pow` | ldt-commit-phase  | elided              |
+/// | `p3-fri`         | `query_pow`  | ldt-query-phase   | elided              |
+///
+/// Protocols absent from this table grind without a security model that reads the same numbers back.
+///
+/// | protocol                     | steps it grinds                                              |
+/// | ---------------------------- | ------------------------------------------------------------ |
+/// | `p3-circle-pcs`              | `commit_pow`, `query_pow`                                    |
+/// | `p3-whir`                    | `sumcheck_pow`, `query_pow`, `final_query_pow`               |
+/// | `p3-whir-hvzk`               | `zk_sumcheck_pow`, `base_pow`                                |
+/// | `p3-stir`                    | `folding_pow`, `query_pow`, `final_folding_pow`, `final_pow` |
+/// | `p3-sumcheck-quadratic`      | `round_pow`                                                  |
+/// | `p3-sumcheck-generic-degree` | `round_pow`                                                  |
+///
+/// None of them declares its sites in bits, so no check can read the credited difficulty back out.
+pub const GRINDING_VOCABULARY: [GrindingStep; 6] = [
+    GrindingStep {
+        protocol: "p3-uni-stark",
+        label: "ood_pow",
+        site: GrindingSite::OutOfDomain,
+        zero_bits: ZeroBitConvention::Elided,
+    },
+    GrindingStep {
+        protocol: "p3-batch-stark",
+        label: "ood_pow",
+        site: GrindingSite::OutOfDomain,
+        zero_bits: ZeroBitConvention::Always,
+    },
+    GrindingStep {
+        protocol: "p3-batch-stark",
+        label: "lookup_pow",
+        site: GrindingSite::LookupChallenge,
+        zero_bits: ZeroBitConvention::WhenPhaseRuns,
+    },
+    GrindingStep {
+        protocol: "p3-fri-pcs",
+        label: "batch_pow",
+        site: GrindingSite::BatchCombination,
+        zero_bits: ZeroBitConvention::Elided,
+    },
+    GrindingStep {
+        protocol: "p3-fri",
+        label: "commit_pow",
+        site: GrindingSite::LdtCommitPhase,
+        zero_bits: ZeroBitConvention::Elided,
+    },
+    GrindingStep {
+        protocol: "p3-fri",
+        label: "query_pow",
+        site: GrindingSite::LdtQueryPhase,
+        zero_bits: ZeroBitConvention::Elided,
+    },
+];
+
+/// The vocabulary row for one protocol's step label, or `None` when the pair
+/// names no site this crate models.
+#[must_use]
+pub fn grinding_step(protocol: &str, label: &str) -> Option<&'static GrindingStep> {
+    GRINDING_VOCABULARY
+        .iter()
+        .find(|step| step.protocol == protocol && step.label == label)
+}
+
+/// One proof-of-work step read back out of an interaction pattern.
+///
+/// `protocol` is the name that protocol binds into its transcript seed.
+///
+/// That is what makes `label` unambiguous, since four crates label a step `"query_pow"`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct RecordedGrind {
+    /// Protocol name bound into the transcript seed the step was read from.
+    pub protocol: &'static str,
+    /// Label the step carries.
+    pub label: &'static str,
+    /// Difficulty in bits the step demands.
+    pub bits: usize,
+}
+
+impl RecordedGrind {
+    /// One recorded step.
+    #[must_use]
+    pub const fn new(protocol: &'static str, label: &'static str, bits: usize) -> Self {
+        Self {
+            protocol,
+            label,
+            bits,
+        }
+    }
+}
+
+/// The difficulty the security model credits at every site of one parameter set.
+///
+/// A FRI-backed protocol splits its grinding across two carriers, and this joins them.
+///
+/// ```text
+///     the STARK's own sites  ->  out-of-domain, batch-combination, lookup-challenge
+///     the FRI regime         ->  ldt-commit-phase, ldt-query-phase
+/// ```
+///
+/// The composite boosts the first three.
+///
+/// The low-degree test folds the last two into its own terms.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct GrindingBudget {
+    /// Bits per site, in the canonical site order.
+    bits: [usize; GrindingSite::ALL.len()],
+}
+
+impl GrindingBudget {
+    /// No grinding credited at any site.
+    pub const NONE: Self = Self {
+        bits: [0; GrindingSite::ALL.len()],
+    };
+
+    /// The three sites a STARK declares, with the low-degree test's own two at zero.
+    ///
+    /// Fill those two in afterwards from the low-degree test's regime.
+    #[must_use]
+    pub const fn from_sites(sites: &GrindingSites) -> Self {
+        let mut bits = [0; GrindingSite::ALL.len()];
+        bits[GrindingSite::OutOfDomain.index()] = sites.out_of_domain;
+        bits[GrindingSite::BatchCombination.index()] = sites.batch_combination;
+        bits[GrindingSite::LookupChallenge.index()] = sites.lookup_challenge;
+        Self { bits }
+    }
+
+    /// Fill in the two sites a FRI low-degree test owns.
+    ///
+    /// The commit-phase grind repeats once per folding round, at one difficulty.
+    ///
+    /// The commit-phase error term credits that difficulty once, which is the conservative reading.
+    #[must_use]
+    pub const fn with_fri(mut self, ldt: &FriRegime) -> Self {
+        self.bits[GrindingSite::LdtCommitPhase.index()] = ldt.commit_pow_bits;
+        self.bits[GrindingSite::LdtQueryPhase.index()] = ldt.query_pow_bits;
+        self
+    }
+
+    /// Bits credited at one site.
+    #[must_use]
+    pub const fn bits(&self, site: GrindingSite) -> usize {
+        self.bits[site.index()]
+    }
+
+    /// Check the difficulties a transcript records against the ones this budget credits.
+    ///
+    /// `protocols` names the transcripts `recorded` was read from.
+    ///
+    /// Without it, a step the model credits and no transcript describes would be
+    /// indistinguishable from a protocol that is simply not in the stack.
+    ///
+    /// A grind repeated once per round appears once per round in `recorded`.
+    ///
+    /// Every occurrence has to carry the credited difficulty.
+    ///
+    /// # Errors
+    ///
+    /// Returns the first disagreement found, naming the site and both numbers.
+    pub fn check(
+        &self,
+        protocols: &[&str],
+        recorded: &[RecordedGrind],
+    ) -> Result<(), GrindingMismatch> {
+        // Every recorded step must belong to a listed protocol and name a known site.
+        //
+        // Either failure means the caller and this table disagree about what
+        // the stack is, which would silently exempt a site from the comparison.
+        for grind in recorded {
+            if !protocols.contains(&grind.protocol) {
+                return Err(GrindingMismatch::UnlistedProtocol {
+                    protocol: grind.protocol,
+                    label: grind.label,
+                    recorded: grind.bits,
+                });
+            }
+            if grinding_step(grind.protocol, grind.label).is_none() {
+                return Err(GrindingMismatch::UnknownStep {
+                    protocol: grind.protocol,
+                    label: grind.label,
+                    recorded: grind.bits,
+                });
+            }
+        }
+
+        // Every step a listed protocol can describe must agree with the model.
+        for step in GRINDING_VOCABULARY
+            .iter()
+            .filter(|step| protocols.contains(&step.protocol))
+        {
+            let credited = self.bits(step.site);
+
+            // Presence is per site.
+            // The difficulty is checked on each occurrence.
+            let mut described = false;
+            for grind in recorded
+                .iter()
+                .filter(|grind| grind.protocol == step.protocol && grind.label == step.label)
+            {
+                described = true;
+                if grind.bits != credited {
+                    return Err(GrindingMismatch::Difficulty {
+                        protocol: step.protocol,
+                        label: step.label,
+                        site: step.site,
+                        credited,
+                        recorded: grind.bits,
+                    });
+                }
+            }
+
+            // What presence has to look like is the protocol's zero-bit convention.
+            match (step.zero_bits, described) {
+                // Conventions that describe the step whatever the difficulty.
+                (ZeroBitConvention::Always | ZeroBitConvention::WhenPhaseRuns, true) => {}
+                // An elided convention describes the step exactly when bits are credited.
+                (ZeroBitConvention::Elided, true) if credited > 0 => {}
+                (ZeroBitConvention::Elided, true) => {
+                    return Err(GrindingMismatch::Unexpected {
+                        protocol: step.protocol,
+                        label: step.label,
+                        site: step.site,
+                    });
+                }
+                // A phase that did not run pays nothing and is credited nothing.
+                (ZeroBitConvention::WhenPhaseRuns, false) => {}
+                // Nothing credited, nothing described.
+                (ZeroBitConvention::Elided, false) if credited == 0 => {}
+                // Bits credited that the transcript never demands.
+                (ZeroBitConvention::Elided | ZeroBitConvention::Always, false) => {
+                    return Err(GrindingMismatch::Missing {
+                        protocol: step.protocol,
+                        label: step.label,
+                        site: step.site,
+                        credited,
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A way the recorded difficulties and the credited ones can disagree.
+///
+/// Every variant names the site, and both numbers wherever there are two.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum GrindingMismatch {
+    /// A step is described at a difficulty the model does not credit.
+    Difficulty {
+        /// Protocol whose transcript describes the step.
+        protocol: &'static str,
+        /// Label the step carries.
+        label: &'static str,
+        /// Site both halves are talking about.
+        site: GrindingSite,
+        /// Bits the security model credits.
+        credited: usize,
+        /// Bits the transcript demands.
+        recorded: usize,
+    },
+    /// The model credits bits at a site the transcript never grinds for.
+    ///
+    /// This is the overstating direction.
+    ///
+    /// The reported level then includes work no prover pays and no verifier checks.
+    Missing {
+        /// Protocol whose transcript omits the step.
+        protocol: &'static str,
+        /// Label the omitted step would carry.
+        label: &'static str,
+        /// Site the model credits.
+        site: GrindingSite,
+        /// Bits the security model credits.
+        credited: usize,
+    },
+    /// A zero-bit step is described where the protocol's convention elides it.
+    Unexpected {
+        /// Protocol whose transcript describes the step.
+        protocol: &'static str,
+        /// Label the step carries.
+        label: &'static str,
+        /// Site the step names.
+        site: GrindingSite,
+    },
+    /// A described step whose `(protocol, label)` pair names no modeled site.
+    UnknownStep {
+        /// Protocol whose transcript describes the step.
+        protocol: &'static str,
+        /// Label the step carries.
+        label: &'static str,
+        /// Bits the transcript demands.
+        recorded: usize,
+    },
+    /// A described step from a protocol the caller did not list.
+    UnlistedProtocol {
+        /// Protocol whose transcript describes the step.
+        protocol: &'static str,
+        /// Label the step carries.
+        label: &'static str,
+        /// Bits the transcript demands.
+        recorded: usize,
+    },
+}
+
+impl Display for GrindingMismatch {
+    /// Name the site, the step it was read from, and both numbers.
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::Difficulty {
+                protocol,
+                label,
+                site,
+                credited,
+                recorded,
+            } => write!(
+                f,
+                "{site} grinding disagrees: the security model credits {credited} bits, \
+                 `{protocol}`'s `{label}` step demands {recorded}",
+            ),
+            Self::Missing {
+                protocol,
+                label,
+                site,
+                credited,
+            } => write!(
+                f,
+                "{site} grinding disagrees: the security model credits {credited} bits, \
+                 `{protocol}` describes no `{label}` step, so 0 are demanded",
+            ),
+            Self::Unexpected {
+                protocol,
+                label,
+                site,
+            } => write!(
+                f,
+                "{site} grinding disagrees: the security model credits 0 bits, \
+                 and `{protocol}` describes a zero-bit `{label}` step it should elide",
+            ),
+            Self::UnknownStep {
+                protocol,
+                label,
+                recorded,
+            } => write!(
+                f,
+                "`{protocol}`'s `{label}` step demands {recorded} bits at a site \
+                 `GRINDING_VOCABULARY` does not map",
+            ),
+            Self::UnlistedProtocol {
+                protocol,
+                label,
+                recorded,
+            } => write!(
+                f,
+                "`{protocol}`'s `{label}` step demands {recorded} bits, \
+                 and `{protocol}` is not among the protocols checked",
+            ),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -106,5 +639,283 @@ mod tests {
     #[test]
     fn default_sites_are_neutral() {
         assert_eq!(GrindingSites::default(), GrindingSites::NONE);
+    }
+
+    /// The FRI regime this crate's own tests grind against.
+    const fn regime(commit_pow_bits: usize, query_pow_bits: usize) -> FriRegime {
+        FriRegime {
+            log_blowup: 1,
+            num_queries: 64,
+            log_final_poly_len: 0,
+            max_log_arity: 3,
+            commit_pow_bits,
+            query_pow_bits,
+        }
+    }
+
+    /// The full FRI-backed uni-STARK stack, in transcript nesting order.
+    const UNI_STARK_STACK: [&str; 3] = ["p3-uni-stark", "p3-fri-pcs", "p3-fri"];
+
+    #[test]
+    fn every_site_appears_in_the_vocabulary_exactly_as_often_as_a_protocol_names_it() {
+        // Invariant: the table maps every site, so no site escapes the comparison.
+        for site in GrindingSite::ALL {
+            assert!(
+                GRINDING_VOCABULARY.iter().any(|step| step.site == site),
+                "{site} is modeled but no protocol's step maps to it"
+            );
+        }
+
+        // No two rows share a key, or the lookup would silently pick one.
+        for (index, left) in GRINDING_VOCABULARY.iter().enumerate() {
+            for right in &GRINDING_VOCABULARY[index + 1..] {
+                assert!(
+                    (left.protocol, left.label) != (right.protocol, right.label),
+                    "`{}`'s `{}` has two vocabulary rows",
+                    left.protocol,
+                    left.label
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_same_label_in_two_protocols_names_one_site_under_two_conventions() {
+        // Fixture state: `ood_pow` is the label both STARK front-ends use.
+        let uni = grinding_step("p3-uni-stark", "ood_pow").expect("uni-STARK grinds before zeta");
+        let batch =
+            grinding_step("p3-batch-stark", "ood_pow").expect("batch-STARK grinds before zeta");
+
+        // The site is a property of the phase, so the two agree on it.
+        assert_eq!(uni.site, batch.site);
+        assert_eq!(uni.site, GrindingSite::OutOfDomain);
+
+        // The convention is a property of the proof layout, so they differ.
+        assert_eq!(uni.zero_bits, ZeroBitConvention::Elided);
+        assert_eq!(batch.zero_bits, ZeroBitConvention::Always);
+    }
+
+    #[test]
+    fn each_site_boosts_the_report_term_its_own_module_labels() {
+        // The report label is the third name of the same phase.
+        assert_eq!(GrindingSite::OutOfDomain.report_label(), DEEP_LABEL);
+        assert_eq!(GrindingSite::BatchCombination.report_label(), BATCH_LABEL);
+        assert_eq!(GrindingSite::LookupChallenge.report_label(), LOGUP_LABEL);
+        assert_eq!(
+            GrindingSite::LdtCommitPhase.report_label(),
+            LDT_COMMIT_LABEL
+        );
+        assert_eq!(GrindingSite::LdtQueryPhase.report_label(), LDT_QUERY_LABEL);
+    }
+
+    #[test]
+    fn the_budget_reads_back_both_halves_of_the_model() {
+        // Fixture state: a distinct value per site, so a swap is visible.
+        let sites = GrindingSites {
+            out_of_domain: 3,
+            batch_combination: 5,
+            lookup_challenge: 7,
+        };
+        let budget = GrindingBudget::from_sites(&sites).with_fri(&regime(11, 13));
+
+        assert_eq!(budget.bits(GrindingSite::OutOfDomain), 3);
+        assert_eq!(budget.bits(GrindingSite::BatchCombination), 5);
+        assert_eq!(budget.bits(GrindingSite::LookupChallenge), 7);
+        assert_eq!(budget.bits(GrindingSite::LdtCommitPhase), 11);
+        assert_eq!(budget.bits(GrindingSite::LdtQueryPhase), 13);
+
+        // `from_sites` alone leaves the low-degree test's own sites at zero.
+        let without_ldt = GrindingBudget::from_sites(&sites);
+        assert_eq!(without_ldt.bits(GrindingSite::LdtCommitPhase), 0);
+        assert_eq!(without_ldt.bits(GrindingSite::LdtQueryPhase), 0);
+    }
+
+    #[test]
+    fn a_stack_that_grinds_exactly_what_the_model_credits_agrees() {
+        let sites = GrindingSites {
+            out_of_domain: 8,
+            batch_combination: 10,
+            ..GrindingSites::NONE
+        };
+        let budget = GrindingBudget::from_sites(&sites).with_fri(&regime(4, 16));
+
+        // The commit-phase grind repeats once per folding round at one difficulty.
+        let recorded = [
+            RecordedGrind::new("p3-uni-stark", "ood_pow", 8),
+            RecordedGrind::new("p3-fri-pcs", "batch_pow", 10),
+            RecordedGrind::new("p3-fri", "commit_pow", 4),
+            RecordedGrind::new("p3-fri", "commit_pow", 4),
+            RecordedGrind::new("p3-fri", "query_pow", 16),
+        ];
+
+        budget
+            .check(&UNI_STARK_STACK, &recorded)
+            .expect("the two halves agree");
+    }
+
+    #[test]
+    fn a_credited_site_the_transcript_never_grinds_for_is_the_overstating_direction() {
+        // Fixture state: the model credits ten batch bits, the transcript demands none.
+        let budget = GrindingBudget::from_sites(&GrindingSites {
+            batch_combination: 10,
+            ..GrindingSites::NONE
+        })
+        .with_fri(&regime(0, 0));
+
+        let mismatch = budget
+            .check(&UNI_STARK_STACK, &[])
+            .expect_err("credited bits nobody pays must be reported");
+
+        assert_eq!(
+            mismatch,
+            GrindingMismatch::Missing {
+                protocol: "p3-fri-pcs",
+                label: "batch_pow",
+                site: GrindingSite::BatchCombination,
+                credited: 10,
+            }
+        );
+    }
+
+    #[test]
+    fn a_difficulty_disagreement_names_the_site_and_both_numbers() {
+        let budget = GrindingBudget::from_sites(&GrindingSites::NONE).with_fri(&regime(0, 16));
+        let recorded = [RecordedGrind::new("p3-fri", "query_pow", 20)];
+
+        let mismatch = budget
+            .check(&["p3-fri"], &recorded)
+            .expect_err("20 recorded against 16 credited must be reported");
+
+        assert_eq!(
+            mismatch,
+            GrindingMismatch::Difficulty {
+                protocol: "p3-fri",
+                label: "query_pow",
+                site: GrindingSite::LdtQueryPhase,
+                credited: 16,
+                recorded: 20,
+            }
+        );
+        // The message is the deliverable, so it carries the site and both numbers.
+        let rendered = alloc::format!("{mismatch}");
+        assert!(rendered.contains("ldt-query-phase"), "{rendered}");
+        assert!(rendered.contains("16"), "{rendered}");
+        assert!(rendered.contains("20"), "{rendered}");
+    }
+
+    #[test]
+    fn the_always_convention_requires_a_zero_bit_step_the_elided_one_forbids() {
+        let budget = GrindingBudget::from_sites(&GrindingSites::NONE);
+
+        // batch-STARK always describes the step, so omitting it is a disagreement.
+        assert_eq!(
+            budget
+                .check(&["p3-batch-stark"], &[])
+                .expect_err("an always-described step cannot be absent"),
+            GrindingMismatch::Missing {
+                protocol: "p3-batch-stark",
+                label: "ood_pow",
+                site: GrindingSite::OutOfDomain,
+                credited: 0,
+            }
+        );
+
+        // Described at zero bits, it agrees.
+        budget
+            .check(
+                &["p3-batch-stark"],
+                &[RecordedGrind::new("p3-batch-stark", "ood_pow", 0)],
+            )
+            .expect("a zero-bit step is what the convention calls for");
+
+        // uni-STARK elides at zero, so describing the step is a disagreement.
+        assert_eq!(
+            budget
+                .check(
+                    &["p3-uni-stark"],
+                    &[RecordedGrind::new("p3-uni-stark", "ood_pow", 0)],
+                )
+                .expect_err("an elided step cannot be described at zero bits"),
+            GrindingMismatch::Unexpected {
+                protocol: "p3-uni-stark",
+                label: "ood_pow",
+                site: GrindingSite::OutOfDomain,
+            }
+        );
+    }
+
+    #[test]
+    fn a_lookup_phase_that_does_not_run_is_neither_paid_for_nor_credited() {
+        // Fixture state: a batch with no lookups describes no `lookup_pow` step.
+        //
+        //     no lookups  ->  no `lookup_pow` step
+        //                 ->  `logup::security_term` returns `None`
+        //                 ->  no term for `lookup_challenge` to boost
+        let budget = GrindingBudget::from_sites(&GrindingSites {
+            lookup_challenge: 20,
+            ..GrindingSites::NONE
+        });
+
+        budget
+            .check(
+                &["p3-batch-stark"],
+                &[RecordedGrind::new("p3-batch-stark", "ood_pow", 0)],
+            )
+            .expect("a phase that does not run credits nothing");
+
+        // Once the phase runs, the difficulty has to be the credited one.
+        assert_eq!(
+            budget
+                .check(
+                    &["p3-batch-stark"],
+                    &[
+                        RecordedGrind::new("p3-batch-stark", "ood_pow", 0),
+                        RecordedGrind::new("p3-batch-stark", "lookup_pow", 8),
+                    ],
+                )
+                .expect_err("8 recorded against 20 credited must be reported"),
+            GrindingMismatch::Difficulty {
+                protocol: "p3-batch-stark",
+                label: "lookup_pow",
+                site: GrindingSite::LookupChallenge,
+                credited: 20,
+                recorded: 8,
+            }
+        );
+    }
+
+    #[test]
+    fn a_step_outside_the_checked_stack_is_reported_rather_than_ignored() {
+        let budget = GrindingBudget::NONE;
+
+        // WHIR's own query grind names a site this table does not map.
+        assert_eq!(
+            budget
+                .check(
+                    &["p3-whir"],
+                    &[RecordedGrind::new("p3-whir", "query_pow", 16)]
+                )
+                .expect_err("an unmapped site must not pass silently"),
+            GrindingMismatch::UnknownStep {
+                protocol: "p3-whir",
+                label: "query_pow",
+                recorded: 16,
+            }
+        );
+
+        // A mapped step from a protocol the caller forgot to list is reported too.
+        assert_eq!(
+            budget
+                .check(
+                    &["p3-fri"],
+                    &[RecordedGrind::new("p3-fri-pcs", "batch_pow", 4)]
+                )
+                .expect_err("an unlisted protocol must not pass silently"),
+            GrindingMismatch::UnlistedProtocol {
+                protocol: "p3-fri-pcs",
+                label: "batch_pow",
+                recorded: 4,
+            }
+        );
     }
 }

--- a/uni-stark/src/transcript.rs
+++ b/uni-stark/src/transcript.rs
@@ -706,12 +706,19 @@ pub enum StarkTranscriptFailure {
 #[cfg(test)]
 mod tests {
     use alloc::vec;
+    use core::str::from_utf8;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
+    use p3_challenger::testing::{
+        SeedDigest, assert_seeds_pairwise_distinct, pow_difficulties, seed_digest,
+    };
     use p3_challenger::{CanSample, DuplexChallenger};
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
+    use p3_security::grinding::{
+        GRINDING_VOCABULARY, GrindingBudget, GrindingSite, GrindingSites, RecordedGrind,
+        ZeroBitConvention, grinding_step,
+    };
     use rand::SeedableRng;
     use rand::rngs::SmallRng;
 
@@ -1114,5 +1121,63 @@ mod tests {
         eight.finish();
 
         assert_ne!(seven_alpha, eight_alpha);
+    }
+    /// This protocol's name, as the vocabulary table keys it.
+    fn protocol() -> &'static str {
+        from_utf8(NAME).expect("the protocol name is ASCII")
+    }
+
+    #[test]
+    fn the_grinding_vocabulary_maps_the_one_grind_this_protocol_describes() {
+        // The security model keys its table on the name and the label bound here.
+        let ood = grinding_step(protocol(), OOD_POW).expect("the out-of-domain grind is mapped");
+        assert_eq!(ood.site, GrindingSite::OutOfDomain);
+        assert_eq!(ood.zero_bits, ZeroBitConvention::Elided);
+
+        // A uni-STARK has no lookups, so it describes no lookup grind and owns no second row.
+        assert_eq!(
+            GRINDING_VOCABULARY
+                .iter()
+                .filter(|step| step.protocol == protocol())
+                .count(),
+            1,
+        );
+    }
+
+    #[test]
+    fn the_out_of_domain_grind_carries_the_difficulty_the_model_credits() {
+        // Invariant: one number reaches the pattern and the report by two routes.
+        //
+        //     ood_pow_bits  --pattern-->        Kind::Pow Length::Fixed
+        //                   --GrindingSites-->  out_of_domain
+        //
+        // Elided at zero, so the sweep covers the step being absent and present.
+        for ood_pow_bits in [0, 1, 8] {
+            let shape = StarkShape {
+                log_ext_degree: 5,
+                log_degree: 5,
+                main_width: 2,
+                preprocessed_width: 0,
+                num_public_values: 1,
+                num_periodic_columns: 0,
+                num_quotient_chunks: 2,
+                opens_main_next_row: true,
+                opens_preprocessed_next_row: false,
+                has_randomization: false,
+                ood_pow_bits,
+            };
+
+            let recorded: Vec<_> = pow_difficulties(&shape.pattern::<F, EF>())
+                .into_iter()
+                .map(|(label, bits)| RecordedGrind::new(protocol(), label, bits))
+                .collect();
+
+            GrindingBudget::from_sites(&GrindingSites {
+                out_of_domain: ood_pow_bits,
+                ..GrindingSites::NONE
+            })
+            .check(&[protocol()], &recorded)
+            .unwrap_or_else(|mismatch| panic!("{mismatch}"));
+        }
     }
 }

--- a/uni-stark/tests/grinding.rs
+++ b/uni-stark/tests/grinding.rs
@@ -9,22 +9,29 @@
 //! the one worth stating explicitly — a grind the prover pays but the analysis
 //! never credits is wasted work, and bits the analysis credits but no verifier
 //! checks are worse than wasted.
+//!
+//! The last test in this file makes that third statement mechanical.
+//!
+//! It walks the three transcripts a uni-STARK proof is built from.
+//!
+//! Then it compares every recorded difficulty against the credited bits, site by site.
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
 use p3_challenger::DuplexChallenger;
+use p3_challenger::testing::pow_difficulties;
 use p3_commit::ExtensionMmcs;
 use p3_dft::Radix2DitParallel;
 use p3_field::extension::BinomialExtensionField;
 use p3_field::{Field, PrimeCharacteristicRing, PrimeField64};
-use p3_fri::{FriParameters, TwoAdicFriPcs};
+use p3_fri::{FriParameters, FriShape, PcsShape, TwoAdicFriPcs};
 use p3_matrix::dense::RowMajorMatrix;
 use p3_merkle_tree::MerkleTreeMmcs;
-use p3_security::grinding::GrindingSites;
+use p3_security::grinding::{GrindingBudget, GrindingSites, RecordedGrind};
 use p3_symmetric::{PaddingFreeSponge, TruncatedPermutation};
 use p3_uni_stark::{
     InvalidProofShapeError, ProvenSecurity, StarkConfig, StarkGenericConfig, StarkSecurityParams,
-    VerificationError, prove, verify,
+    StarkShape, VerificationError, prove, verify,
 };
 use rand::SeedableRng;
 use rand::rngs::SmallRng;
@@ -80,10 +87,9 @@ type MyConfig = StarkConfig<Pcs, Challenge, Challenger>;
 const BATCH_POW_BITS: usize = 8;
 const OOD_POW_BITS: usize = 8;
 
-const fn fri_params(
-    batch_proof_of_work_bits: usize,
-    challenge_mmcs: ChallengeMmcs,
-) -> FriParameters<ChallengeMmcs> {
+/// Generic in the commitment scheme so the same parameters can drive a proof and,
+/// with `M = ()`, the transcript shapes the last test derives.
+const fn fri_params<M>(batch_proof_of_work_bits: usize, challenge_mmcs: M) -> FriParameters<M> {
     FriParameters {
         log_blowup: 2,
         log_final_poly_len: 0,
@@ -332,4 +338,112 @@ fn grinding_is_monotone_at_every_site() {
         );
         previous = current;
     }
+}
+
+/// The three protocols a uni-STARK proof over `p3-fri` layers, outermost first.
+///
+/// Each brackets the next, and each seeds its own transcript, so the same step
+/// label in two of them is two different steps.
+const UNI_STARK_STACK: [&str; 3] = ["p3-uni-stark", "p3-fri-pcs", "p3-fri"];
+
+/// The grinding this parameter set credits.
+///
+/// Out-of-domain bits come from the config, the other four from the FRI parameters.
+const fn credited(fri: &FriParameters<()>, ood_pow_bits: usize) -> GrindingBudget {
+    GrindingBudget::from_sites(&GrindingSites {
+        out_of_domain: ood_pow_bits,
+        ..fri.grinding_sites()
+    })
+    .with_fri(&fri.security_regime())
+}
+
+/// Every grinding difficulty the three transcripts of one configuration demand.
+///
+/// Fixture state: one opening of width three, and a two-round folding schedule.
+///
+/// Nothing but the difficulties reaches the result, so those choices do not move it.
+fn demanded(fri: &FriParameters<()>, ood_pow_bits: usize) -> Vec<RecordedGrind> {
+    let stark = StarkShape {
+        log_ext_degree: 5,
+        log_degree: 5,
+        main_width: 2,
+        preprocessed_width: 0,
+        num_public_values: 0,
+        num_periodic_columns: 0,
+        num_quotient_chunks: 2,
+        opens_main_next_row: false,
+        opens_preprocessed_next_row: false,
+        has_randomization: false,
+        ood_pow_bits,
+    };
+    let opening = PcsShape {
+        claimed_evaluation_counts: vec![vec![vec![3]]],
+        batch_pow_bits: fri.batch_proof_of_work_bits,
+    };
+    let ldt = FriShape::with_schedule(fri, vec![2, 2], 8);
+
+    let patterns = [
+        stark.pattern::<Val, Challenge>(),
+        opening.pattern::<Val, Challenge>(),
+        ldt.pattern::<Val, Challenge>(),
+    ];
+
+    UNI_STARK_STACK
+        .iter()
+        .zip(&patterns)
+        .flat_map(|(protocol, pattern)| {
+            pow_difficulties(pattern)
+                .into_iter()
+                .map(|(label, bits)| RecordedGrind::new(protocol, label, bits))
+        })
+        .collect()
+}
+
+#[test]
+fn recorded_grinding_matches_what_the_security_model_credits() {
+    // Property: recorded difficulty == credited difficulty, at every site.
+    //
+    // A parameter set that fails it reports bits nobody pays for, or pays for work
+    // the report throws away.
+    //
+    // Sweep: every site at zero and at one positive difficulty.
+    //
+    // Both sides of the elided-at-zero convention are therefore exercised.
+    for batch_pow_bits in [0, 10] {
+        for ood_pow_bits in [0, 8] {
+            for commit_pow_bits in [0, 4] {
+                for query_pow_bits in [0, 16] {
+                    let fri = FriParameters {
+                        commit_proof_of_work_bits: commit_pow_bits,
+                        query_proof_of_work_bits: query_pow_bits,
+                        ..fri_params(batch_pow_bits, ())
+                    };
+
+                    credited(&fri, ood_pow_bits)
+                        .check(&UNI_STARK_STACK, &demanded(&fri, ood_pow_bits))
+                        .unwrap_or_else(|mismatch| {
+                            panic!(
+                                "batch={batch_pow_bits} ood={ood_pow_bits} \
+                                 commit={commit_pow_bits} query={query_pow_bits}: {mismatch}"
+                            )
+                        });
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn the_configuration_these_tests_prove_with_is_accounted_for() {
+    // The config the other tests prove with is itself consistent.
+    //
+    // The numbers handed to the prover are the numbers the security report is built from.
+    let fri = fri_params(BATCH_POW_BITS, ());
+    let config = make_config(BATCH_POW_BITS, OOD_POW_BITS);
+    let ood_pow_bits = config.ood_proof_of_work_bits();
+
+    assert_eq!(ood_pow_bits, OOD_POW_BITS);
+    credited(&fri, ood_pow_bits)
+        .check(&UNI_STARK_STACK, &demanded(&fri, ood_pow_bits))
+        .unwrap_or_else(|mismatch| panic!("{mismatch}"));
 }


### PR DESCRIPTION
Depends on #2108 and the branches below it. This PR targets `test/typed-transcript-separation`; retarget after they land. It is the last item of the typed-transcript campaign.

## Why this exists

Grinding bits are the one soundness parameter that lives in two places at once: the transcript, which decides how much work a prover actually pays, and the security accounting, which decides how many bits the parameter set is *reported* to buy. Nothing compared them. A mismatch is a silently overstated security claim — a number in a report nobody re-ran.

Now that every proof-of-work step is a recorded `Kind::Pow` interaction carrying its difficulty as `Length::Fixed(bits)`, the two halves can be checked against each other. This makes a mismatch a test failure.

## The obstacle was vocabulary

Three disjoint naming schemes for the same sites, and no mapping between them anywhere in the tree. `GRINDING_VOCABULARY` is that table, keyed on `(protocol, label)` — never on the label alone, since `query_pow` appears in four crates and `ood_pow` in two.

| Protocol | Label | Site | Carrier | Report label | Zero bits |
| --- | --- | --- | --- | --- | --- |
| `p3-uni-stark` | `ood_pow` | `OutOfDomain` | `out_of_domain` | `deep-ali` | `Elided` |
| `p3-batch-stark` | `ood_pow` | `OutOfDomain` | `out_of_domain` | `deep-ali` | `Always` |
| `p3-batch-stark` | `lookup_pow` | `LookupChallenge` | `lookup_challenge` | `logup-fingerprint` | `WhenPhaseRuns` |
| `p3-fri-pcs` | `batch_pow` | `BatchCombination` | `batch_combination` | `batch-combination` | `Elided` |
| `p3-fri` | `commit_pow` | `LdtCommitPhase` | `FriRegime::commit_pow_bits` | `ldt-commit-phase` | `Elided` |
| `p3-fri` | `query_pow` | `LdtQueryPhase` | `FriRegime::query_pow_bits` | `ldt-query-phase` | `Elided` |

## Where it lives

Split along the line the dependency graph already has.

The vocabulary is a *fact about the protocols*, reviewable as a table, so it sits in `p3-security` beside `GrindingSites`. Crucially `check` takes `&[RecordedGrind]` rather than an `InteractionPattern`, so **`p3-security` gains no dependency on `p3-challenger`** and an audit tool in production can call it. Only the five-line pattern reader — `pow_difficulties` — lives in `p3-challenger`'s `test-utils`, because it exists solely to feed assertions.

## The zero-bit convention split

Sites do not agree on how to record zero, so the convention is declared per row and enforced in both directions:

- **`Elided`** — step present iff credited bits > 0. A described zero-bit step is unexpected; an absent step with bits credited is missing.
- **`Always`** — `batch-stark`'s `ood_pow`, whose witness travels in the proof unconditionally. Absence is an error *even at zero credited bits*, which is what makes the convention bite rather than decorate.
- **`WhenPhaseRuns`** — `batch-stark`'s `lookup_pow`. Absence carries no constraint, and that is argued rather than fudged: with no interactions `logup::security_term` returns `None`, so there is no term for those bits to boost and they are demonstrably inert.

## Proving it bites

Three deliberate desynchronisations, all reverted. The understating direction:

```
`new_testing`: ldt-query-phase grinding disagrees: the security model credits 0 bits,
  `p3-fri`'s `query_pow` step demands 1
```

And the dangerous direction — the transcript stops grinding while the model still credits it:

```
batch=0 ood=8 commit=0 query=0: out-of-domain grinding disagrees:
  the security model credits 8 bits, `p3-uni-stark` describes no `ood_pow` step, so 0 are demanded
```

One negative result worth recording: my first attempted desync did not fire, because the documented recipe overrides that field by struct update and the FRI-only stack lists no protocol owning the site. Both behaviours are correct; it just is not a reachable desync.

## What the guarantee actually is

Stated precisely, because the narrow reading and the broad one are easy to conflate:

> No parameter set **that a test instantiates** reports grinding bits it does not pay for.

That is narrower than "no mismatch exists in the tree". **Every caller of the budget check is inside a `mod tests` or an integration test** — there are zero production callers. A configuration added to `examples/`, or any downstream parameter set, is unchecked. The vocabulary table would catch it, but nothing on a proving or verifying path consults it.

The check takes `&[RecordedGrind]` rather than a pattern precisely so that an audit tool *could* call it without dragging a transcript dependency into `p3-security` — but today none does, and that is the whole distance between the two readings.

A test-only cross-check is the right first move: the two numbers were never compared at all before, and widening it means deciding where a production check belongs and what it costs on a hot path. That is a separate decision, not a footnote here.

## What was checked by hand

Every named `FriParameters` constructor agrees. The only non-test callers of `StarkSecurityParams::from_air` are the four sites in `examples`, and all four are consistent — the one plausible overstatement among them is already blocked by an assertion in `CirclePcs::new`. So no parameter set the tests reach, and none of the four in `examples`, reports bits it does not pay for.

## Scope, and what each remaining protocol needs

In scope: FRI, FRI PCS, uni-STARK, batch-STARK — the only protocols where both halves are already callable.

- **Circle** is cheapest: it reads `commit_pow` and `query_pow` straight from the shared `FriParameters`, so `security_regime()` already carries the right numbers. It needs a `p3-security` dependency and two rows.
- **WHIR** is hardest: its grinding is *derived* from a budget, not configured, and the security side is a disjoint model reporting `f64` bounds with no per-site accessor. Its rounds carry different difficulties, so a single `usize` per site is not enough — the budget needs a per-round vector. One PR per pipeline.
- **STIR** has no security module at all despite depending on `p3-security`; its bits come from a closure that solves for the gap to a buffered security level. A model has to exist before there is a credited number to compare against. Two PRs: model, then accessor.
- **multi-STARK** needs no rows. It records no `Kind::Pow` step of its own — the grind happens inside the delegated sumcheck patterns, under those protocols' names. Which also means it cannot be checked in isolation: the credited bits live in a config it passes down and the recorded bits in a transcript it does not own, so the check must span the bracket. Blocked on giving the sumcheck a security model at all.

## Public surface

No `_POW` label constant and no protocol `NAME` was exported. Each protocol asserts its own rows from inside its own crate, where the private constants are visible. One `const` became `pub(crate)` so `fri`'s two transcript modules can check their two halves of one `FriParameters` together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

