### PR TITLE
ci: trim the build matrix and scope the Rust cache to main

### DIFF
--- a/.github/workflows/ci-heavy.yml
+++ b/.github/workflows/ci-heavy.yml
@@ -47,6 +47,8 @@ jobs:
           echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=${{ matrix.features }}" >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test WHIR exhaustive sweep
         run: python3 scripts/check.py whir-exhaustive
@@ -70,6 +72,8 @@ jobs:
         run: echo "RUSTFLAGS=$RUSTFLAGS -C target-feature=+pclmulqdq" >> "$GITHUB_ENV"
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test the 2^16 round trip
         run: python3 scripts/check.py binary-large

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,45 +24,53 @@ env:
 
 jobs:
   build_and_test:
-    name: Build and Test
+    name: Build and Test (${{ matrix.name }})
     strategy:
       matrix:
         include:
-          # Default and `parallel`-feature runs are split into separate legs
-          # so they execute as concurrent jobs instead of sequential steps.
-          - os: ubuntu-latest
-            parallel: false
-          - os: ubuntu-latest
-            parallel: true
-          - os: ubuntu-latest
+          # `modes` selects which of the default and `parallel`-feature runs a leg
+          # performs. A leg naming both runs them as sequential steps sharing one
+          # warm target directory.
+          - name: linux
+            os: ubuntu-latest
+            modes: serial
+          - name: linux, parallel
+            os: ubuntu-latest
+            modes: parallel
+          - name: linux, avx2
+            os: ubuntu-latest
             features: "+avx2"
-            parallel: false
-          - os: ubuntu-latest
+            modes: serial
+          - name: linux, avx2, parallel
+            os: ubuntu-latest
             features: "+avx2"
-            parallel: true
+            modes: parallel
           # PCLMULQDQ is present on essentially every x86_64 CPU since ~2010, so the
           # carryless-multiply paths can be tested rather than merely compiled.
-          - os: ubuntu-latest
+          - name: linux, pclmulqdq
+            os: ubuntu-latest
             features: "+pclmulqdq"
-            parallel: false
-          - os: ubuntu-latest
-            features: "+pclmulqdq"
-            parallel: true
-          # A leg's job name embeds its `features`, and the two below are required status
-          # checks, so renaming either one leaves a required check that is never reported.
+            modes: serial parallel
+          # The serial/parallel split belongs on the Linux legs above: it exercises
+          # `maybe-rayon`, whose two backends do not vary by operating system. The
+          # macOS and Windows legs run the `parallel` configuration consumers ship.
+          - name: macos, parallel
+            os: macos-latest
+            modes: parallel
+          - name: windows, parallel
+            os: windows-latest
+            modes: parallel
+          # A leg's job name is its `name`, and most of them are required status
+          # checks, so renaming one leaves a required check that is never reported.
           # New feature combinations go in legs of their own.
-          - os: ubuntu-latest
+          - name: linux, avx512f, build only
+            os: ubuntu-latest
             features: "+avx512f"
             # GitHub-hosted runners aren't guaranteed to have AVX-512 hardware,
             # so this leg only verifies the AVX-512 paths compile.
             compile_only: true
             target: x86_64-unknown-linux-gnu
-            parallel: false
-          - os: ubuntu-latest
-            features: "+avx512f"
-            compile_only: true
-            target: x86_64-unknown-linux-gnu
-            parallel: true
+            modes: serial parallel
           # VPCLMULQDQ, the 256- and 512-bit carryless multiply, arrived with Ice Lake and
           # Zen 3. GitHub's runner pool still includes older parts, so these legs compile the
           # wide carryless-multiply paths rather than running them.
@@ -70,46 +78,26 @@ jobs:
           # A user-mode emulator is not a way around that. QEMU's translator decodes the
           # 128-bit carryless multiply only, so every test reaching a 256-bit product dies
           # on an illegal instruction. Executing these paths needs real silicon.
-          - os: ubuntu-latest
+          - name: linux, avx2+vpclmulqdq, build only
+            os: ubuntu-latest
             features: "+avx2,+vpclmulqdq"
             compile_only: true
             target: x86_64-unknown-linux-gnu
