### PR TITLE
fix(transcript): address the review follow-ups from the typed-transcript stack

### DIFF
--- a/batch-stark/src/transcript.rs
+++ b/batch-stark/src/transcript.rs
@@ -142,6 +142,7 @@ struct OpeningArgument;
 ///
 /// Every other described step is replayed against data the caller validated first.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum BatchTranscriptFailure {
     /// The witness guarding the lookup challenges misses its difficulty.
     #[error("lookup phase PoW witness does not meet the required {bits} bits")]

--- a/circle/src/transcript.rs
+++ b/circle/src/transcript.rs
@@ -136,6 +136,7 @@ pub type OpeningClaim<'a, EF> = (Point<EF>, &'a [EF]);
 /// A described grinding step therefore always has a witness to replay it.
 /// Only the strength of that witness can still fail here.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum CircleTranscriptFailure {
     /// A grinding witness did not produce the zero bits its step requires.
     #[error("invalid proof-of-work witness for the {phase} phase: {bits} bits required")]

--- a/commit/src/pcs/multilinear.rs
+++ b/commit/src/pcs/multilinear.rs
@@ -53,6 +53,25 @@ where
     /// be a flat polynomial, a table layout, or another structure that expands
     /// to multilinear evaluations over the Boolean hypercube.
     ///
+    /// # Transcript
+    ///
+    /// The challenger is the sponge the whole proof shares, and this phase owes it one absorb.
+    ///
+    /// ```text
+    ///     required   ->  the commitment being returned, absorbed once
+    ///     forbidden  ->  any other absorb, any sample, any grind
+    /// ```
+    ///
+    /// A verifier never reaches this method, so it absorbs that same commitment in its place.
+    /// The obligation above is what makes the two interchangeable.
+    ///
+    /// An absorbed table height, or a batching challenge drawn here, desyncs the two sides.
+    /// Neither side has a step out of place, so the caller sees an unexplained rejection.
+    ///
+    /// Absorbing at all needs a challenger able to observe this commitment type.
+    /// This trait bounds no challenger, so each implementation carries that bound itself.
+    /// The prescribed-point opening sub-trait requires it of every caller it serves.
+    ///
     /// # Returns
     ///
     /// - A succinct commitment (e.g. a Merkle root).

--- a/fri/src/pcs_transcript.rs
+++ b/fri/src/pcs_transcript.rs
@@ -507,6 +507,7 @@ where
 
 /// A transcript step the proof failed to satisfy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum PcsTranscriptFailure {
     /// One opening carries a claimed-evaluation count the run never described.
     #[error("opening {opening}: claimed evaluation count mismatch: expected {expected}, got {got}")]
@@ -745,38 +746,44 @@ mod tests {
     }
 
     #[test]
