### PR TITLE
fix(binary-pcs): enforce claim batching soundness budget

### DIFF
--- a/binary-pcs/src/error.rs
+++ b/binary-pcs/src/error.rs
@@ -80,6 +80,17 @@ pub enum BinaryPcsError<MmcsError> {
     #[error("expected {expected} opening batches, proof carries {actual}")]
     OpeningBatchCountMismatch { expected: usize, actual: usize },
 
+    /// The opening batching challenge cannot retain the configured security target across
+    /// this many claimed evaluations.
+    #[error(
+        "opening protocol has {actual} claims, but at most {max} retain the configured {security_level}-bit security level"
+    )]
+    OpeningClaimCountExceedsSecurityBudget {
+        actual: usize,
+        max: usize,
+        security_level: usize,
+    },
+
     /// One opening batch has the wrong number of evaluations for its column list.
     #[error("table {table_idx} opening expected {expected} evaluations, got {actual}")]
     OpeningBatchSizeMismatch {

--- a/binary-pcs/src/params.rs
+++ b/binary-pcs/src/params.rs
@@ -85,9 +85,15 @@ const fn log2_ceil_u128(value: u128) -> usize {
 ///
 /// Taking the ceiling of the logarithm rounds the result **down**, so this understates the
 /// achieved security by up to one bit rather than overstating it.
+const fn field_error_numerator(log_domain_size: usize, num_fold_rounds: usize) -> u128 {
+    (1u128 << log_domain_size) + 1 + 2 * num_fold_rounds as u128
+}
+
 const fn field_security_bits_at(log_domain_size: usize, num_fold_rounds: usize) -> usize {
-    let numerator = (1u128 << log_domain_size) + 1 + 2 * num_fold_rounds as u128;
-    ALPHABET_BITS.saturating_sub(log2_ceil_u128(numerator))
+    ALPHABET_BITS.saturating_sub(log2_ceil_u128(field_error_numerator(
+        log_domain_size,
+        num_fold_rounds,
+    )))
 }
 
 /// Parameters chosen by the caller.
@@ -103,7 +109,8 @@ pub struct BinaryPcsParams {
 
 /// The round schedule derived from [`BinaryPcsParams`] and the polynomial's arity.
 ///
-/// The schedule prices the field's width and the query count, and nothing else.
+/// The schedule prices the field's width, opening-claim batching, and the query count, and
+/// nothing else.
 /// In particular it does not price the commitment scheme, which is supplied separately.
 /// A digest narrower than `2 * security_level` bits leaves the reported level undeliverable.
 /// Supplying one wide enough is the caller's obligation.
@@ -352,6 +359,34 @@ impl BinaryPcsConfig {
         self.params.pow_bits
     }
 
+    /// Security target this configuration promises, in bits.
+    #[must_use]
+    pub const fn security_level(&self) -> usize {
+        self.params.security_level
+    }
+
+    /// Largest number of opening claims one batching challenge can combine while retaining
+    /// this configuration's security target.
+    ///
+    /// Combining `k` claimed evaluations with powers of one uniform field element adds a
+    /// `(k - 1) / |F|` failure term. This limit reserves that term alongside the fold and
+    /// sumcheck numerator already charged by [`Self::field_security_bits`].
+    #[must_use]
+    pub const fn max_opening_claims(&self) -> usize {
+        // Batched-fold configurations reserve half the target error for the query phase.
+        // Opening batching shares the remaining half with the other field-error terms.
+        let query_reserve = if self.log_folding_factor > 1 { 1 } else { 0 };
+        let target_numerator =
+            1u128 << (ALPHABET_BITS - self.params.security_level - query_reserve);
+        let base_numerator = self.field_error_numerator();
+        let max = target_numerator.saturating_sub(base_numerator) + 1;
+        if max > usize::MAX as u128 {
+            usize::MAX
+        } else {
+            max as usize
+        }
+    }
+
     /// Bits of security the sampled queries deliver.
     ///
     /// The query phase runs one test per distinct first-batch coset, capped at the
@@ -365,20 +400,25 @@ impl BinaryPcsConfig {
         REGIME.queries_error(self.params.log_inv_rate, self.num_queries)
     }
 
-    /// Bits of security the fold and sumcheck rounds leave, rounded down.
+    /// Bits of security the fold and sumcheck rounds leave before opening-claim batching,
+    /// rounded down.
     ///
     /// No query count buys these bits back. Batched configurations reserve one additional
     /// bit to add this error to the query error; see [`Self::try_with_folding`].
     #[must_use]
     pub const fn field_security_bits(&self) -> usize {
+        ALPHABET_BITS.saturating_sub(log2_ceil_u128(self.field_error_numerator()))
+    }
+
+    /// Numerator of the field-error terms, before opening-claim batching.
+    const fn field_error_numerator(&self) -> u128 {
         if self.log_folding_factor == 1 {
-            field_security_bits_at(self.log_domain_size(), self.num_fold_rounds())
+            field_error_numerator(self.log_domain_size(), self.num_fold_rounds())
         } else {
             // Sum the geometric series of all virtual codeword lengths and every
             // fold/sumcheck error. log_domain_size < usize::BITS leaves room in u128.
-            let numerator = (2u128 << self.log_domain_size()) - (2u128 << self.log_final_len())
-                + 3 * self.num_variables as u128;
-            ALPHABET_BITS.saturating_sub(log2_ceil_u128(numerator))
+            (2u128 << self.log_domain_size()) - (2u128 << self.log_final_len())
+                + 3 * self.num_variables as u128
         }
     }
 }
@@ -630,5 +670,44 @@ mod tests {
             large < small,
             "a larger domain must leave fewer bits: {large} vs {small}"
         );
+    }
+
+    /// At one variable and rate `2^-2`, the fold and sumcheck field-error numerator is 11.
+    /// A 124-bit target leaves a numerator budget of 16, so the alpha batching term can add
+    /// at most five more roots: six claims total.
+    #[test]
+    fn opening_claim_capacity_reserves_the_alpha_batching_term() {
+        let config = BinaryPcsConfig::try_new(
+            1,
+            BinaryPcsParams {
+                log_inv_rate: 2,
+                pow_bits: 0,
+                security_level: 124,
+            },
+        )
+        .unwrap();
+        assert_eq!(config.security_level(), 124);
+        assert_eq!(config.field_security_bits(), 124);
+        assert_eq!(config.max_opening_claims(), 6);
+    }
+
+    /// Batched folds use their larger geometric field-error numerator and retain the bit
+    /// reserved for composition with the query phase. Here that leaves 256 numerator units;
+    /// the folds and sumcheck spend 132, so 125 opening claims are the exact boundary.
+    #[test]
+    fn batched_folding_claim_capacity_preserves_the_query_reserve() {
+        let config = BinaryPcsConfig::try_new(
+            4,
+            BinaryPcsParams {
+                log_inv_rate: 2,
+                pow_bits: 0,
+                security_level: 119,
+            },
+        )
+        .unwrap()
+        .try_with_folding(2)
+        .unwrap();
+        assert_eq!(config.field_security_bits(), 120);
+        assert_eq!(config.max_opening_claims(), 125);
     }
 }