-            parallel: false
-          - os: ubuntu-latest
-            features: "+avx2,+vpclmulqdq"
-            compile_only: true
-            target: x86_64-unknown-linux-gnu
-            parallel: true
-          - os: ubuntu-latest
+            modes: serial parallel
+          - name: linux, avx512f+vpclmulqdq, build only
+            os: ubuntu-latest
             features: "+avx512f,+vpclmulqdq"
             compile_only: true
             target: x86_64-unknown-linux-gnu
-            parallel: false
-          - os: ubuntu-latest
-            features: "+avx512f,+vpclmulqdq"
-            compile_only: true
-            target: x86_64-unknown-linux-gnu
-            parallel: true
-          - os: ubuntu-24.04-arm
+            modes: serial parallel
+          - name: arm64, sve2, build only
+            os: ubuntu-24.04-arm
             features: "+sve2"
             # GitHub's arm64 runners aren't guaranteed to have SVE2 hardware,
             # so this leg only verifies the SVE2 paths compile.
             compile_only: true
             target: aarch64-unknown-linux-gnu
-            parallel: false
-          - os: ubuntu-24.04-arm
-            features: "+sve2"
-            compile_only: true
-            target: aarch64-unknown-linux-gnu
-            parallel: true
-          - os: macos-latest
-            parallel: false
-          - os: macos-latest
-            parallel: true
-          - os: windows-latest
-            parallel: false
-          - os: windows-latest
-            parallel: true
+            modes: serial parallel
     runs-on: ${{ matrix.os }}
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
 
@@ -127,6 +115,8 @@ jobs:
 
       # Smarter cache for Rust builds; avoids overfilling the runner disk.
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # nextest schedules every test from every binary in one pool instead of
       # running binaries one at a time, so idle cores get filled by other
@@ -137,33 +127,33 @@ jobs:
           tool: cargo-nextest
 
       - name: Test
-        if: ${{ !matrix.compile_only && !matrix.parallel }}
+        if: ${{ !matrix.compile_only && contains(matrix.modes, 'serial') }}
         run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py test
 
       - name: Test doctests
-        if: ${{ !matrix.compile_only && !matrix.parallel }}
+        if: ${{ !matrix.compile_only && contains(matrix.modes, 'serial') }}
         # nextest doesn't run doctests, so cover them with plain `cargo test`.
         run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py doctest
 
       - name: Test with parallel
-        if: ${{ !matrix.compile_only && matrix.parallel }}
+        if: ${{ !matrix.compile_only && contains(matrix.modes, 'parallel') }}
         run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py test --parallel
 
       - name: Test with parallel doctests
-        if: ${{ !matrix.compile_only && matrix.parallel }}
+        if: ${{ !matrix.compile_only && contains(matrix.modes, 'parallel') }}
         run: ${{ runner.os == 'Windows' && 'python' || 'python3' }} scripts/check.py doctest --parallel
 
       - name: Build
-        if: ${{ matrix.compile_only && !matrix.parallel }}
+        if: ${{ matrix.compile_only && contains(matrix.modes, 'serial') }}
         # Keep target-feature RUSTFLAGS off host build scripts and proc macros.
         run: python3 scripts/check.py architecture --target ${{ matrix.target }}
 
       - name: Build with parallel
-        if: ${{ matrix.compile_only && matrix.parallel }}
+        if: ${{ matrix.compile_only && contains(matrix.modes, 'parallel') }}
         run: python3 scripts/check.py architecture --target ${{ matrix.target }} --parallel
 
       - name: Test keccak (aarch64, no SHA3)
-        if: ${{ matrix.os == 'macos-latest' && !matrix.parallel }}
+        if: ${{ matrix.os == 'macos-latest' }}
         env:
           RUSTFLAGS: -C debuginfo=0 -C target-feature=-sha3
         run: python3 scripts/check.py test --package p3-keccak
@@ -185,6 +175,8 @@ jobs:
         id: rs-stable
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # Library packages are discovered through Cargo metadata. Host-only packages
       # explicitly opt out with `package.metadata.plonky3.embedded = false`.
@@ -210,6 +202,8 @@ jobs:
         with:
           targets: ${{ env.build_target }}, ${{ env.run_target }}
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Install wasmtime
         env:
           WASMTIME_VERSION: v44.0.1