-    fn the_delegation_bracket_leaves_the_sponge_untouched() {
-        // Invariant: the markers are structural.
-        // They record the delegation, and absorb nothing.
+    fn both_sides_walk_the_delegation_bracket_identically() {
+        // Invariant: the two sides come through the bracket in the same place.
         //
-        // Fixture state: the two sides over the same shape, each bracketing an empty delegation.
+        //     alpha        ->  the batching challenge agrees across the delegation
+        //     next sample  ->  the sponges are still in step once the bracket closes
+        //
+        // Fixture state: one shape, driven once by each side, each bracketing an empty run.
+        //
+        // The shape describes the bracket unconditionally, so neither side can skip it.
+        // An absorbing marker would move both sponges alike, so it is outside what this pins.
         let shape = shape_with(vec![vec![vec![1]]]);
         let claims: Vec<CommitmentWithOpeningPoints<EF, (), ()>> =
             vec![((), vec![((), vec![(EF::ONE, vec![EF::ONE])])]).into()];
 
-        let mut bracketed_challenger = fresh_challenger();
-        let mut bracketed =
-            PcsVerifierTranscript::<Ch, F, EF>::new(&mut bracketed_challenger, shape.clone());
-        bracketed.claimed_openings(&claims).unwrap();
-        let bracketed_alpha = bracketed.batch_phase(None).unwrap();
-        bracketed.delegate(|_| ());
-        bracketed.finish();
+        let mut verifier_challenger = fresh_challenger();
+        let mut verifier =
+            PcsVerifierTranscript::<Ch, F, EF>::new(&mut verifier_challenger, shape.clone());
+        verifier.claimed_openings(&claims).unwrap();
+        let verifier_alpha = verifier.batch_phase(None).unwrap();
+        verifier.delegate(|_| ());
+        verifier.finish();
 
         // The prover side plays the same steps and must land on the same challenge.
-        let mut plain_challenger = fresh_challenger();
-        let mut plain = PcsProverTranscript::<Ch, F, EF>::new(&mut plain_challenger, shape);
-        plain.claimed_openings(&vec![vec![vec![vec![EF::ONE]]]]);
-        let (plain_alpha, witness) = plain.batch_phase();
-        plain.delegate(|_| ());
-        plain.finish();
+        let mut prover_challenger = fresh_challenger();
+        let mut prover = PcsProverTranscript::<Ch, F, EF>::new(&mut prover_challenger, shape);
+        prover.claimed_openings(&vec![vec![vec![vec![EF::ONE]]]]);
+        let (prover_alpha, witness) = prover.batch_phase();
+        prover.delegate(|_| ());
+        prover.finish();
 
-        assert_eq!(bracketed_alpha, plain_alpha);
+        assert_eq!(verifier_alpha, prover_alpha);
         assert_eq!(witness, None);
         // Both sponges advanced identically, so they still agree on what comes next.
-        let bracketed_next: F = bracketed_challenger.sample();
-        let plain_next: F = plain_challenger.sample();
-        assert_eq!(bracketed_next, plain_next);
+        let verifier_next: F = verifier_challenger.sample();
+        let prover_next: F = prover_challenger.sample();
+        assert_eq!(verifier_next, prover_next);
     }
+
     /// This protocol's name, as the vocabulary table keys it.
     fn protocol() -> &'static str {
         from_utf8(NAME).expect("the protocol name is ASCII")

--- a/fri/src/transcript.rs
+++ b/fri/src/transcript.rs
@@ -475,6 +475,7 @@ where
 /// Only the two grinding steps a FRI run replays are reachable here.
 /// The one guarding the batching challenge is drawn before the run starts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum TranscriptFailure {
     /// A grinding witness did not meet the difficulty its step requires.
     #[error("{0} phase PoW witness does not meet the required difficulty")]

--- a/multi-stark/src/lookup/transcript.rs
+++ b/multi-stark/src/lookup/transcript.rs
@@ -452,10 +452,10 @@ mod tests {
 
     #[test]
     fn every_field_of_the_plan_reaches_the_lookup_seed() {
-        // Walk the shape field by field, perturbing one number at a time.
+        // Each row below perturbs the shape and asserts the seed moved with it.
         //
-        // The step sequence is the same for every batch, so none of these can ride
-        // in the fingerprint. This walk is the check that the label carries them all.
+        // Every batch describes one step sequence, so none of these can ride in the fingerprint.
+        // This walk is the check that the label carries them all.
         lookup_field_moves_the_seed("num_variables", |s| s.num_variables += 1);
         lookup_field_moves_the_seed("max_width", |s| s.max_width += 1);
         lookup_field_moves_the_seed("num_buses", |s| s.num_buses += 1);

--- a/multi-stark/src/transcript.rs
+++ b/multi-stark/src/transcript.rs
@@ -122,6 +122,8 @@ struct PreprocessedOpening;
 ///
 /// The pair absorbs nothing.
 /// What it records is that a sub-protocol runs at this position, under its own seed.
+///
+/// The driver's opener and closer append this pair to their pattern record and touch nothing else, so a marker has no path to the sponge.
 fn delegation<T: ?Sized>(label: Label) -> [Interaction; 2] {
     [
         Interaction::marker::<T>(Hierarchy::Begin, Kind::Protocol, label),
@@ -682,6 +684,7 @@ where
 
 /// A statement-level transcript step the batch failed to satisfy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum MultiStarkTranscriptFailure {
     /// The described preprocessed-commitment step arrived with no commitment.
     #[error("{tables} preprocessed table(s) described but the verifying key carries no commitment")]
@@ -717,6 +720,7 @@ mod tests {
     extern crate std;
 
     use alloc::vec;
+    use core::ops::Range;
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
     use p3_challenger::DuplexChallenger;
@@ -763,6 +767,18 @@ mod tests {
         }
     }
 
+    /// Whether two shapes seed a sponge identically, compared on the preimage not a sample.
+    ///
+    /// The preimage is the pattern fingerprint followed by the instance label.
+    /// Comparing it rather than one sampled element keeps the comparison exact.
+    fn seeds_agree(left: &MultiStarkShape, right: &MultiStarkShape) -> bool {
+        let left = left.domain_separator::<F>();
+        let right = right.domain_separator::<F>();
+
+        left.pattern().pattern_hash() == right.pattern().pattern_hash()
+            && left.instance_label() == right.instance_label()
+    }
+
     /// First challenge a shape's seed produces on a fresh sponge.
     fn first_challenge(shape: &MultiStarkShape) -> F {
         let mut challenger = fresh_challenger();
@@ -772,32 +788,53 @@ mod tests {
 
     /// Every field of the shape, each moved one step away from `base_shape`.
     ///
-    /// One entry per configuration knob, so a knob added without a binding shows up here.
+    /// The batch and one of its instances are destructured below with no rest pattern.
+    /// Both are destructured, since a new knob can land on either struct.
+    /// Every binding then feeds the row that covers it, so an unread field is a build failure.
+    ///
+    /// The enforcement is weaker than it looks.
+    /// A new field trips the missing-field error at the baseline's struct literals first.
+    /// What is enforced is that the author must come through here, not that a row appears.
     fn one_step_from_base() -> Vec<(&'static str, MultiStarkShape)> {
+        let MultiStarkShape {
+            instances,
+            pow_bits,
+        } = base_shape();
+        let num_instances = instances.len();
+        let MultiStarkInstanceShape {
+            num_variables,
+            main_width,
+            preprocessed_width,
+            num_public_values,
+        } = instances
+            .into_iter()
+            .next()
+            .expect("the baseline batch is not empty");
+
         let mut mutations = Vec::new();
 
         let mut shape = base_shape();
-        shape.pow_bits += 1;
+        shape.pow_bits = pow_bits + 1;
         mutations.push(("pow_bits", shape));
 
         let mut shape = base_shape();
-        shape.instances.pop();
+        shape.instances.truncate(num_instances - 1);
         mutations.push(("instances.len", shape));
 
         let mut shape = base_shape();
-        shape.instances[0].num_variables += 1;
+        shape.instances[0].num_variables = num_variables + 1;
         mutations.push(("instance.num_variables", shape));
 
         let mut shape = base_shape();
-        shape.instances[0].main_width += 1;
+        shape.instances[0].main_width = main_width + 1;
         mutations.push(("instance.main_width", shape));
 
         let mut shape = base_shape();
-        shape.instances[0].preprocessed_width += 1;
+        shape.instances[0].preprocessed_width = preprocessed_width + 1;
         mutations.push(("instance.preprocessed_width", shape));
 
         let mut shape = base_shape();
-        shape.instances[0].num_public_values += 1;
+        shape.instances[0].num_public_values = num_public_values + 1;
         mutations.push(("instance.num_public_values", shape));
 
         mutations
@@ -886,8 +923,6 @@ mod tests {
         // Baseline: the two-instance shape, seeded and sampled once.
         let baseline = first_challenge(&base_shape());
 
-        // Each mutation moves exactly one field one step.
-        //
         // A field the fingerprint covers moves the seed through the step sequence.
         // A field it does not must move it through the instance label instead.
         for (field, shape) in one_step_from_base() {
@@ -1233,8 +1268,11 @@ mod tests {
         drop(transcript);
     }
 
-    /// A shape drawn from the same knobs the walk above perturbs.
-    fn arbitrary_shape() -> impl Strategy<Value = MultiStarkShape> {
+    /// A shape drawn from the same knobs the walk above perturbs, over a given batch size.
+    ///
+    /// The size is a parameter rather than fixed, so a property needing two instances draws two.
+    /// Narrowing the draw beats filtering it, since a rejected case is a case that did no work.
+    fn arbitrary_shape_sized(instances: Range<usize>) -> impl Strategy<Value = MultiStarkShape> {
         let instance = (1_usize..4, 1_usize..4, 0_usize..3, 0_usize..4).prop_map(
             |(num_variables, main_width, preprocessed_width, num_public_values)| {
                 MultiStarkInstanceShape {
@@ -1246,12 +1284,24 @@ mod tests {
             },
         );
 
-        (proptest::collection::vec(instance, 1..4), 0_usize..5).prop_map(|(instances, pow_bits)| {
-            MultiStarkShape {
+        (proptest::collection::vec(instance, instances), 0_usize..5).prop_map(
+            |(instances, pow_bits)| MultiStarkShape {
                 instances,
                 pow_bits,
-            }
-        })
+            },
+        )
+    }
+
+    /// Every legal batch size, the single-instance batch included.
+    fn arbitrary_shape() -> impl Strategy<Value = MultiStarkShape> {
+        arbitrary_shape_sized(1..4)
+    }
+
+    /// Only the batch sizes a permutation can reorder.
+    ///
+    /// A one-instance batch has no permutation but the identity, so it is left out.
+    fn arbitrary_reorderable_shape() -> impl Strategy<Value = MultiStarkShape> {
+        arbitrary_shape_sized(2..4)
     }
 
     proptest! {
@@ -1278,17 +1328,43 @@ mod tests {
             right in arbitrary_shape(),
         ) {
             // Soundness over random batches: distinct descriptions land on distinct seeds.
+            prop_assert_eq!(left == right, seeds_agree(&left, &right));
+        }
+
+        #[test]
+        fn permuting_the_instances_of_a_batch_moves_the_seed(
+            shape in arbitrary_reorderable_shape(),
+        ) {
+            // Soundness over random batches: the batch order is part of the statement.
             //
-            // The seed preimage is the fingerprint followed by the instance label.
-            // Comparing the preimage rather than one sampled element keeps this exact.
-            let left_seed = left.domain_separator::<F>();
-            let right_seed = right.domain_separator::<F>();
+            //     public-value counts  ->  step lengths, so the fingerprint holds their order
+            //     arities and widths   ->  instance label, written in the same order
+            //
+            // Every rotation and the reversal are tried, which is every order of a two-instance batch.
+            //
+            // Why the draw starts at two instances: a one-instance batch offers no rotation and a reversal equal to itself.
+            // Every case then reaches at least one real comparison below.
+            let rotations = (1..shape.instances.len()).map(|shift| {
+                let mut rotated = shape.clone();
+                rotated.instances.rotate_left(shift);
+                rotated
+            });
+            let mut reversed = shape.clone();
+            reversed.instances.reverse();
 
-            let seeds_agree = left_seed.pattern().pattern_hash()
-                == right_seed.pattern().pattern_hash()
-                && left_seed.instance_label() == right_seed.instance_label();
+            for permuted in rotations.chain(core::iter::once(reversed)) {
+                // A batch of interchangeable instances is left where it was by a permutation.
+                if permuted == shape {
+                    continue;
+                }
 
-            prop_assert_eq!(left == right, seeds_agree);
+                prop_assert!(
+                    !seeds_agree(&shape, &permuted),
+                    "{:?} and its permutation {:?} share a seed",
+                    shape.instances,
+                    permuted.instances,
+                );
+            }
         }
     }
 }

--- a/multi-stark/src/verifier.rs
+++ b/multi-stark/src/verifier.rs
@@ -97,7 +97,17 @@ where
 ///     8. recompute the batched constraint at r and match the reduced sum
 /// ```
 ///
-/// Both sides walk one pattern, so a step either side skips or reorders is rejected.
+/// Both sides walk one pattern, and each driver checks only its own party against it:
+///
+/// ```text
+///     this verifier misplaces a step  ->  its own driver refuses the call
+///     the prover skips an absorb      ->  the sponges diverge, so a later check fails
+///     the prover skips a bracket      ->  the delegated verification rejects on its own
+/// ```
+///
+/// Why the brackets absorb nothing: a driver's opener and closer only append a marker to its own pattern record, and neither reaches the sponge.
+///
+/// That holds by construction on both sides rather than by test, so a skipped delegation is caught by the callee and never here.
 ///
 /// Each AIR instance is evaluated at the suffix of the common point matching its
 /// trace height. Main openings are returned in instance order. Preprocessed
@@ -231,18 +241,19 @@ where
         }
     };
 
-    // Invariant: no early return may cross the span from here to the driver's `finish`.
+    // Invariant: a return between here and the driver's `finish` must release the driver first.
     //
-    //     main opening           -> Begin, the scheme's own run, End, on any outcome
-    //     preprocessed opening   -> the same, when the batch describes one
-    //     finish                 -> every described step replayed
-    //     rejection              -> propagated afterwards, never across a live driver
+    //     main opening            -> Begin, the scheme's own run, End, on any outcome
+    //     main rejection          -> abort, then return, with the preprocessed step unplayed
+    //     preprocessed opening    -> the same bracket, when the batch describes one
+    //     finish                  -> every described step replayed
+    //     preprocessed rejection  -> travels past `finish`, since no described step follows it
     //
-    // Neither opening feeds the other, so both rejections travel past the driver as results.
+    // A rejected batch with preprocessed columns therefore costs one opening, not two.
 
     // 6. Open the committed main trace tables at their suffixes of the bound point.
     // The returned values are bound to the main commitment.
-    let opened_main = transcript.main_opening(|challenger| {
+    let main_evals = match transcript.main_opening(|challenger| {
         config.pcs().verify_at(
             &proof.commitment,
             &proof.opening,
@@ -250,7 +261,14 @@ where
             &instances.main_points(&reduction.point),
             challenger,
         )
-    });
+    }) {
+        Ok(evals) => evals,
+        // Nothing below can change this verdict, so the preprocessed opening never runs.
+        Err(error) => {
+            transcript.abort();
+            return Err(VerificationError::Opening(error));
+        }
+    };
 
     // 7. Open the preprocessed tables at their suffixes of the same bound point.
     // The owned batches are kept local so the closing check can borrow them.
@@ -273,7 +291,6 @@ where
     // Every described step has now been replayed.
     transcript.finish();
 
-    let main_evals = opened_main.map_err(VerificationError::Opening)?;
     let preprocessed_evals = opened_preprocessed
         .transpose()
         .map_err(VerificationError::Opening)?;

--- a/multi-stark/src/zerocheck/transcript.rs
+++ b/multi-stark/src/zerocheck/transcript.rs
@@ -544,7 +544,7 @@ mod tests {
 
     #[test]
     fn every_field_of_the_shape_reaches_the_seed() {
-        // Walk the shape field by field, perturbing one number at a time.
+        // Each row below perturbs the shape and asserts the seed moved with it.
         //
         // Some of these move the step sequence and some only the label.
         // The walk does not care which, only that the seed moves either way.

--- a/multi-stark/tests/whir_fibonacci.rs
+++ b/multi-stark/tests/whir_fibonacci.rs
@@ -980,13 +980,16 @@ fn verify_rejects_tampered_main_commitment() {
         &mut challenger(),
     )
     .unwrap_err();
-    match err {
-        VerificationError::Opening(WhirVerifierError::MerkleProofInvalid { position, reason }) => {
-            assert_eq!(position, 0);
-            assert_eq!(reason, "Base field Merkle multiproof verification failed");
-        }
-        other => panic!("expected a Merkle opening rejection, got {other:?}"),
-    }
+    // The variant and the placeholder position are the assertion.
+    //
+    // The wording belongs to the commitment scheme, so it is not pinned here.
+    assert!(
+        matches!(
+            err,
+            VerificationError::Opening(WhirVerifierError::MerkleProofInvalid { position: 0, .. })
+        ),
+        "expected a Merkle opening rejection, got {err:?}"
+    );
 }
 
 const WHIR_FIXTURE: &str = "tests/fixtures/multi_stark_whir_v0_8_0.postcard";

--- a/multi-stark/tests/whir_preprocessed.rs
+++ b/multi-stark/tests/whir_preprocessed.rs
@@ -5,6 +5,7 @@
 //! opened at the single point the zerocheck binds.
 
 use core::borrow::Borrow;
+use core::sync::atomic::{AtomicUsize, Ordering};
 
 use p3_air::{Air, AirBuilder, BaseAir, WindowAccess};
 use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
@@ -549,4 +550,131 @@ fn verify_rejects_tampered_preprocessed_opening() {
         }
         other => panic!("expected a preprocessed Merkle opening rejection, got {other:?}"),
     }
+}
+
+/// A configuration that counts how often a caller reaches for the preprocessed scheme.
+///
+/// The verifier asks for it in one place only, inside the preprocessed opening bracket.
+/// The count is therefore the number of preprocessed openings the verifier performed.
+struct CountingConfig {
+    /// The configuration the other tests use, wrapped unchanged.
+    inner: WhirConfigForTest,
+    /// Times the preprocessed scheme has been handed out since the last read.
+    preprocessed_lookups: AtomicUsize,
+}
+
+impl CountingConfig {
+    const fn new(inner: WhirConfigForTest) -> Self {
+        Self {
+            inner,
+            preprocessed_lookups: AtomicUsize::new(0),
+        }
+    }
+
+    /// Read the count and reset it, so each phase is measured on its own.
+    fn take_preprocessed_lookups(&self) -> usize {
+        self.preprocessed_lookups.swap(0, Ordering::Relaxed)
+    }
+}
+
+impl MultiStarkConfig for CountingConfig {
+    type Val = F;
+    type Challenge = EF;
+    type Challenger = MyChallenger;
+    type Pcs = TestPcs;
+
+    fn pcs(&self) -> &TestPcs {
+        self.inner.pcs()
+    }
+
+    fn collision_resistance_bits(&self) -> Option<usize> {
+        self.inner.collision_resistance_bits()
+    }
+
+    fn preprocessed_pcs(&self) -> &TestPcs {
+        self.preprocessed_lookups.fetch_add(1, Ordering::Relaxed);
+        self.inner.preprocessed_pcs()
+    }
+
+    fn min_num_variables(&self) -> usize {
+        self.inner.min_num_variables()
+    }
+
+    fn build_witness(&self, tables: Vec<Table<F>>) -> Witness<F> {
+        self.inner.build_witness(tables)
+    }
+
+    fn committed_table<'a>(
+        &self,
+        prover_data: &'a p3_whir::WhirProverData<F, EF, MyMmcs, L>,
+        table_index: usize,
+    ) -> &'a Table<F> {
+        self.inner.committed_table(prover_data, table_index)
+    }
+}
+
+#[test]
+fn a_rejected_main_opening_leaves_the_preprocessed_opening_unrun() {
+    // Invariant: the preprocessed opening cannot change a verdict the main opening already made.
+    //
+    // Fixture state: one instance with preprocessed columns, so both openings are described.
+    // The configuration counts every hand-out of the preprocessed scheme.
+    let n = 256;
+    let fixed = fixed_column(n);
+    let air = PreprocessedAir { height: n };
+    let trace = main_trace(&fixed);
+    let log_height = log2_strict_usize(n);
+    let config = CountingConfig::new(config_for(log_height));
+    let airs = [&air];
+
+    let (pk, vk) = setup(&config, &airs, &mut challenger());
+
+    let mut proof = prove(
+        &config,
+        ProverInstances::new(vec![ProverInstance::new(
+            &air,
+            Table::new(trace.transpose()),
+            &pk,
+            &[],
+        )]),
+        0,
+        &mut challenger(),
+    );
+
+    // Setup and proving reach for the scheme as well, so the verifier starts from zero.
+    config.take_preprocessed_lookups();
+
+    // Baseline: an untouched proof verifies, and its preprocessed opening runs once.
+    verify(
+        &config,
+        VerifierInstances::new(vec![VerifierInstance::new(&air, &vk, log_height, &[])]),
+        &proof,
+        0,
+        &mut challenger(),
+    )
+    .expect("honest preprocessed proof must verify");
+    assert_eq!(config.take_preprocessed_lookups(), 1);
+
+    // Mutation: shift the first opened main current-row value by one field element.
+    let batch = &proof.opening.evals[0];
+    let mut current = batch.current().to_vec();
+    current[0] += EF::ONE;
+    proof.opening.evals[0] = OpeningBatch::new(current, batch.next().to_vec());
+
+    // Expected rejection: the opened main value is no longer bound to the main commitment.
+    let err = verify(
+        &config,
+        VerifierInstances::new(vec![VerifierInstance::new(&air, &vk, log_height, &[])]),
+        &proof,
+        0,
+        &mut challenger(),
+    )
+    .unwrap_err();
+    assert!(
+        matches!(err, VerificationError::Opening(_)),
+        "expected a main opening rejection, got {err:?}"
+    );
+
+    // The rejecting path never asked for the preprocessed scheme, so it opened nothing twice.
+    assert_eq!(config.take_preprocessed_lookups(), 0);
 }

--- a/stir/src/transcript.rs
+++ b/stir/src/transcript.rs
@@ -798,6 +798,7 @@ fn close(steps: &mut Vec<Interaction>, label: &'static str) {
 ///
 /// A count carries both the number the run was described with and the number supplied.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TranscriptFailure {
     /// A grinding witness did not meet the difficulty its step requires.
     #[error("{round}: {stage} proof-of-work witness clears fewer than {bits} bits")]

--- a/sumcheck/src/error.rs
+++ b/sumcheck/src/error.rs
@@ -37,7 +37,9 @@ pub enum SumcheckError {
         difficulty: usize,
     },
 
-    /// The proof carries fewer PoW witnesses than sumcheck rounds.
+    /// The witness count is not the one the difficulty fixes.
+    ///
+    /// Zero difficulty admits no witnesses, and a positive one admits exactly one per round.
     #[error("Sumcheck PoW witness count mismatch: expected {expected}, got {actual}")]
     PowWitnessCountMismatch {
         /// Witness count the configuration fixes.

--- a/sumcheck/src/generic_degree/proof.rs
+++ b/sumcheck/src/generic_degree/proof.rs
@@ -136,7 +136,14 @@ impl<F, EF> GenericDegreeProof<F, EF> {
         // The rejection happens at the offending round, not before the replay.
         // A proof whose round 3 carries the wrong width has rounds 0 to 2 absorbed first.
         //
-        // The verdict is unaffected: the sponge is dropped on the error path and never reused.
+        // The sponge is borrowed from the caller, so it outlives the rejection half advanced.
+        //
+        // What keeps the verdict safe is that every caller propagates the error:
+        //
+        //     propagate -> the half-advanced sponge is abandoned with the failed verification
+        //     retry     -> the next attempt starts from a state the rejected proof chose
+        //
+        // A retry on this borrow is therefore unsound: it lets a prover pick its own challenges.
         let shape = GenericDegreeShape::new(num_rounds, degree, pow_bits);
         let mut transcript =
             VerifierTranscript::<Challenger, F, EF>::new(challenger, shape, self.claimed_sum);

--- a/sumcheck/src/generic_degree/util.rs
+++ b/sumcheck/src/generic_degree/util.rs
@@ -49,6 +49,8 @@ impl<EF: Field> RoundPolyInterpolator<EF> {
     ///
     /// `h(r)`, computed by barycentric Lagrange interpolation over the precomputed domain.
     pub fn eval(&self, evals: &[EF], sum_constraint: EF, r: EF) -> EF {
+        // Width contract, enforced upstream by the round polynomial's fixed-length step.
+        // A bounded length there would replace that rejection with a silent mis-interpolation.
         debug_assert_eq!(evals.len() + 1, self.x_coords.len());
 
         // Reconstruct the full evaluation vector at the integer nodes 0, 1, …, degree.

--- a/sumcheck/src/layout/prover/mod.rs
+++ b/sumcheck/src/layout/prover/mod.rs
@@ -48,6 +48,15 @@ pub trait Layout<F: Field, EF: ExtensionField<F>>: Sized {
     /// - `witness`                — stacked committed polynomial plus its tables.
     /// - `folding`                — folding factor consumed by the first WHIR round.
     /// - `starting_log_inv_rate`  — initial log-inverse rate of the RS code.
+    ///
+    /// # Transcript
+    ///
+    /// The default body absorbs exactly one value, the Merkle root it returns.
+    ///
+    /// An override owes the sponge that same single absorb, and no other absorb, sample or grind.
+    ///
+    /// A verifier never reaches this method, so it absorbs that one root in its place.
+    /// An absorbed table height would desync the two sides with no step out of place on either.
     fn commit<E, MT, Challenger>(
         encoder: &E,
         mmcs: &MT,

--- a/sumcheck/src/transcript.rs
+++ b/sumcheck/src/transcript.rs
@@ -135,8 +135,14 @@ impl SumcheckShape {
         //     evaluation basis:  [h(0), h(inf)]
         //     projective basis:  [s(1), s(inf)]
         //
-        // Matching every variant here is what turns a future reading of some other width
-        // into a compile error, rather than a second protocol sharing this description.
+        // Matching every variant forces a new reading to be given a width here.
+        //
+        // That is the whole of what the match buys:
+        //
+        //     another width         -> this line must change, so the description changes
+        //     another step sequence -> a copied arm compiles and shares this description
+        //
+        // Readings that agree on width and sequence are separated only by the instance byte.
         let values_per_round = match self.basis {
             Basis::Evaluation => VALUES_PER_ROUND,
             Basis::Projective => VALUES_PER_ROUND,

--- a/sumcheck/src/zk/mod.rs
+++ b/sumcheck/src/zk/mod.rs
@@ -47,10 +47,29 @@
 //! # Module layout
 //!
 //! - Proof record and mask oracle handle.
-//! - Fiat-Shamir description of one masked batch, driven by all three parties.
+//! - Fiat-Shamir description of one masked batch, driven by every party.
 //! - Prover-side sumcheck with mask sampling and round-polynomial assembly.
 //! - Verifier-side replay with the dropped-coefficient reconstruction.
-//! - Witness-free simulator used to prove honest-verifier zero-knowledge.
+//! - Witness-free simulators, one per prelude, used to prove honest-verifier zero-knowledge.
+//!
+//! # Two preludes, and the scope of each
+//!
+//! A masked batch reaches its target one of two ways, and the description names which:
+//!
+//! ```text
+//!     recorded claims  ->  the target is derived from the claims a verifier recorded
+//!     inherited claim  ->  the target arrives as public input and is bound first
+//! ```
+//!
+//! The composed WHIR pipeline plays the inherited one, at every batch, on both sides.
+//!
+//! The recorded-claims prelude is this crate's own standalone surface instead.
+//! No in-tree pipeline plays it: its entry points serve callers who drive a masked batch directly, and it stays supported on that basis.
+//!
+//! Both preludes carry a witness-free simulator, so neither ships without its zero-knowledge argument.
+//!
+//! Scope, so a future reader can act on it: a third prelude owes a third simulator.
+//! Retiring the recorded-claims prelude means retiring the public entry points that expose it, which is an API decision rather than a change inside this module.
 //!
 //! # Layout coverage
 //!
@@ -68,6 +87,51 @@
 //! A prover treats a violation as its own configuration bug.
 //!
 //! A verifier reports it.
+//!
+//! # Divergences from the paper
+//!
+//! ## `ell_zk >= 3`, against the paper's `ell_zk >= 2`
+//!
+//! The round polynomial here is a product of two multilinears, so it is quadratic in `X`.
+//!
+//! ```text
+//!     h_size = max(ell_zk, 3)
+//!
+//!     ell_zk = 2  ->  mask covers slots 0, 1 only, and slot 2 carries eps * c_inf alone
+//!     ell_zk = 3  ->  mask covers slot 2 as well
+//! ```
+//!
+//! At `ell_zk = 2` the quadratic coefficient would ship unmasked, so the bound is deliberately one higher.
+//!
+//! ## The `aux * 2^{-j}` carry
+//!
+//! An inherited batch adds an auxiliary constant to its target, matching Definition 5.8.
+//!
+//! The carry is the normalisation that makes it behave like a constant function on the cube.
+//!
+//! ```text
+//!     AUX * 2^{-k} at every point of {0,1}^k
+//!
+//!     round-j partial sum  ->  2^{k-j} * AUX * 2^{-k}  =  AUX * 2^{-j}
+//!     cube total           ->  2^{k}   * AUX * 2^{-k}  =  AUX
+//! ```
+//!
+//! Round `j` therefore adds `eps * AUX * 2^{-j}` to its constant slot, and the residual carries `eps * AUX * 2^{-k}`.
+//!
+//! ## Compiled hiding is computational, not perfect
+//!
+//! Lemma 6.4 is proved for an IOR whose masks are oracles, with a simulator answering queried positions.
+//!
+//! ```text
+//!     paper     ->  mask oracle, only the queried positions are ever seen
+//!     this code ->  the whole mask codeword committed under one MMCS root
+//! ```
+//!
+//! A root determines the masks information-theoretically, so indistinguishability of the commits rests on the commitment hiding a high-entropy leaf set.
+//!
+//! Perfect indistinguishability still holds for everything the simulator itself emits.
+//!
+//! This is the standard IOR-to-argument compilation step, not a defect of the construction.
 //!
 //! # References
 //!
@@ -87,6 +151,6 @@ pub use data::{
     mask_residual_covectors, mask_residual_covectors_from_shape,
 };
 pub use prover::{ZkLayout, ZkPrefixProver, ZkProver, ZkSuffixProver, stack_codewords};
-pub use simulator::simulate_classic_unpacked;
+pub use simulator::{simulate_classic_unpacked, simulate_classic_unpacked_claim};
 pub use transcript::{ZkPrelude, ZkProverTranscript, ZkSumcheckShape, ZkVerifierTranscript};
 pub use verifier::ZkVerifier;

--- a/sumcheck/src/zk/simulator.rs
+++ b/sumcheck/src/zk/simulator.rs
@@ -1,4 +1,19 @@
-//! Witness-free simulator for the HVZK sumcheck.
+//! Witness-free simulators for the HVZK sumcheck.
+//!
+//! One per prelude, over the single description every party drives.
+//!
+//! ```text
+//!     recorded claims  ->  mu is derived from the claims a verifier recorded
+//!     inherited claim  ->  mu arrives as public input and is bound first
+//! ```
+//!
+//! Everything after the prelude is prelude-agnostic, so one body plays it for both.
+//!
+//! # Witness-freeness
+//!
+//! Definition 5.8 of eprint 2026/391 makes the sumcheck target public input.
+//!
+//! The inherited entry point therefore takes no verifier at all.
 
 use alloc::vec::Vec;
 
@@ -17,7 +32,124 @@ use super::prover::common::{mask_endpoints, sample_masks};
 use super::transcript::{ZkProverTranscript, ZkSumcheckShape};
 use super::verifier::ZkVerifier;
 
-/// Witness-free HVZK simulator (Lemma 6.4).
+/// Simulate the masking prelude and the round chain of one batch.
+///
+/// The transcript arrives with its prelude already played.
+///
+/// The two entry points reach the target differently, so only what follows is shared.
+///
+/// # Arguments
+///
+/// - `transcript`: driver positioned just after the prelude, and the source of the shape.
+/// - `claimed_sum`: the scalar the batch runs against.
+/// - `encoding`: mask code the masks are drawn from and encoded under.
+/// - `mmcs`: commitment scheme carrying the interleaved mask oracle.
+/// - `rng`: source of the mask messages and of every wire coordinate.
+///
+/// # Returns
+///
+/// - Simulated proof record.
+/// - The batch mask commitment.
+/// - Per-round challenges.
+fn simulate_claim<F, EF, Enc, M, Challenger, R>(
+    transcript: &mut ZkProverTranscript<'_, Challenger, F, EF>,
+    claimed_sum: EF,
+    encoding: &Enc,
+    mmcs: &M,
+    rng: &mut R,
+) -> (ZkSumcheckData<F, EF>, M::Commitment, Point<EF>)
+where
+    F: TranscriptField,
+    EF: ExtensionField<F>,
+    Enc: ZkEncodingWithRandomness<EF>,
+    Enc::Codeword: Matrix<EF>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    R: Rng,
+    StandardUniform: Distribution<EF>,
+{
+    // The shape the driver was seeded with, so the wire width cannot drift from the description.
+    let shape = transcript.shape();
+    let k = shape.num_rounds;
+
+    // Sample, encode and commit the masks (Construction 6.3 step 1 replay).
+    //
+    // Uniform messages give uniform codewords, so the codeword distribution is exactly the prover's.
+    //
+    // The commit is a root over that whole codeword, which fixes the masks information-theoretically.
+    // Indistinguishability of the commits is therefore computational, as the crate's zk module docs record.
+    //
+    // The prover's own helper draws them, so the two draw sequences cannot drift.
+    let (masks, _mask_randomness, (mask_commitment, _prover_data)) =
+        sample_masks::<EF, _, _, _>(k, encoding, mmcs, rng);
+
+    // The endpoint sum via the closed form (Construction 6.3 step 2 replay).
+    //
+    //     mu_tilde = 2^{k-1} * sum_l ( s_l(0) + s_l(1) )
+    //
+    // Byte-equivalent to the honest prover under matched RNG seeds.
+    let (mu_tilde, _endpoints) = mask_endpoints::<EF>(&masks, k);
+
+    // Bind the oracle and mu_tilde, then draw the combining challenge.
+    let eps: EF = transcript.masks(mask_commitment.clone(), mu_tilde);
+
+    // Per-round wire sampling, simulating Construction 6.3 step 4.
+    //
+    // Every coordinate is drawn uniformly over the extension field.
+    //
+    // Wire shape (linear coefficient c_1 dropped):
+    //
+    //     wire_size = max(ell_zk, 3) - 1
+    //
+    //     wire = [ c_0, c_2, c_3, ..., c_d ]
+    let wire_size = shape.wire_len();
+
+    // Output container.
+    //
+    // The metadata fields are populated up front.
+    let mut zk_data = ZkSumcheckData::<F, EF> {
+        mu_tilde,
+        round_coefficients: Vec::with_capacity(k),
+        pow_witnesses: Vec::with_capacity(if shape.pow_bits > 0 { k } else { 0 }),
+    };
+
+    // Per-round challenges and running target mirroring the verifier.
+    let mut randomness: Vec<EF> = Vec::with_capacity(k);
+    let mut target: EF = eps * claimed_sum + mu_tilde;
+
+    for _ in 0..k {
+        // Every wire coordinate is uniform over the full extension field (Lemma 6.4 with `F := EF`).
+        let wire: Vec<EF> = (0..wire_size).map(|_| rng.random::<EF>()).collect();
+
+        // One call binds the wire, grinds when enabled, and draws the challenge.
+        let (gamma_j, witness) = transcript.round(&wire);
+        zk_data.pow_witnesses.extend(witness);
+
+        // Reconstruct c_1:
+        //
+        //     2 * c_0 + c_1 + sum_{i>=2} c_i = target
+        //     => c_1 = target - 2 * c_0 - sum_{i>=2} c_i
+        let c0 = wire[0];
+        let high_sum: EF = wire[1..].iter().copied().sum();
+        let c1 = target - c0.double() - high_sum;
+
+        // Horner-evaluate h_j at gamma_j to derive the next target:
+        //
+        //     h_j(gamma) = c_0 + gamma * (c_1 + gamma * (c_2 + ... + gamma * c_d))
+        target = core::iter::once(c0)
+            .chain(core::iter::once(c1))
+            .chain(wire[1..].iter().copied())
+            .horner(gamma_j);
+
+        // Record wire and challenge.
+        zk_data.round_coefficients.push(wire);
+        randomness.push(gamma_j);
+    }
+
+    (zk_data, mask_commitment, Point::new(randomness))
+}
+
+/// Witness-free HVZK simulator over the claims a verifier recorded (Lemma 6.4).
 ///
 /// Produces a transcript indistinguishable from the honest prover's view by reading only the verifier's recorded claims; never the witness itself.
 ///
@@ -35,7 +167,7 @@ use super::verifier::ZkVerifier;
 /// It runs over the prover's own mask helpers, not a copy of them.
 ///
 /// ```text
-///     shape    ->  ZkSumcheckShape::new_batching, exactly as the layout prover builds it
+///     shape    ->  the batching description, exactly as the layout prover builds it
 ///     prelude  ->  the same drawn batching challenge
 ///     masks    ->  sample_masks, then mask_endpoints
 ///     rounds   ->  the same wire, grinding and challenge steps
@@ -67,7 +199,6 @@ use super::verifier::ZkVerifier;
 /// # Panics
 ///
 /// When the configuration cannot describe a masked batch, exactly as the prover panics.
-#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 pub fn simulate_classic_unpacked<F, EF, Enc, M, Challenger, R>(
     challenger: &mut Challenger,
     verifier: &ZkVerifier<F, EF>,
@@ -87,19 +218,15 @@ where
     R: Rng,
     StandardUniform: Distribution<EF>,
 {
-    // Protocol shape.
-    let k = folding_factor;
-    let ell_zk = encoding.message_len();
-
     // The same description the layout prover builds from the same three numbers.
-    let shape = ZkSumcheckShape::new_batching(k, ell_zk, pow_bits);
+    let shape = ZkSumcheckShape::new_batching(folding_factor, encoding.message_len(), pow_bits);
     shape
         .validate::<F>()
         .expect("a simulator's own configuration must describe a masked batch");
 
     let mut transcript = ZkProverTranscript::<Challenger, F, EF>::new(challenger, shape);
 
-    // Phase 1: draw alpha and derive mu (replays Construction 6.3 prelude).
+    // Draw alpha and derive mu (replays the Construction 6.3 prelude of the layout path).
     //
     // Honest prover's transcript order after the claim phase:
     //
@@ -109,86 +236,118 @@ where
     let alpha: EF = transcript.batching_challenge();
     let mu = verifier.sum(alpha);
 
-    // Phase 2: sample, encode and commit the masks (Construction 6.3 step 1 replay).
-    //
-    // Uniform messages produce uniform Reed-Solomon codewords.
-    // Their Merkle commits are indistinguishable from the honest prover's (zero simulator error for RS).
-    //
-    // The prover's own helper draws them, so the two draw sequences cannot drift.
-    let (masks, _mask_randomness, (mask_commitment, _prover_data)) =
-        sample_masks::<EF, _, _, _>(k, encoding, mmcs, rng);
-
-    // Phase 3: mu_tilde via the closed form (Construction 6.3 step 2 replay).
-    //
-    //     mu_tilde = 2^{k-1} * sum_l ( s_l(0) + s_l(1) )
-    //
-    // Byte-equivalent to the honest prover under matched RNG seeds.
-    let (mu_tilde, _endpoints) = mask_endpoints::<EF>(&masks, k);
-
-    // Bind the oracle and mu_tilde, then draw the combining challenge.
-    let eps: EF = transcript.masks(mask_commitment.clone(), mu_tilde);
-
-    // Phase 4: per-round wire sampling (Construction 6.3 step 4 simulated; every coordinate uniform over EF).
-    //
-    // Wire shape (linear coefficient c_1 dropped):
-    //
-    //     wire_size = max(ell_zk, 3) - 1
-    //
-    //     wire = [ c_0, c_2, c_3, ..., c_d ]
-    let wire_size = shape.wire_len();
-
-    // Output container; metadata fields populated up front.
-    let mut zk_data = ZkSumcheckData::<F, EF> {
-        mu_tilde,
-        round_coefficients: Vec::with_capacity(k),
-        pow_witnesses: Vec::with_capacity(if pow_bits > 0 { k } else { 0 }),
-    };
-
-    // Per-round challenges and running target mirroring the verifier.
-    let mut randomness: Vec<EF> = Vec::with_capacity(k);
-    let mut target: EF = eps * mu + mu_tilde;
-
-    for _ in 0..k {
-        // Every wire coordinate is uniform over the full extension field
-        // (Lemma 6.4 with `F := EF`).
-        let wire: Vec<EF> = (0..wire_size).map(|_| rng.random::<EF>()).collect();
-
-        // One call binds the wire, grinds when enabled, and draws the challenge.
-        let (gamma_j, witness) = transcript.round(&wire);
-        zk_data.pow_witnesses.extend(witness);
-
-        // Reconstruct c_1:
-        //
-        //     2 * c_0 + c_1 + sum_{i>=2} c_i = target
-        //     => c_1 = target - 2 * c_0 - sum_{i>=2} c_i
-        let c0 = wire[0];
-        let high_sum: EF = wire[1..].iter().copied().sum();
-        let c1 = target - c0.double() - high_sum;
-
-        // Horner-evaluate h_j at gamma_j to derive the next target:
-        //
-        //     h_j(gamma) = c_0 + gamma * (c_1 + gamma * (c_2 + ... + gamma * c_d))
-        target = core::iter::once(c0)
-            .chain(core::iter::once(c1))
-            .chain(wire[1..].iter().copied())
-            .horner(gamma_j);
-
-        // Record wire and challenge.
-        zk_data.round_coefficients.push(wire);
-        randomness.push(gamma_j);
-    }
+    let simulated = simulate_claim(&mut transcript, mu, encoding, mmcs, rng);
 
     // Every described step has been played, so the sponge goes back to the caller.
     transcript.finish();
 
-    (zk_data, mask_commitment, Point::new(randomness))
+    simulated
+}
+
+/// Witness-free HVZK simulator over a claim the batch inherits (Lemma 6.4).
+///
+/// This is the prelude the residual prover plays, and so the one a WHIR round ships.
+///
+/// # Public input
+///
+/// The target is a parameter, matching Definition 5.8 of eprint 2026/391.
+///
+/// ```text
+///     paper       ->  mu = <f, sl(st)> + sum_i <xi_i, sl_i(st_i)>
+///     this crate  ->  claimed_sum + aux_claim, the scalar the prover binds
+/// ```
+///
+/// Nothing else about the instance is read, so this entry point takes no verifier.
+///
+/// # Method
+///
+/// - Bind the inherited claim, exactly where the prover binds it.
+/// - Sample and commit fresh masks just like the prover.
+/// - Sample each wire coordinate uniformly over `EF` (the honest joint distribution).
+/// - Reconstruct the dropped `c_1` from the affine identity, so every simulated wire verifies by construction.
+///
+/// # Why the auxiliary constant needs no separate treatment
+///
+/// It is constant in `X` and independent of the masks.
+///
+/// ```text
+///     aux * 2^{-j}  ->  summed into the constant slot before masking
+///     rank of the linear map on the witness  ->  unchanged
+/// ```
+///
+/// So it lands in the affine offset the target already carries.
+///
+/// # Arguments
+///
+/// - `challenger`: sponge of the surrounding protocol, driven to the pre-batch state.
+/// - `claimed_sum`: the scalar the batch runs against, matching what the prover binds.
+/// - `folding_factor`: number of rounds the batch runs.
+/// - `pow_bits`: grinding difficulty per round, or zero to omit grinding.
+/// - `encoding`: mask code the masks are drawn from and encoded under.
+/// - `mmcs`: commitment scheme carrying the interleaved mask oracle.
+/// - `rng`: source of the mask messages and of every wire coordinate.
+///
+/// # Scope
+///
+/// Same as the recorded-claims entry point: one Construction 6.3 batch, not the composed HVZK-WHIR protocol.
+///
+/// The mask oracle's prover data is discarded, so the mask messages and encoding randomness are not returned.
+///
+/// # Returns
+///
+/// - Simulated transcript.
+/// - The batch mask commitment.
+/// - Per-round challenges.
+///
+/// # Panics
+///
+/// When the configuration cannot describe a masked batch, exactly as the prover panics.
+pub fn simulate_classic_unpacked_claim<F, EF, Enc, M, Challenger, R>(
+    challenger: &mut Challenger,
+    claimed_sum: EF,
+    folding_factor: usize,
+    pow_bits: usize,
+    encoding: &Enc,
+    mmcs: &M,
+    rng: &mut R,
+) -> (ZkSumcheckData<F, EF>, M::Commitment, Point<EF>)
+where
+    F: TranscriptField,
+    EF: ExtensionField<F>,
+    Enc: ZkEncodingWithRandomness<EF>,
+    Enc::Codeword: Matrix<EF>,
+    M: Mmcs<EF>,
+    Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
+    R: Rng,
+    StandardUniform: Distribution<EF>,
+{
+    // The same description the residual prover builds from the same three numbers.
+    let shape = ZkSumcheckShape::new_inherited(folding_factor, encoding.message_len(), pow_bits);
+    shape
+        .validate::<F>()
+        .expect("a simulator's own configuration must describe a masked batch");
+
+    let mut transcript = ZkProverTranscript::<Challenger, F, EF>::new(challenger, shape);
+
+    // The claim opens the description, ahead of the masking prelude.
+    //
+    //     claim  ->  mask commit  ->  mu_tilde  ->  eps  ->  wires
+    transcript.bind_claim(claimed_sum);
+
+    let simulated = simulate_claim(&mut transcript, claimed_sum, encoding, mmcs, rng);
+
+    // Every described step has been played, so the sponge goes back to the caller.
+    transcript.finish();
+
+    simulated
 }
 
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
 
-    use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing};
+    use p3_field::{BasedVectorSpace, Field, PackedValue, PrimeCharacteristicRing, dot_product};
+    use p3_multilinear_util::poly::Poly;
     use p3_zk_codes::ZkEncoding;
     use proptest::prelude::*;
     use rand::rngs::SmallRng;
@@ -196,7 +355,8 @@ mod tests {
 
     use super::*;
     use crate::layout::TableShape;
-    use crate::strategy::VariableOrder;
+    use crate::product_polynomial::ProductPolynomial;
+    use crate::strategy::{SumcheckProver, VariableOrder};
     use crate::zk::ZkVerifier;
     use crate::zk::test_helpers::{EF, F, MyChallenger, MyMmcs, make_setup, run_prover};
 
@@ -221,6 +381,16 @@ mod tests {
     /// 4. The mask encoding's own simulator returns the correct shape (RS simulator error = 0).
     ///
     /// The binding parameter only affects the real run; the simulator output depends only on the wire schema, which both binding modes share.
+    ///
+    /// Check 3 reads the band above the two plain-bearing slots, which the wire width decides:
+    ///
+    /// ```text
+    ///     ell_zk = 3  ->  wire_len = 2, so the band is empty and check 3 reads nothing
+    ///     ell_zk > 3  ->  wire_len = ell_zk - 1, so the band is ell_zk - 3 wide
+    /// ```
+    ///
+    /// The shortest legal mask is therefore a case check 3 cannot fail on.
+    /// The proptests below draw above it, and a test of its own covers the floor.
     fn run_acceptance_and_mask_prelude_coupling(
         binding: VariableOrder,
         n_vars: usize,
@@ -371,7 +541,7 @@ mod tests {
         #[test]
         fn prop_simulator_accepts_and_couples_mask_prelude_rs_prefix(
             n_vars in 3usize..=8,
-            ell_zk in 3usize..=5,
+            ell_zk in 4usize..=5,
             num_eqs in 1usize..=3,
             seed in 0u64..1024,
         ) {
@@ -381,6 +551,9 @@ mod tests {
             //
             // Per-case invariants pinned by
             // run_acceptance_and_mask_prelude_coupling (see docstring).
+            //
+            // Why ell_zk >= 4: lengths 2 and 3 both give a 2-coordinate wire, on which the driver's check 3 reads nothing.
+            // The shortest legal mask is covered by a test of its own instead.
 
             // Compression step requires the folded polynomial to retain at
             // least one full packed lane. Packing width depends on the ISA.
@@ -403,13 +576,15 @@ mod tests {
         #[test]
         fn prop_simulator_accepts_and_couples_mask_prelude_rs_suffix(
             n_vars in 3usize..=8,
-            ell_zk in 3usize..=5,
+            ell_zk in 4usize..=5,
             num_eqs in 1usize..=3,
             seed in 0u64..1024,
         ) {
             // Same invariant on the suffix path. Suffix mode never packs
             // the residual factor, so the parameter window is wider:
             // folding can go up to `n_vars - 1` instead of `n_vars - k_pack`.
+            //
+            // The mask length starts at 4 for the same reason as the prefix draw above.
             let folding_factor = 1 + (seed as usize % (n_vars - 1).max(1));
 
             prop_assert!(
@@ -564,14 +739,22 @@ mod tests {
     ///
     /// Reads nothing but the description and the values the batch bound.
     /// Returns the per-round challenges the driver draws.
+    ///
+    /// `claim` selects the prelude: `None` draws the batching challenge, `Some` binds the inherited scalar.
     fn replay_through_the_description(
         challenger: &mut MyChallenger,
         shape: ZkSumcheckShape,
+        claim: Option<EF>,
         mask_commitment: <MyMmcs as Mmcs<EF>>::Commitment,
         zk_data: &ZkSumcheckData<F, EF>,
     ) -> Vec<EF> {
         let mut transcript = ZkProverTranscript::<MyChallenger, F, EF>::new(challenger, shape);
-        let _alpha = transcript.batching_challenge();
+        match claim {
+            None => {
+                let _alpha: EF = transcript.batching_challenge();
+            }
+            Some(claim) => transcript.bind_claim(claim),
+        }
         let _eps = transcript.masks(mask_commitment, zk_data.mu_tilde);
         let gammas = zk_data
             .round_coefficients
@@ -635,6 +818,7 @@ mod tests {
             replay_through_the_description(
                 &mut real_replay_ch,
                 shape,
+                None,
                 real_run.mask_commitment.clone(),
                 &real_run.zk_data,
             ),
@@ -667,6 +851,7 @@ mod tests {
             replay_through_the_description(
                 &mut sim_replay_ch,
                 shape,
+                None,
                 sim_commitment.clone(),
                 &sim_zk_data,
             ),
@@ -728,5 +913,468 @@ mod tests {
                 &mut verifier_challenger,
             )
             .expect("verifier must accept the simulator's PoW witnesses");
+    }
+
+    /// Acceptance, mask-prelude coupling and wire-shape driver for the inherited-claim prelude.
+    ///
+    /// # Invariants per `(order, n_vars, folding, ell_zk, aux)` case
+    ///
+    /// 1. The verifier accepts both the residual prover's and the simulator's transcript.
+    /// 2. Each side's challenge stream is the one the verifier redraws from the claim it was handed.
+    /// 3. `mu_tilde` and the mask commit match bit-for-bit under matched seeds (deterministic equality, not a distributional test).
+    /// 4. The simulated record has one wire of width `max(ell_zk, 3) - 1` per round, and no grinding witness.
+    /// 5. Wire coordinates with index `>= 2` escape the base-field subspace on both sides.
+    ///
+    /// Check 2 is what a wrong bound claim trips.
+    ///
+    /// Check 5 reads the band above the two plain-bearing slots, which the wire width decides:
+    ///
+    /// ```text
+    ///     ell_zk = 3  ->  wire_len = 2, so the band is empty and check 5 reads nothing
+    ///     ell_zk > 3  ->  wire_len = ell_zk - 1, so the band is ell_zk - 3 wide
+    /// ```
+    ///
+    /// The shortest legal mask is therefore a case check 5 cannot fail on.
+    /// The proptest below draws above it, and a test of its own covers the floor.
+    ///
+    /// Grinding is off here, so the replay accepts any well-shaped record and only the redrawn stream moves.
+    ///
+    /// The simulator receives the target as public input and no verifier at all.
+    #[allow(clippy::too_many_arguments)]
+    fn run_inherited_acceptance_and_mask_prelude_coupling(
+        order: VariableOrder,
+        n_vars: usize,
+        folding_factor: usize,
+        ell_zk: usize,
+        aux_claim: EF,
+        seed: u64,
+    ) -> Result<(), &'static str> {
+        let pow_bits = 0;
+
+        // Honest arm: a product polynomial and the claim it really sums to.
+        let mut data_rng = SmallRng::seed_from_u64(seed.wrapping_add(1));
+        let evals = Poly::<EF>::rand(&mut data_rng, n_vars);
+        let weights = Poly::<EF>::rand(&mut data_rng, n_vars);
+        let claimed_sum = dot_product::<EF, _, _>(
+            evals.as_slice().iter().copied(),
+            weights.as_slice().iter().copied(),
+        );
+
+        // The scalar both sides bind, and the only instance data the simulator reads:
+        //
+        //     joint_claim = <f, w> + aux
+        let joint_claim = claimed_sum + aux_claim;
+
+        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+        let poly = ProductPolynomial::<F, EF>::new_unpacked(order, evals, weights);
+
+        let mut real_ch = MyChallenger::new(perm.clone());
+        let mut real_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let mut zk_data_real = ZkSumcheckData::<F, EF>::default();
+        let real_handoff = SumcheckProver::new(poly, claimed_sum).into_zk_sumcheck(
+            &mut zk_data_real,
+            &encoding,
+            &mmcs,
+            folding_factor,
+            pow_bits,
+            aux_claim,
+            &mut real_ch,
+            &mut real_rng,
+        );
+        let commitment_real = real_handoff.mask_oracle.0.clone();
+
+        // Honest verifier replay of the residual arm.
+        let mut real_verifier_ch = MyChallenger::new(perm.clone());
+        let real_replay = ZkVerifier::<F, EF>::verify_claim::<MyMmcs, _>(
+            &zk_data_real,
+            &commitment_real,
+            ell_zk,
+            folding_factor,
+            pow_bits,
+            joint_claim,
+            &mut real_verifier_ch,
+        )
+        .map_err(|_| "real residual transcript rejected by verifier")?;
+        if real_replay.randomness != real_handoff.randomness {
+            return Err("verifier redrew a different stream than the residual prover's");
+        }
+
+        // === Simulator run (matched mask-RNG seed) ===
+        //
+        // Same fresh sponge state, same encoding, same commitment scheme.
+        let mut sim_ch = MyChallenger::new(perm.clone());
+        let mut sim_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let (zk_data_sim, commitment_sim, gammas_sim) =
+            simulate_classic_unpacked_claim::<F, EF, _, _, _, _>(
+                &mut sim_ch,
+                joint_claim,
+                folding_factor,
+                pow_bits,
+                &encoding,
+                &mmcs,
+                &mut sim_rng,
+            );
+
+        let mut sim_verifier_ch = MyChallenger::new(perm);
+        let sim_replay = ZkVerifier::<F, EF>::verify_claim::<MyMmcs, _>(
+            &zk_data_sim,
+            &commitment_sim,
+            ell_zk,
+            folding_factor,
+            pow_bits,
+            joint_claim,
+            &mut sim_verifier_ch,
+        )
+        .map_err(|_| "simulator transcript rejected by verifier")?;
+        if sim_replay.randomness != gammas_sim {
+            return Err("verifier redrew a different stream than the simulator's");
+        }
+
+        // === Coupling certificate ===
+
+        if zk_data_real.mu_tilde != zk_data_sim.mu_tilde {
+            return Err("matched-RNG coupling: mu_tilde differs");
+        }
+        if commitment_real != commitment_sim {
+            return Err("matched-RNG coupling: mask commitment differs");
+        }
+
+        // === Wire shape ===
+        //
+        //     wire_len = max(ell_zk, 3) - 1
+        let wire_len = ell_zk.max(3) - 1;
+        if zk_data_sim.round_coefficients.len() != folding_factor {
+            return Err("simulator emitted a wire count other than the round count");
+        }
+        if gammas_sim.as_slice().len() != folding_factor {
+            return Err("simulator emitted a challenge count other than the round count");
+        }
+        if zk_data_sim
+            .round_coefficients
+            .iter()
+            .any(|wire| wire.len() != wire_len)
+        {
+            return Err("simulator emitted a wire of the wrong width");
+        }
+        if !zk_data_sim.pow_witnesses.is_empty() {
+            return Err("simulator emitted a grinding witness with pow_bits == 0");
+        }
+
+        // === Extension-valued wires on both sides ===
+        //
+        // The masks are extension-valued, so every wire coordinate is uniform over EF.
+        //
+        // The index-`>= 2` coordinates are mask-only.
+        // An `F`-valued mask would pin them to the base field and reintroduce the witness leak.
+        for wire in &zk_data_real.round_coefficients {
+            for &c in wire.iter().skip(2) {
+                if !escapes_f_subspace(c) {
+                    return Err("residual-prover wire[i >= 2] collapsed into the F-subspace");
+                }
+            }
+        }
+        for wire in &zk_data_sim.round_coefficients {
+            for &c in wire.iter().skip(2) {
+                if !escapes_f_subspace(c) {
+                    return Err("simulator wire[i >= 2] collapsed into the F-subspace");
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn prop_inherited_simulator_accepts_and_couples_mask_prelude_rs(
+            n_vars in 2usize..=8,
+            ell_zk in 4usize..=5,
+            order_bit in 0usize..2,
+            seed in 0u64..1024,
+        ) {
+            // Invariant: on the prelude a WHIR round plays, both transcripts verify.
+            //
+            // Their mask preludes also couple value for value under matched RNG seeds.
+            //
+            // Per-case invariants are pinned by the driver's docstring.
+            //
+            // Why ell_zk >= 4: lengths 2 and 3 both give a 2-coordinate wire, on which the driver's check 5 reads nothing.
+            // The shortest legal mask is covered by a test of its own instead.
+            //
+            // Fixture state: no auxiliary claim.
+            //
+            // A live carry is exercised by a test of its own.
+            //
+            // The residual arm never packs, so folding may reach every variable.
+            let folding_factor = 1 + (seed as usize % n_vars);
+            let order = if order_bit == 0 {
+                VariableOrder::Prefix
+            } else {
+                VariableOrder::Suffix
+            };
+
+            prop_assert!(
+                run_inherited_acceptance_and_mask_prelude_coupling(
+                    order,
+                    n_vars,
+                    folding_factor,
+                    ell_zk,
+                    EF::ZERO,
+                    seed,
+                ).is_ok()
+            );
+        }
+    }
+
+    #[test]
+    fn both_simulators_hold_at_the_shortest_legal_mask() {
+        // Invariant: the shortest mask a batch may run under still accepts and still couples.
+        //
+        // Fixture state: ell_zk = 3, 8 variables, 2 rounds, both binding orders, no auxiliary claim.
+        //
+        //     wire_len = max(3, 3) - 1 = 2
+        //
+        // The wire is the two plain-bearing slots alone, so the mask-only band above them is empty.
+        // Both drivers' stratification check therefore reads no coordinate at this length.
+        // What this pins is acceptance, the redrawn challenge stream, and the matched-seed coupling.
+        //
+        // The proptests draw from 4 so that band always has work.
+        // This is the case that keeps the floor covered while they do.
+        let ell_zk = 3;
+        let n_vars = 8;
+        let folding_factor = 2;
+        let seed = 0xF10;
+
+        for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
+            let batching = run_acceptance_and_mask_prelude_coupling(
+                order,
+                n_vars,
+                folding_factor,
+                ell_zk,
+                1,
+                seed,
+            );
+            assert_eq!(
+                batching,
+                Ok(()),
+                "recorded-claims prelude, order = {order:?}: {}",
+                batching.err().unwrap_or_default(),
+            );
+
+            let inherited = run_inherited_acceptance_and_mask_prelude_coupling(
+                order,
+                n_vars,
+                folding_factor,
+                ell_zk,
+                EF::ZERO,
+                seed,
+            );
+            assert_eq!(
+                inherited,
+                Ok(()),
+                "inherited-claim prelude, order = {order:?}: {}",
+                inherited.err().unwrap_or_default(),
+            );
+        }
+    }
+
+    #[test]
+    fn the_inherited_simulator_runs_against_a_non_zero_auxiliary_claim() {
+        // Invariant: the auxiliary constant is part of the public target, not a second input.
+        //
+        // Definition 5.8 of eprint 2026/391 puts it inside `mu`:
+        //
+        //     mu = <f, sl(st)> + sum_i <xi_i, sl_i(st_i)>
+        //        = claimed_sum + aux
+        //
+        // WHIR's per-round call site passes a running mask-claim total there.
+        // The deployed simulator therefore has to hold with the constant switched on.
+        //
+        // It is constant in X and independent of the masks.
+        // So it rides the affine offset and never reaches the linear map on the witness.
+        //
+        // Fixture state: 6 variables, 3 rounds, mask length 4, both binding orders.
+        //
+        //     aux = 1           ->  smallest live carry
+        //     aux = 7           ->  the value the honest-side deferred-binding test uses
+        //     aux = 12345       ->  an arbitrary interior value
+        //     aux = 2013265920  ->  p - 1 for p = 2^{31} - 2^{27} + 1, the largest element
+        let n_vars = 6;
+        let folding_factor = 3;
+        let ell_zk = 4;
+
+        for aux in [1u64, 7, 12_345, 2_013_265_920] {
+            for order in [VariableOrder::Prefix, VariableOrder::Suffix] {
+                let aux_claim = EF::from_u64(aux);
+                assert_ne!(
+                    aux_claim,
+                    EF::ZERO,
+                    "the fixture must exercise a live carry"
+                );
+
+                let outcome = run_inherited_acceptance_and_mask_prelude_coupling(
+                    order,
+                    n_vars,
+                    folding_factor,
+                    ell_zk,
+                    aux_claim,
+                    0x5EED + aux,
+                );
+                assert_eq!(
+                    outcome,
+                    Ok(()),
+                    "aux = {aux}, order = {order:?}: {}",
+                    outcome.err().unwrap_or_default(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn the_inherited_simulator_and_the_residual_prover_play_one_description() {
+        // Invariant: honest-verifier zero knowledge needs both parties on one step sequence.
+        //
+        // This is the inherited-claim prelude.
+        // The description therefore opens by binding the scalar rather than by drawing a challenge.
+        //
+        //     party      | bound values                                  | stream
+        //     -----------+-----------------------------------------------+---------------
+        //     prover     | joint claim, its commitment, mu_tilde, wires  | its gammas
+        //     simulator  | joint claim, its commitment, mu_tilde, wires  | its gammas
+        //
+        // A step either party played out of order would panic the bare driver, or move its stream.
+        //
+        // Fixture state: 6 variables, 2 rounds, mask length 4, aux = 7, seed = 11.
+        //
+        // PoW is disabled, so the replay draws no witness of its own.
+        let n_vars = 6;
+        let folding_factor = 2;
+        let ell_zk = 4;
+        let pow_bits = 0;
+        let seed = 11u64;
+        let aux_claim = EF::from_u64(7);
+
+        let shape = ZkSumcheckShape::new_inherited(folding_factor, ell_zk, pow_bits);
+
+        let mut data_rng = SmallRng::seed_from_u64(seed.wrapping_add(1));
+        let evals = Poly::<EF>::rand(&mut data_rng, n_vars);
+        let weights = Poly::<EF>::rand(&mut data_rng, n_vars);
+        let claimed_sum = dot_product::<EF, _, _>(
+            evals.as_slice().iter().copied(),
+            weights.as_slice().iter().copied(),
+        );
+        let joint_claim = claimed_sum + aux_claim;
+
+        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+        let poly = ProductPolynomial::<F, EF>::new_unpacked(VariableOrder::Prefix, evals, weights);
+
+        // Honest residual run.
+        let mut real_ch = MyChallenger::new(perm.clone());
+        let mut real_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let mut zk_data_real = ZkSumcheckData::<F, EF>::default();
+        let real_handoff = SumcheckProver::new(poly, claimed_sum).into_zk_sumcheck(
+            &mut zk_data_real,
+            &encoding,
+            &mmcs,
+            folding_factor,
+            pow_bits,
+            aux_claim,
+            &mut real_ch,
+            &mut real_rng,
+        );
+        let real_gammas: Vec<EF> = real_handoff.randomness.iter().copied().collect();
+
+        // The residual prover's own stream, reproduced from the description alone.
+        let mut real_replay_ch = MyChallenger::new(perm.clone());
+        assert_eq!(
+            replay_through_the_description(
+                &mut real_replay_ch,
+                shape,
+                Some(joint_claim),
+                real_handoff.mask_oracle.0.clone(),
+                &zk_data_real,
+            ),
+            real_gammas,
+            "the residual prover's stream must come out of the shared description",
+        );
+
+        // Simulator run from an identically seeded sponge.
+        let mut sim_ch = MyChallenger::new(perm.clone());
+        let mut sim_rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let (zk_data_sim, commitment_sim, gammas_sim) =
+            simulate_classic_unpacked_claim::<F, EF, _, _, _, _>(
+                &mut sim_ch,
+                joint_claim,
+                folding_factor,
+                pow_bits,
+                &encoding,
+                &mmcs,
+                &mut sim_rng,
+            );
+
+        // The simulator's own stream, reproduced from the very same description.
+        let mut sim_replay_ch = MyChallenger::new(perm);
+        assert_eq!(
+            replay_through_the_description(
+                &mut sim_replay_ch,
+                shape,
+                Some(joint_claim),
+                commitment_sim.clone(),
+                &zk_data_sim,
+            ),
+            gammas_sim.iter().copied().collect::<Vec<_>>(),
+            "the simulator's stream must come out of the shared description",
+        );
+
+        // Matched RNG seeds, so the masking prelude couples value for value.
+        assert_eq!(zk_data_real.mu_tilde, zk_data_sim.mu_tilde);
+        assert_eq!(real_handoff.mask_oracle.0, commitment_sim);
+
+        // The wires themselves are not equal, and Lemma 6.4 does not claim they are.
+        assert_eq!(
+            zk_data_real.round_coefficients.len(),
+            zk_data_sim.round_coefficients.len(),
+        );
+    }
+
+    #[test]
+    fn the_inherited_simulator_with_pow_replays() {
+        // Invariant: one valid grinding witness per round when the configuration enables PoW.
+        //
+        // Fixture state: 2 rounds, mask length 4, 4 grinding bits, claim = 9, seed = 0x5eed.
+        let seed = 0x5eed;
+        let folding_factor = 2;
+        let ell_zk = 4;
+        let pow_bits = 4;
+        let joint_claim = EF::from_u64(9);
+        let (perm, mmcs, encoding) = make_setup(seed, ell_zk);
+
+        let mut sim_ch = MyChallenger::new(perm.clone());
+        let mut rng = SmallRng::seed_from_u64(seed.wrapping_add(2));
+        let (zk_data, mask_commitment, _) = simulate_classic_unpacked_claim::<F, EF, _, _, _, _>(
+            &mut sim_ch,
+            joint_claim,
+            folding_factor,
+            pow_bits,
+            &encoding,
+            &mmcs,
+            &mut rng,
+        );
+
+        assert_eq!(zk_data.pow_witnesses.len(), folding_factor);
+
+        let mut verifier_ch = MyChallenger::new(perm);
+        ZkVerifier::<F, EF>::verify_claim::<MyMmcs, _>(
+            &zk_data,
+            &mask_commitment,
+            ell_zk,
+            folding_factor,
+            pow_bits,
+            joint_claim,
+            &mut verifier_ch,
+        )
+        .expect("verifier must accept the simulator's PoW witnesses");
     }
 }

--- a/sumcheck/src/zk/transcript.rs
+++ b/sumcheck/src/zk/transcript.rs
@@ -2,7 +2,7 @@
 //!
 //! One description of everything a masked batch absorbs.
 //!
-//! Prover, verifier and simulator all drive that same description.
+//! Both provers, both verifiers and both witness-free simulators drive that same description.
 //!
 //! # Shape
 //!
@@ -38,9 +38,12 @@
 //!
 //! It seeds a transcript of its own from a borrowed sponge, and hands the sponge back.
 //!
-//! The surrounding protocol brackets this run inside its own description.
+//! ```text
+//!     caller's fingerprint  ->  seeded first, and may restate this batch's numbers
+//!     delegation markers    ->  none, so the run is no step of the caller's description
+//! ```
 //!
-//! That is what lets the two descriptions be written independently and still compose.
+//! The two descriptions compose through the order their seeds reach the sponge.
 //!
 //! # What the shape binds
 //!
@@ -65,9 +68,9 @@
 //!
 //! # Simulator
 //!
-//! The witness-free simulator of Lemma 6.4 plays this same description.
+//! The witness-free simulators of Lemma 6.4 play this same description, one per prelude.
 //!
-//! Hiding holds only while its transcript is indistinguishable from the prover's.
+//! Hiding holds only while a simulator's transcript is indistinguishable from its prover's.
 //!
 //! A divergence between the two is a loud pattern failure here, not a silent loss of hiding.
 
@@ -419,6 +422,15 @@ where
         }
     }
 
+    /// The numbers this batch was described with.
+    ///
+    /// Seeding consumed them, so the driver holds the only copy that matches the sponge.
+    /// A helper reads them here rather than taking a second copy it cannot check.
+    #[must_use]
+    pub const fn shape(&self) -> ZkSumcheckShape {
+        self.shape
+    }
+
     /// Draw the challenge that weights the claims a layout recorded.
     ///
     /// # Panics
@@ -563,6 +575,14 @@ where
         }
     }
 
+    /// The numbers this batch was described with.
+    ///
+    /// Mirrors the prover-side accessor, so the shared replay body reads either side the same way.
+    #[must_use]
+    pub const fn shape(&self) -> ZkSumcheckShape {
+        self.shape
+    }
+
     /// Draw the challenge that weights the claims this verifier recorded.
     ///
     /// # Panics
@@ -678,6 +698,18 @@ where
             .state
             .challenge_extension::<F, EF, FieldToFieldCodec<F>>(ROUND_CHALLENGE)
             .into_inner())
+    }
+
+    /// Release the completeness check without playing the steps that remain.
+    ///
+    /// A caller that rejects a proof part-way through the description calls this.
+    ///
+    /// The check is there to catch a description left half-played by mistake.
+    /// A rejection is not that, and its drop-time panic would bury the rejection.
+    ///
+    /// Idempotent, so a step that already released the check may be aborted again.
+    pub fn abort(&mut self) {
+        self.state.abort();
     }
 
     /// Close the transcript once every described step has been played.

--- a/sumcheck/src/zk/verifier.rs
+++ b/sumcheck/src/zk/verifier.rs
@@ -128,10 +128,9 @@ where
     ///
     /// # Arguments
     ///
-    /// - `transcript`: driver positioned just after the prelude.
+    /// - `transcript`: driver positioned just after the prelude, and the source of the shape.
     /// - `zk_data`: the proof record, already counted against the shape.
     /// - `mask_commitment`: the batch's interleaved mask oracle.
-    /// - `shape`: the numbers the description was built from.
     /// - `claimed_sum`: the scalar the batch runs against.
     ///
     /// # Errors
@@ -141,7 +140,6 @@ where
         transcript: &mut ZkVerifierTranscript<'_, Ch, F, EF>,
         zk_data: &ZkSumcheckData<F, EF>,
         mask_commitment: &M::Commitment,
-        shape: ZkSumcheckShape,
         claimed_sum: EF,
     ) -> Result<ZkVerifierHandoff<EF>, SumcheckError>
     where
@@ -149,6 +147,9 @@ where
         M: Mmcs<EF>,
         Ch: FieldChallenger<F> + GrindingChallenger<Witness = F> + CanObserve<M::Commitment>,
     {
+        // The shape the driver was seeded with, so the round count cannot drift from the description.
+        let shape = transcript.shape();
+
         let eps = transcript.masks(mask_commitment.clone(), zk_data.mu_tilde);
 
         let mut target: EF = eps * claimed_sum + zk_data.mu_tilde;
@@ -288,8 +289,10 @@ where
         let mu = self.inner.sum(alpha);
 
         // Phase 3: bind the mask oracle and mu_tilde, draw eps, and walk the round chain.
-        let handoff =
-            Self::replay_claim::<M, _>(&mut transcript, zk_data, mask_commitment, shape, mu)?;
+        //
+        // A rejection releases the driver here rather than relying on the step that raised it.
+        let handoff = Self::replay_claim::<M, _>(&mut transcript, zk_data, mask_commitment, mu)
+            .inspect_err(|_| transcript.abort())?;
 
         // Every described step was replayed, so the sponge goes back to the caller.
         transcript.finish();
@@ -357,13 +360,10 @@ where
         let mut transcript = ZkVerifierTranscript::<Ch, F, EF>::new(challenger, shape);
         transcript.bind_claim(claimed_sum);
 
-        let handoff = Self::replay_claim::<M, _>(
-            &mut transcript,
-            zk_data,
-            mask_commitment,
-            shape,
-            claimed_sum,
-        )?;
+        // A rejection releases the driver here rather than relying on the step that raised it.
+        let handoff =
+            Self::replay_claim::<M, _>(&mut transcript, zk_data, mask_commitment, claimed_sum)
+                .inspect_err(|_| transcript.abort())?;
 
         transcript.finish();
 

--- a/uni-stark/src/transcript.rs
+++ b/uni-stark/src/transcript.rs
@@ -677,6 +677,7 @@ where
 
 /// A transcript step the proof failed to satisfy.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Error)]
+#[non_exhaustive]
 pub enum StarkTranscriptFailure {
     /// The described preprocessed-commitment step arrived with no commitment.
     #[error(

--- a/whir/src/pcs/zk/tests.rs
+++ b/whir/src/pcs/zk/tests.rs
@@ -660,9 +660,13 @@ fn zk_whir_conditioned_witness_round_trip_accepts() {
     //
     // The per-component simulation tests live where the masks are drawn:
     //
-    //     masked sumcheck wires  ->  p3-sumcheck simulator tests
+    //     masked sumcheck wires  ->  p3-sumcheck inherited-claim simulator tests
     //     private OOD answers    ->  code_switch programmability tests
     //     one-time-pad reveals   ->  base case OTP test
+    //
+    // Every batch here inherits its claim, so the inherited-claim simulator covers these wires.
+    //
+    // The recorded-claims one plays a prelude no WHIR round reaches.
     let num_variables = 12;
     let mut rng = SmallRng::seed_from_u64(21);
 

--- a/whir/src/transcript/mod.rs
+++ b/whir/src/transcript/mod.rs
@@ -630,6 +630,7 @@ impl WhirShape {
 
 /// A transcript step the proof failed to satisfy.
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum TranscriptFailure {
     /// A grinding witness did not meet the difficulty its step requires.
     #[error("round {round}: query grinding witness clears fewer than {bits} bits")]

--- a/whir/src/transcript/zk.rs
+++ b/whir/src/transcript/zk.rs
@@ -440,6 +440,10 @@ impl ZkWhirShape {
         Challenger: FieldChallenger<F> + GrindingChallenger<Witness = F>,
     {
         // Every masked batch sends the same wire width.
+        //
+        // The sumcheck crate derives the same number from the same input, so this is a copy.
+        // Both sides of this pipeline seed from this one, so the copy cannot desync them.
+        // Drift would instead leave the fingerprint describing steps the run no longer takes.
         let wire_len = config.zk.ell_zk.max(3) - 1;
 
         // Each round queries its own domain, folded by that round's arity.
@@ -512,6 +516,12 @@ impl ZkWhirShape {
     }
 
     /// Describe the transcript this shape fixes.
+    ///
+    /// # Scope
+    ///
+    /// The description reaches the sponge as a seed fingerprint, and no driver plays it.
+    ///
+    /// Every phase is a leaf step, so the delegations to the sumcheck batches carry no markers.
     ///
     /// # Panics
     ///


### PR DESCRIPTION
Addresses every non-blocking follow-up from the reviews of the typed-transcript stack (#2081, #2102, #2103, #2105, #2106, #2107, #2109), plus the one piece the hiding-sumcheck review turned up as genuinely missing.

The stack's branches were deleted at merge before these landed, so none of it is in `main` today. One PR rather than several: only the simulator is new functionality, and it turned out to be additive with no soundness question attached.

## The one behaviour change

The multi-STARK verifier deferred **both** opening errors to reach the driver's completeness check. So a proof with a bad main opening still executed the preprocessed verification, against attacker-supplied `proof.preprocessed_opening`, with a challenger in a state no honest run produces — roughly doubling verifier work on the rejecting path for any batch with preprocessed columns.

The main opening now releases the driver and returns, exactly as the lookup and zerocheck arms already did. The verdict is unchanged.

Pinned by a counting configuration that records every hand-out of the preprocessed scheme. Restoring the old flow:

```
assertion `left == right` failed
  left: 1
 right: 0
```

## Two contracts, written where an implementor reads them

Declining to hoist the main-commitment absorb out of the commitment scheme rested on a property the trait never stated: **a commit phase absorbs exactly the commitment it returns, and does nothing else.** An out-of-tree implementation that absorbed a table height or drew a batching challenge would compile, satisfy the pattern on both sides, and desync as an unexplained completeness failure.

That obligation is now on the multilinear commit method. It is also on the layout commit default body, which is where the guarantee actually lives for two of the three in-tree implementations — a `Layout` override could have broken both PCSs without either PCS file changing.

I considered adding a `CanObserve<Self::Commitment>` bound and **declined**, having measured it: 34 errors, the decisive one being that `MultiStarkProof`'s derived serde would have to prove a challenger can observe a commitment. And the prescribed-point opening sub-trait already requires it where the bracket is actually played. A bound cannot express "one absorb and nothing else" anyway.

## A witness-free simulator for the prelude that ships

The hiding sumcheck has two preludes — one derives its target from recorded claims, the other inherits it — and only the first had a simulator. WHIR plays the second, at every batch.

Reading eprint 2026/391 settles which is canonical, and it is the opposite of what the code's coverage suggests: Construction 6.3's target is **explicit public input** to the sub-protocol, and Definition 5.8 defines it as the claimed sum plus the auxiliary mask total — exactly the value the inherited prelude binds. So the inherited path *is* the paper's construction, and the recorded-claims one is the layer added on top.

The argument carries over unchanged. The auxiliary term is constant in `X` and independent of the masks, so it lands in the affine offset and never touches the linear map whose rank the proof computes. Its per-round carry shares slot 0 with the plain constant and is summed **before** masking, so it introduces no new independent linear functional of the witness — one uniform mask coefficient blinds an arbitrary constant on that slot however many witness terms compose it.

The verifier already split its prelude from its shared body; the simulator now does the same. The new entry point takes the claimed sum as a parameter and needs **no verifier argument at all**, which is itself the evidence that the target is public.

Tests cover it at a live auxiliary claim, which nothing did before — the honest side already exercised a nonzero carry, but the simulator never met one. Worth noting that the auxiliary term is not dead code: WHIR passes zero at the first call site and a nonzero running mask-claim total at every subsequent one.

One thing the falsification found, and it changed the tests: at zero grinding difficulty the verifier cannot reject a well-shaped record at all, so acceptance alone is a toothless assertion. The driver now also requires the verifier's redrawn challenge stream to equal the one its counterpart produced. Feeding it the wrong claim fails four tests with that message; drawing wires from the base-field subspace instead of uniformly fails five.

## Three divergences from the paper, recorded rather than rediscovered

- **The mask length bound is deliberately stronger** than the paper's. The round polynomial here is a product of two multilinears, hence quadratic in `X`; at the paper's bound the mask has no coefficient for the quadratic slot and it would ship unmasked. Verified directly: at the lower bound the quadratic slot equals the unmasked plain value exactly.
- **The auxiliary carry's halving is the normalisation consistent with Definition 5.8.** Adding a constant `AUX * 2^{-k}` at every point of the `k`-cube gives round-`j` partial sum `AUX * 2^{-j}` and cube total `AUX`. Checked for `k` in `1..=6`.
- **Compiled hiding is computational, not perfect.** The lemma is proved for an IOR with *oracle* masks whose queried positions a simulator answers. This code commits the whole mask codeword under one root, which information-theoretically determines the masks. A comment asserted perfect indistinguishability of the commits; it now says what holds. Standard IOR-to-argument compilation, stated as scope rather than alarm.

## Accuracy

Six comments claimed properties the code does not have. The two worth naming:

- *"the sponge is dropped on the error path and never reused"* — it is a `&mut` borrowed from the caller, handed back mutated mid-round. What keeps the verdict safe is that every caller propagates; a retry would let a prover pick its own challenges. The comment now says so, because it was inviting exactly that change.
- *"a step either side skips or reorders is rejected"* — a driver is a purely local self-check with no visibility into the other party. What rejects a prover that skips an absorb is sponge divergence; what rejects a skipped bracket is the callee's own verification.

A FRI test is renamed to what it actually pins: its old name promised the delegation markers absorb nothing, but if they did, both sides would absorb identically and every assertion would still pass.

Two shape sweeps now destructure without a rest pattern, so a new field must be confronted. Honest about the limit: a new field trips the missing-field error at the struct literals **first**, which masks the pattern error, so what is enforced is that the author comes through the function — not that a row appears. An instance-permutation property that was structurally sound but unasserted is now asserted, and it holds.

The transcript-failure error enums become `#[non_exhaustive]` as a family of eight, matching the one that already was. The verification-error enums are deliberately left: adding the attribute there also compiles clean, so it is an API-policy decision about enums downstream code legitimately matches to route a rejection, not a review follow-up.

Also corrected: a fixture count (six across four pipelines, not three), a stale error doc, and a note in the WHIR test suite that cited simulator tests as its hiding evidence when they exercised a prelude WHIR never plays.

## Verification

3980 tests pass, `scripts/check.py lint` clean, no `.postcard` fixture changed — this alters no transcript and no wire format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