--- a/binary-pcs/src/pcs.rs
+++ b/binary-pcs/src/pcs.rs
@@ -52,6 +52,22 @@ impl<MT> BinaryPcs<MT> {
             encoder: AdditiveRsEncoder::default(),
         }
     }
+
+    fn opening_claim_count(protocol: &OpeningProtocol) -> usize {
+        protocol.iter_openings().fold(0usize, |count, (_, batch)| {
+            count.saturating_add(batch.len())
+        })
+    }
+
+    fn assert_protocol_security(&self, protocol: &OpeningProtocol) {
+        let actual = Self::opening_claim_count(protocol);
+        let max = self.config.max_opening_claims();
+        assert!(
+            actual <= max,
+            "opening protocol has {actual} claims, but at most {max} retain the configured {}-bit security level",
+            self.config.security_level()
+        );
+    }
 }
 
 impl<MT> BinaryPcs<MT>
@@ -100,15 +116,16 @@ where
     /// via [`Verifier::add_claim_at`], `None` samples the point from the transcript via
     /// [`Verifier::add_claim`], mirroring the prover's `eval_at`/`eval` choice.
     ///
-    /// `OpeningBatchCountMismatch`, both round-count checks, `FinalCodewordLengthMismatch` and
-    /// `NonEmptyPowWitnesses` run before this function performs any transcript operation of its
-    /// own, so a malformed proof is rejected rather than indexed out of bounds or used to
-    /// desync the replay. That does not mean the challenger itself is untouched: `verify`
-    /// observes the commitment before calling here, and `verify_at`'s contract requires the
-    /// caller to have done the same. `OpeningBatchSizeMismatch`, by contrast, is checked once
-    /// per claim inside the claim-recording loop below, after every earlier claim in the same
-    /// proof has already been absorbed — it is ordered only relative to its own claim, not to
-    /// the transcript as a whole.
+    /// `OpeningClaimCountExceedsSecurityBudget`, `OpeningBatchCountMismatch`, both round-count
+    /// checks, `FinalCodewordLengthMismatch` and `NonEmptyPowWitnesses` run before this function
+    /// performs any transcript operation of its own, so a malformed proof is rejected rather
+    /// than indexed out of bounds or used to desync the replay. That does not mean the
+    /// challenger itself is untouched: `verify` observes the commitment before calling here,
+    /// and `verify_at`'s contract requires the caller to have done the same.
+    /// `OpeningBatchSizeMismatch`, by contrast, is checked once per claim inside the
+    /// claim-recording loop below, after every earlier claim in the same proof has already been
+    /// absorbed — it is ordered only relative to its own claim, not to the transcript as a
+    /// whole.
     ///
     /// The per-round sumcheck replay is interleaved with each intermediate round's commitment
     /// observation, one `SumcheckData::verify_rounds` call per fold round, because a single