@@ -254,6 +248,8 @@ jobs:
           tool: cargo-machete,cargo-sort,taplo
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Test repository command interface
         run: python3 scripts/check.py lint --check scripts


### PR DESCRIPTION
## Motivation

The Plonky3 org is on the free GitHub plan: **20 concurrent jobs org-wide, 5 concurrent macOS**. A single CI run was **21 jobs**, so one PR saturated the org's entire concurrency budget and PRs were effectively serialized.

Separately, the Actions cache was over quota and thrashing:

```
active_caches_size_in_bytes: 10,631,657,109   (limit: 10 GB)
refs/heads/main       24 caches
refs/pull/2100/merge  11
refs/pull/2097/merge   6
refs/pull/2114/merge   2
```

`Swatinem/rust-cache` had no `save-if`, so every PR branch saved its own ~300 MB cache per matrix leg. Those pushed the repository past the 10 GB limit, GitHub evicted LRU — which is `main`'s entries, the ones every PR restores from — and legs rebuilt cold. That is why a `Test` step took 11–15 minutes.

## Changes

**Matrix: 18 legs → 11 (21 jobs → 14).** Legs are selected by an explicit `name` and a `modes` list rather than a boolean `parallel` axis, so a leg can run both configurations as sequential steps sharing one warm target directory.

| Leg | Runs |
| --- | --- |
| `linux` | serial |
| `linux, parallel` | parallel |
| `linux, avx2` | serial |
| `linux, avx2, parallel` | parallel |
| `linux, pclmulqdq` | serial + parallel |
| `macos, parallel` | parallel, plus the keccak `-sha3` check |
| `windows, parallel` | parallel |
| `linux, avx512f, build only` | both builds |
| `linux, avx2+vpclmulqdq, build only` | both builds |
| `linux, avx512f+vpclmulqdq, build only` | both builds |
| `arm64, sve2, build only` | both builds |

The serial/parallel split exercises `maybe-rayon`, whose two backends do not vary by operating system, so it stays on the Linux legs; macOS and Windows run the `parallel` configuration consumers ship. The only coverage removed is macOS-serial and Windows-serial — the merged legs run the same commands as before, in fewer jobs.

**Cache: `save-if: ${{ github.ref == 'refs/heads/main' }}`** on all six `rust-cache` uses in `ci.yml` and `ci-heavy.yml`. Pull requests restore from `main` and no longer save.

## Measured impact

Per-job durations from run `34334938358`:

| | Before | After |
| --- | --- | --- |
| Jobs per run | 21 | 14 |
| Job-minutes | ~143 | ~105 (est.) |
| Concurrent macOS slots | 2 | 1 |
| Concurrent Windows slots | 2 | 1 |
| Active caches | 43 (10.6 GB) | ~24 (~7 GB) |

The cache change is expected to account for more of the wall-clock win than the matrix trim, since it is what makes the test steps rebuild from cold.

## Required status checks must be updated with this merge

Job names changed, so the 15 current required contexts become 11. Preserving the existing policy that the `pclmulqdq` and `vpclmulqdq` legs are not gating:

```
Formatting and Clippy
Build embedded
Test wasm32 simd128
Build and Test (linux)
Build and Test (linux, parallel)
Build and Test (linux, avx2)
Build and Test (linux, avx2, parallel)
Build and Test (macos, parallel)
Build and Test (windows, parallel)
Build and Test (linux, avx512f, build only)
Build and Test (arm64, sve2, build only)
```

Worth considering separately: `linux, pclmulqdq` is now a single job and is the only leg that executes carry-less multiply rather than merely compiling it, so promoting it to required is cheap.

**Every open PR needs a rebase once the contexts are switched**, since a PR still running the old `ci.yml` reports the old job names. With ~20 PRs open, this is worth timing deliberately.

## Test plan

- [x] `ci.yml` and `ci-heavy.yml` parse as YAML
- [x] Matrix expansion simulated leg-by-leg against the step guards; every command that ran before still runs, except macOS-serial and Windows-serial
- [x] `actionlint` clean on `ci.yml`, `ci-heavy.yml`, `bench-smoke.yml`, `pr-labeler.yml`
- [ ] CI on this PR reports the 11 new job names