@@ -134,6 +151,16 @@ where
             + CanSampleUniformBits<BinaryField128>
             + CanObserve<MT::Commitment>,
     {
+        let opening_claims = Self::opening_claim_count(protocol);
+        let max_opening_claims = self.config.max_opening_claims();
+        if opening_claims > max_opening_claims {
+            return Err(BinaryPcsError::OpeningClaimCountExceedsSecurityBudget {
+                actual: opening_claims,
+                max: max_opening_claims,
+                security_level: self.config.security_level(),
+            });
+        }
+
         if protocol.num_openings() != proof.evals.len() {
             return Err(BinaryPcsError::OpeningBatchCountMismatch {
                 expected: protocol.num_openings(),
@@ -284,6 +311,7 @@ where
         protocol: Self::OpeningProtocol,
         challenger: &mut Challenger,
     ) -> Self::Proof {
+        self.assert_protocol_security(&protocol);
         let evals = protocol
             .iter_openings()
             .map(|(table_idx, batch)| prover_data.layout.eval(table_idx, batch, challenger))
@@ -329,6 +357,7 @@ where
         challenger: &mut Challenger,
     ) -> Self::Proof {
         assert_eq!(protocol.num_openings(), points.len());
+        self.assert_protocol_security(protocol);
         let evals = protocol
             .iter_openings()
             .zip(points)

--- a/binary-pcs/tests/end_to_end.rs
+++ b/binary-pcs/tests/end_to_end.rs
@@ -209,6 +209,52 @@ fn a_zero_grinding_budget_round_trips() {
     }
 }
 
+/// Opening claims are compressed with successive powers of one 128-bit challenge. Seven
+/// claims therefore add a degree-six failure term to the field-error union bound. At this
+/// shape the fold and sumcheck numerator is already 11, so a 124-bit target permits at most
+/// six claims: the seventh raises the numerator above `2^(128 - 124) = 16`.
+#[test]
+fn verifier_rejects_opening_batches_below_the_configured_security_level() {
+    let num_variables = 1;
+    let mut rng = SmallRng::seed_from_u64(0xA17A);
+    let table = Table::rand(&mut rng, 1, num_variables);
+    let witness = SuffixProver::<F, F>::new_witness(vec![table], 0);
+    let protocol = OpeningProtocol::new(vec![TableSpec::new(
+        TableShape::new(num_variables, 1),
+        (0..7)
+            .map(|_| OpeningBatch::new(vec![0], Vec::new()))
+            .collect(),
+    )]);
+
+    // The low-target prover and high-target verifier sample every fold pair at this tiny
+    // domain, so they otherwise produce and consume the same proof shape. This lets the test
+    // exercise the verifier's security gate without asking a fixed prover to emit a proof it
+    // now knows cannot meet its own target.
+    let prover_config = BinaryPcsConfig::try_new(num_variables, params(2, 0, 40)).unwrap();
+    let prover_pcs = BinaryPcs::new(prover_config, mmcs());
+    let mut prover_challenger = challenger();
+    let (commitment, prover_data) = prover_pcs.commit(witness, &mut prover_challenger);
+    let proof = prover_pcs.open(prover_data, protocol.clone(), &mut prover_challenger);
+
+    let verifier_config = BinaryPcsConfig::try_new(num_variables, params(2, 0, 124)).unwrap();
+    let verifier_pcs = BinaryPcs::new(verifier_config, mmcs());
+    let mut verifier_challenger = challenger();
+    let err = verifier_pcs
+        .verify(&commitment, &proof, &mut verifier_challenger, protocol)
+        .unwrap_err();
+    assert!(
+        matches!(
+            err,
+            BinaryPcsError::OpeningClaimCountExceedsSecurityBudget {
+                actual: 7,
+                max: 6,
+                security_level: 124,
+            }
+        ),
+        "expected OpeningClaimCountExceedsSecurityBudget, got {err:?}"
+    );
+}
+
 /// The degenerate edge below `small_configurations_round_trip`'s sweep: `num_variables = 1`
 /// gives `num_fold_rounds() == 1`, so `fold_rounds`'s `rounds` vector is empty and every
 /// `num_fold_rounds - 1` derivation in the verifier bottoms out at zero rather than


### PR DESCRIPTION
## overview

a malicious prover can target a root of the alpha-batching polynomial when enough opening claims are combined. `BinaryPcsConfig` advertised `security_level` bits without accounting for the 

$$
\frac{\mathrm{num\_claims} - 1}{2^{128}}
$$

failure term, which allows proofs below the requested soundness to verify. e.g., a 124-bit configuration permits at most six claims in the tested setup. seven claims reduce soundness to at most 123 bits, but the verifier accepted them before this PR.

---

what this PR does:

* derives the maximum safe claim count from the field-error budget
* preserves the query reserve for batched-fold configurations
* rejects oversized protocols with a typed verifier error
* prevents provers from generating protocols below their configured target
* adds exact boundary tests and a test case that failed before the fix
