### PR TITLE
feat(stir)!: drive the STIR PCS transcript through the typed Fiat-Shamir layer

### DIFF
--- a/stir/src/lib.rs
+++ b/stir/src/lib.rs
@@ -59,6 +59,7 @@ pub mod config;
 pub mod error;
 pub mod pcs;
 mod pcs_budget;
+pub mod pcs_transcript;
 pub mod proof;
 pub mod prover;
 mod soundness;

--- a/stir/src/pcs.rs
+++ b/stir/src/pcs.rs
@@ -94,8 +94,8 @@ use p3_commit::{
 use p3_dft::TwoAdicSubgroupDft;
 use p3_field::coset::TwoAdicMultiplicativeCoset;
 use p3_field::{
-    BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, PrimeCharacteristicRing,
-    PrimeField32, PrimeField64, TwoAdicField, batch_multiplicative_inverse,
+    BasedVectorSpace, ExtensionField, Field, PackedFieldExtension, PrimeField32, PrimeField64,
+    TwoAdicField, batch_multiplicative_inverse,
 };
 use p3_matrix::Matrix;
 use p3_matrix::bitrev::{BitReversedMatrixView, BitReversibleMatrix};
@@ -112,6 +112,10 @@ use tracing::instrument;
 use crate::config::{StirConfig, StirConfigError, StirOptions, StirParameters};
 use crate::error::{ProofShapeError, StirError};
 use crate::pcs_budget::PcsBatch;
+use crate::pcs_transcript::{
+    OpeningProverTranscript, OpeningVerifierTranscript, StirPcsBucketShape, StirPcsOpeningShape,
+    observe_claims, observe_commitment, observe_opened_values,
+};
 use crate::proof::StirProof;
 use crate::prover::prove_stir_multi_from_codewords;
 use crate::utils::{combine_on_coset, eval_degree_correction};
@@ -195,11 +199,15 @@ impl<Val: Send + Sync + Clone, InputMmcs: Mmcs<Val>> StirProverData<Val, InputMm
 /// group, not across the whole commitment) and committed in its own tree. A commitment whose
 /// heights all fit one group therefore holds a single root.
 ///
-/// The roots are wrapped rather than handed out as a bare `Vec` so a challenger can observe
-/// the whole commitment in one call — which is what
-/// `p3_uni_stark::StarkGenericConfig`'s `Challenger: CanObserve<Pcs::Commitment>` bound asks
-/// for. Observing runs the root count first, so two commitments that split a given total of
-/// roots differently cannot reach the same transcript state.
+/// The roots are wrapped rather than handed out as a bare `Vec`.
+///
+/// A challenger can then observe the whole commitment in one call.
+///
+/// That single call is what a generic proving configuration asks its challenger for.
+///
+/// The absorption is seeded with the root count.
+///
+/// Two commitments that split a given total of roots differently stay apart.
 ///
 /// Dereferences to its roots, so reading them needs no unwrapping.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -214,11 +222,13 @@ impl<C> Deref for StirCommitment<C> {
     }
 }
 
-/// Absorbs a commitment's group count, then each of its roots.
+/// Absorbs a commitment's roots under the commitment scheme's own transcript.
 ///
-/// The count goes in first, as one fixed-width field element.
-/// Two commitments with different group counts therefore cannot produce the same transcript.
-/// Absorbing three roots as one commitment also stays distinct from absorbing them as two.
+/// The seed fixes how many roots the commitment holds.
+///
+/// Two commitments that split a given total of roots differently stay apart.
+///
+/// So do two commitments over the same roots in the opposite order.
 ///
 /// Every challenger backend routes here rather than writing the sequence out again.
 /// A backend that absorbed a commitment differently would not fail a test: prover and verifier
@@ -226,12 +236,11 @@ impl<C> Deref for StirCommitment<C> {
 fn observe_stir_commitment<Ch, F, C>(challenger: &mut Ch, commitment: StirCommitment<C>)
 where
     Ch: CanObserve<F> + CanObserve<C>,
-    F: PrimeCharacteristicRing,
+    F: PrimeField64,
+    C: Clone,
 {
-    challenger.observe(F::from_usize(commitment.0.len()));
-    for root in commitment.0 {
-        challenger.observe(root);
-    }
+    // The typed phase owns the whole sequence: the seed, then the roots.
+    observe_commitment::<Ch, F, C>(challenger, commitment.0);
 }
 
 // The shared body above is a free function rather than a blanket impl.
@@ -243,8 +252,9 @@ where
 impl<F, P, C, const WIDTH: usize, const RATE: usize> CanObserve<StirCommitment<C>>
     for DuplexChallenger<F, P, WIDTH, RATE>
 where
-    F: Copy + PrimeCharacteristicRing,
+    F: PrimeField64,
     P: CryptographicPermutation<[F; WIDTH]>,
+    C: Clone,
     Self: CanObserve<C>,
 {
     fn observe(&mut self, commitment: StirCommitment<C>) {
@@ -256,6 +266,7 @@ impl<F, Inner, C> CanObserve<StirCommitment<C>> for SerializingChallenger32<F, I
 where
     F: PrimeField32,
     Inner: CanObserve<u8>,
+    C: Clone,
     Self: CanObserve<C>,
 {
     fn observe(&mut self, commitment: StirCommitment<C>) {
@@ -759,7 +770,7 @@ type BucketCombine<Challenge> = Option<(
 type ProverDataWithPoints<'a, Val, InputMmcs, Challenge> =
     OpeningRequest<'a, StirProverData<Val, InputMmcs>, Challenge>;
 
-/// Everything `open` settles before STIR runs.
+/// Everything `open` settles before the bucket phase runs.
 struct PreparedOpen<Val, Challenge, StirMmcs, Challenger> {
     batch_pow_witness: Option<Val>,
     /// Claimed evaluations, already absorbed into the transcript.
@@ -767,11 +778,20 @@ struct PreparedOpen<Val, Challenge, StirMmcs, Challenger> {
     /// Distinct shared LDE heights across every commitment's groups, descending: one STIR
     /// instance ("bucket") each.
     bucket_log_heights: Vec<usize>,
+    /// Native-height classes present in each bucket, descending.
+    ///
+    /// One entry per bucket, in the order the heights above are in.
+    bucket_native_heights: Vec<Vec<usize>>,
     /// The derived config of each bucket's instance.
     stir_configs: Vec<Arc<StirConfig<Val, Challenge, StirMmcs, Challenger>>>,
-    /// Each bucket's initial codeword in natural order: its reduced opening, `Combine`d across
-    /// native-height classes when the bucket holds more than one.
-    initial_codewords: Vec<Vec<Challenge>>,
+    /// One alpha-batched reduced opening per height class, bit-reversed and unmerged.
+    ///
+    /// A class is keyed by its shared LDE height and its native height.
+    ///
+    /// Merging a bucket's classes needs a challenge.
+    ///
+    /// The bucket phase is what draws it.
+    reduced_openings: alloc::collections::BTreeMap<(usize, usize), Vec<Challenge>>,
 }
 
 impl<Val, Dft, InputMmcs, StirMmcs, Challenge, Challenger>
@@ -909,19 +929,28 @@ where
                                 // Slice the precomputed adjusted weights to match this matrix's height.
                                 // Zero-allocation hot path: straight to the SIMD dot product.
                                 let adj = &adjusted_weights.get(&point).unwrap()[..h];
-                                let ys = low_coset.interpolate_coset_with_precomputation(
+                                low_coset.interpolate_coset_with_precomputation(
                                     Val::GENERATOR,
                                     point,
                                     adj,
-                                );
-                                challenger.observe_algebra_slice(&ys);
-                                ys
+                                )
                             })
                             .collect_vec()
                     })
                     .collect_vec()
             })
             .collect_vec();
+
+        // Bind every claimed evaluation before any challenge can depend on one.
+        //
+        // The description of this phase is derived from the same tree.
+        //
+        // It holds one container per level of it.
+        //
+        //     commitment -> matrix -> opening point -> one value per column
+        //
+        // So the grouping reaches the seed, not only the absorbed values.
+        observe_opened_values::<Challenger, Val, Challenge>(challenger, &all_opened_values);
 
         // Step 2: Alpha-batch into one reduced-opening vector per (shared LDE domain, native
         // height) class. Every matrix in a class lives on the same physical domain (its
@@ -1049,23 +1078,16 @@ where
                 })
                 .collect();
 
-        let initial_codewords: Vec<Vec<Challenge>> = bucket_log_heights
-            .iter()
-            .map(|&log_shared_h| {
-                combined_bucket_codeword::<Val, Challenge, Challenger>(
-                    &mut reduced_openings,
-                    log_shared_h,
-                    challenger,
-                )
-            })
-            .collect();
-
+        // Merging a bucket's classes needs a challenge drawn in the bucket phase.
+        //
+        // So the classes travel on unmerged.
         PreparedOpen {
             batch_pow_witness,
             opened_values: all_opened_values,
             bucket_log_heights,
+            bucket_native_heights,
             stir_configs,
-            initial_codewords,
+            reduced_openings,
         }
     }
 
@@ -1101,47 +1123,91 @@ where
             batch_pow_witness,
             opened_values,
             bucket_log_heights,
+            bucket_native_heights,
             stir_configs,
-            initial_codewords,
+            mut reduced_openings,
         } = prepared;
         let stir_config_refs: Vec<&StirConfig<Val, Challenge, StirMmcs, Challenger>> =
             stir_configs.iter().map(AsRef::as_ref).collect();
 
-        let bucket_results = prove_stir_multi_from_codewords(
-            &stir_config_refs,
-            initial_codewords,
-            &self.dft,
-            challenger,
+        // One description covers the whole bucket phase.
+        //
+        //     merging challenges  ->  bracketed proximity test  ->  lane draws
+        let shape = StirPcsOpeningShape::new(
+            izip!(&bucket_log_heights, &bucket_native_heights, &stir_configs)
+                .map(|(&log_h, native_heights, config)| {
+                    StirPcsBucketShape::new(log_h, native_heights.clone(), config)
+                })
+                .collect(),
         );
+        let mut transcript =
+            OpeningProverTranscript::<Challenger, Val, Challenge>::new(challenger, shape);
 
-        let bucket_proofs = bucket_log_heights
+        // Phase 1: merge each bucket's classes into the codeword STIR runs on.
+        //
+        // A bucket holding one class is already its own codeword and draws nothing.
+        let initial_codewords: Vec<Vec<Challenge>> = bucket_log_heights
             .iter()
-            .zip(&stir_configs)
-            .zip(bucket_results)
-            .map(|((&log_h, stir_config), (stir_proof, first_round))| {
-                let log_arity0 = stir_config.log_starting_folding_factor;
-                let lanes = sample_lanes::<Val, _>(challenger, first_round.draws.len(), log_arity0);
-                let positions = query_positions(&first_round.draws, &lanes, log_h, log_arity0);
-                let row_indices = positions_to_row_indices(&positions, log_h);
-
-                let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> = prover_data
-                    .iter()
-                    .map(|data| {
-                        // Each group has its own tree on its own domain, so a bucket reads
-                        // exactly the group committed at its LDE height.
-                        let group = data.group_at(log_h)?;
-                        let (opened_values, opening_proof) =
-                            self.input_mmcs.open_multi_batch(&row_indices, &group.data);
-                        Some(InputOpenings {
-                            opened_values,
-                            opening_proof,
-                        })
-                    })
-                    .collect();
-
-                (stir_proof, input_openings)
+            .zip(&bucket_native_heights)
+            .enumerate()
+            .map(|(bucket, (&log_h, native_heights))| {
+                let r_comb = transcript.combination_challenge(bucket);
+                combined_bucket_codeword(&mut reduced_openings, log_h, native_heights, r_comb)
             })
             .collect();
+
+        // Phase 2: every bucket's proximity test runs in lockstep, inside the bracket.
+        let bucket_results = transcript.delegate(|challenger| {
+            prove_stir_multi_from_codewords(
+                &stir_config_refs,
+                initial_codewords,
+                &self.dft,
+                challenger,
+            )
+        });
+
+        // Phase 3: one lane per first-round query draw, per bucket.
+        //
+        // Every STIR message is already in the sponge, the commitments above all.
+        //
+        // So no lane can be chosen to dodge a disagreement.
+        let bucket_lanes: Vec<Vec<usize>> = (0..bucket_log_heights.len())
+            .map(|bucket| transcript.lanes(bucket))
+            .collect();
+        transcript.finish();
+
+        let bucket_proofs = izip!(
+            &bucket_log_heights,
+            &stir_configs,
+            bucket_results,
+            bucket_lanes
+        )
+        .map(|(&log_h, stir_config, (stir_proof, first_round), lanes)| {
+            let log_arity0 = stir_config.log_starting_folding_factor;
+            // Both the lane count and the draw count come from the schedule.
+            debug_assert_eq!(lanes.len(), first_round.draws.len());
+            let positions = query_positions(&first_round.draws, &lanes, log_h, log_arity0);
+            let row_indices = positions_to_row_indices(&positions, log_h);
+
+            let input_openings: Vec<Option<InputOpenings<Val, InputMmcs>>> = prover_data
+                .iter()
+                .map(|data| {
+                    // Each group has its own tree on its own domain.
+                    //
+                    // So a bucket reads exactly the group committed at its LDE height.
+                    let group = data.group_at(log_h)?;
+                    let (opened_values, opening_proof) =
+                        self.input_mmcs.open_multi_batch(&row_indices, &group.data);
+                    Some(InputOpenings {
+                        opened_values,
+                        opening_proof,
+                    })
+                })
+                .collect();
+
+            (stir_proof, input_openings)
+        })
+        .collect();
 
         (
             opened_values,
@@ -1297,26 +1363,25 @@ where
             }
         }
 
-        // Observe all opened values to keep the transcript in sync.
-        for CommitmentOpening {
-            matrices: domain_claims,
-            ..
-        } in &commitments_with_opening_points
-        {
-            for MatrixOpening {
-                points: point_claims,
-                ..
-            } in domain_claims
-            {
-                for PointOpening {
-                    values: opened_vals,
-                    ..
-                } in point_claims
-                {
-                    challenger.observe_algebra_slice(opened_vals);
-                }
-            }
-        }
+        // Bind every claimed evaluation before any challenge can depend on one.
+        //
+        // The description of this phase is derived from the claims themselves.
+        //
+        // It holds one container per level of them.
+        //
+        //     commitment -> matrix -> opening point -> one value per column
+        //
+        // So the grouping reaches the seed, not only the absorbed values.
+        //
+        // The claims are the statement this call was handed.
+        //
+        // Nothing here is read out of the proof.
+        //
+        // No count is attacker-chosen.
+        observe_claims::<Challenger, Val, Challenge, _, _>(
+            challenger,
+            &commitments_with_opening_points,
+        );
 
         let alpha: Challenge = crate::batch_transcript::verify(
             challenger,
@@ -1585,36 +1650,77 @@ where
         let stir_proofs: Vec<&StirProof<Challenge, StirMmcs, Val>> =
             proof.iter().map(|(p, _)| p).collect();
 
-        // For every bucket with more than one native-height class present, sample the
-        // `Combine` challenge and derive its per-class coefficients up front, at the same
-        // transcript position the prover's `combined_bucket_codeword` used (before any
-        // STIR-internal transcript operations) — mirroring how `alpha` itself is sampled
-        // once, up front, rather than lazily inside a bucket's closure.
-        let bucket_combine: Vec<BucketCombine<Challenge>> = bucket_log_heights
-            .iter()
-            .zip(&bucket_native_heights)
-            .map(|(_, native_heights)| {
-                if native_heights.len() <= 1 {
-                    return None;
-                }
+        // One description covers the whole bucket phase.
+        //
+        //     merging challenges  ->  bracketed proximity test  ->  lane draws
+        //
+        // Every count in it comes from the schedules and the claimed heights.
+        //
+        // None comes from the proof.
+        //
+        // Both sides fix the description up front.
+        let shape = StirPcsOpeningShape::new(
+            izip!(&bucket_log_heights, &bucket_native_heights, &stir_configs)
+                .map(|(&log_h, native_heights, config)| {
+                    StirPcsBucketShape::new(log_h, native_heights.clone(), config)
+                })
+                .collect(),
+        );
+        let mut transcript =
+            OpeningVerifierTranscript::<Challenger, Val, Challenge>::new(challenger, shape);
 
+        // Phase 1: redraw each merging challenge and derive its per-class coefficients.
+        //
+        // Both happen at the transcript position the prover merged its classes at.
+        //
+        // A bucket holding one native-height class merges nothing and draws nothing.
+        let bucket_combine: Vec<BucketCombine<Challenge>> = bucket_native_heights
+            .iter()
+            .enumerate()
+            .map(|(bucket, native_heights)| {
+                let r_comb = transcript.combination_challenge(bucket)?;
+                // The tallest class heads the list.
+                //
+                // Its own degree is the target degree.
                 let log_d_star = native_heights[0];
-                let r_comb: Challenge = challenger.sample_algebra_element();
                 let coeffs =
                     combine_coefficients(r_comb, log_d_star, native_heights.iter().copied());
                 Some((r_comb, native_heights.iter().copied().zip(coeffs).collect()))
             })
             .collect();
 
-        // STIR runs first: it absorbs each bucket's initial-oracle commitment, checks every
-        // round, and hands back the round-0 fibers it authenticated against that commitment
-        // together with the draws that selected them.
-        let outputs = verify_stir_multi_inner(
-            &stir_config_refs,
-            &stir_proofs,
-            challenger,
-            None::<Vec<NoExternalFibers<Challenge, StirMmcs::Error, InputMmcs::Error>>>,
-        )?;
+        // Phase 2: the proximity test runs inside the bracket.
+        //
+        // It absorbs each bucket's initial-oracle commitment and checks every round.
+        //
+        // It then hands back the round-0 fibers it authenticated against that commitment.
+        //
+        // The draws that selected those fibers come back alongside them.
+        let outputs = match transcript.delegate(|challenger| {
+            verify_stir_multi_inner(
+                &stir_config_refs,
+                &stir_proofs,
+                challenger,
+                None::<Vec<NoExternalFibers<Challenge, StirMmcs::Error, InputMmcs::Error>>>,
+            )
+        }) {
+            Ok(outputs) => outputs,
+            Err(err) => {
+                // Releasing the completeness check keeps this rejection the only failure.
+                transcript.abort();
+                return Err(err);
+            }
+        };
+
+        // Phase 3: one lane per first-round query draw, per bucket.
+        //
+        // Every STIR message is already in the sponge, the commitments above all.
+        //
+        // So no lane can be chosen to dodge a disagreement.
+        let bucket_lanes: Vec<Vec<usize>> = (0..bucket_log_heights.len())
+            .map(|bucket| transcript.lanes(bucket))
+            .collect();
+        transcript.finish();
 
         for (bucket, (&log_h, output)) in bucket_log_heights.iter().zip(&outputs).enumerate() {
             let stir_config = &stir_configs[bucket];
@@ -1628,11 +1734,12 @@ where
             let fold_height0 = bucket_height >> log_arity0;
             let domain_gen = Val::two_adic_generator(log_h);
 
-            // One lane per round-0 draw, sampled only now that every STIR message — the
-            // initial-oracle commitment above all — is in the transcript.
-            let lanes =
-                sample_lanes::<Val, _>(challenger, output.first_round_draws.len(), log_arity0);
-            let positions = query_positions(&output.first_round_draws, &lanes, log_h, log_arity0);
+            // The lanes this bucket drew, one per first-round query draw.
+            //
+            // Both the lane count and the draw count come from the schedule.
+            let lanes = &bucket_lanes[bucket];
+            debug_assert_eq!(lanes.len(), output.first_round_draws.len());
+            let positions = query_positions(&output.first_round_draws, lanes, log_h, log_arity0);
             let n_q = positions.len();
             let row_indices = positions_to_row_indices(&positions, log_h);
             // Coset point of each queried position: `GENERATOR * g^p`.
@@ -2099,24 +2206,6 @@ pub struct StirPcsProof<
 /// has STIR commit the initial oracle itself, so no such source ever exists.
 type NoExternalFibers<EF, E, IE> = fn(&[usize]) -> Result<Vec<Vec<EF>>, StirError<E, IE>>;
 
-/// One uniformly sampled fiber lane per round-0 query draw, in draw order.
-fn sample_lanes<Val, Challenger>(
-    challenger: &mut Challenger,
-    num_draws: usize,
-    log_arity0: usize,
-) -> Vec<usize>
-where
-    Challenger: CanSampleUniformBits<Val>,
-{
-    (0..num_draws)
-        .map(|_| {
-            challenger
-                .sample_uniform_bits::<true>(log_arity0)
-                .expect("RESAMPLE = true: rejection loops internally, never errors")
-        })
-        .collect()
-}
-
 /// The natural-order LDE positions `j + lane * 2^(log_h - log_arity0)` of every
 /// `(draw, lane)` pair, ascending and deduplicated.
 ///
@@ -2234,52 +2323,78 @@ fn combine_coefficients<EF: Field>(
 /// Merge one shared-LDE-height bucket's native-height classes into a single codeword on
 /// their shared domain, via `Combine` (§4.5) when more than one class is present.
 ///
-/// `reduced_openings` is keyed by `(log_shared_lde_height, log_native_height)`; this removes
-/// every class at `log_shared_h`, descending by native height, and returns the natural
-/// (not yet bit-reversed) combined codeword STIR should run on.
+/// # Overview
 ///
-/// Each class's codeword is taken out of the map rather than borrowed so it can be
-/// un-bit-reversed in place: at PCS scale a class spans the whole shared domain, so cloning
-/// them all would double peak memory for the duration of `Combine`.
-fn combined_bucket_codeword<Val, Challenge, Challenger>(
+/// The map is keyed by `(log_shared_lde_height, log_native_height)`.
+///
+/// This removes every class of the given shared height.
+///
+/// It returns the merged codeword in natural order, not bit-reversed.
+///
+/// Each class is taken out of the map rather than borrowed, to un-reverse it in place.
+///
+/// A class spans the whole shared domain at PCS scale.
+///
+/// Cloning them all would double peak memory for the duration of the merge.
+///
+/// # Arguments
+///
+/// - `reduced_openings`: every class's alpha-batched reduced opening, bit-reversed.
+/// - `log_shared_h`: log of the shared domain whose classes are merged.
+/// - `log_native_heights`: log of every native height present, descending.
+/// - `r_comb`: the merging challenge, or nothing when a single height is present.
+///
+/// # Panics
+///
+/// - When a listed class is absent from the map.
+/// - When several heights are present and no merging challenge was drawn for them.
+fn combined_bucket_codeword<Val, Challenge>(
     reduced_openings: &mut alloc::collections::BTreeMap<(usize, usize), Vec<Challenge>>,
     log_shared_h: usize,
-    challenger: &mut Challenger,
+    log_native_heights: &[usize],
+    r_comb: Option<Challenge>,
 ) -> Vec<Challenge>
 where
     Val: TwoAdicField + PrimeField64,
     Challenge: ExtensionField<Val> + TwoAdicField,
-    Challenger: FieldChallenger<Val>,
 {
-    let mut log_ds: Vec<usize> = reduced_openings
-        .keys()
-        .filter(|(h, _)| *h == log_shared_h)
-        .map(|&(_, log_d)| log_d)
-        .collect();
-    log_ds.sort_unstable_by(|a, b| b.cmp(a));
-
-    // `combine_on_coset` indexes its inputs (and produces its output) in natural order, but
-    // `reduced_openings` is bit-reversed (built from the bit-reversed LDE matrices), so each
-    // class's codeword is un-reversed before combining; the combined result is then already
-    // in the natural order STIR expects, with no further reversal needed.
-    let mut natural_ros: Vec<Vec<Challenge>> = log_ds
+    // The merge indexes its inputs, and produces its output, in natural order.
+    //
+    // The reduced openings are bit-reversed.
+    //
+    // They were built from the bit-reversed LDE matrices.
+    //
+    // So each class's codeword is un-reversed on the way in.
+    //
+    // The merged result then sits in the natural order the proximity test expects.
+    let mut natural_ros: Vec<Vec<Challenge>> = log_native_heights
         .iter()
         .map(|&log_d| {
             let mut natural = reduced_openings
                 .remove(&(log_shared_h, log_d))
-                .expect("key came from this map");
+                .expect("every listed class was accumulated into this map");
             reverse_slice_index_bits(&mut natural);
             natural
         })
         .collect();
 
-    if natural_ros.len() == 1 {
-        return natural_ros.pop().expect("checked non-empty above");
-    }
+    // A bucket of one class is already its own codeword.
+    let Some(r_comb) = r_comb else {
+        assert_eq!(
+            natural_ros.len(),
+            1,
+            "several native heights on one domain must be merged under a challenge",
+        );
+        return natural_ros
+            .pop()
+            .expect("a bucket holds at least one class");
+    };
 
-    let log_d_star = log_ds[0];
-    let r_comb: Challenge = challenger.sample_algebra_element();
-    let coeffs = combine_coefficients(r_comb, log_d_star, log_ds.iter().copied());
+    // The tallest class heads the descending list.
+    //
+    // Its own degree is the target degree.
+    let log_d_star = log_native_heights[0];
+    let coeffs = combine_coefficients(r_comb, log_d_star, log_native_heights.iter().copied());
 
     let groups: Vec<(Challenge, usize, &[Challenge])> = coeffs
         .into_iter()
@@ -2335,6 +2450,7 @@ mod tests {
     use alloc::{format, vec};
 
     use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::testing::seed_digest;
     use p3_challenger::{CanSampleBits, DuplexChallenger, HashChallenger};
     use p3_commit::ExtensionMmcs;
     use p3_dft::Radix2DitParallel;
@@ -2432,40 +2548,43 @@ mod tests {
     }
 
     #[test]
-    fn every_backend_absorbs_a_commitment_the_same_way() {
-        // Invariant: a backend's impl is the shared sequence, never a hand-written variant.
+    fn every_backend_absorbs_a_commitment_through_the_shared_phase() {
+        // Invariant: a backend's impl routes through the shared typed phase.
         //
-        //     observe(commitment)  ==  observe(len) then observe(each root)
+        // It never writes out a hand-written variant of the sequence.
         //
-        // Checked per backend against the sequence spelled out by hand, since prover and
-        // verifier share one challenger type and would be wrong together if it drifted.
+        //     observe(commitment)  ==  the commitment phase over the same roots
+        //
+        // This is checked per backend.
+        //
+        // Prover and verifier share one challenger type.
+        //
+        // A drifting backend would make both of them wrong together.
+        //
+        // Fixture state: three digests absorbed as one commitment of three roots.
         let roots = vec![digest(0x01), digest(0x02), digest(0x03)];
 
         let mut via_commitment = byte_challenger();
         via_commitment.observe(StirCommitment(roots.clone()));
 
-        let mut by_hand = byte_challenger();
-        by_hand.observe(BabyBear::from_usize(roots.len()));
-        for root in roots {
-            by_hand.observe(root);
-        }
+        let mut via_phase = byte_challenger();
+        observe_commitment::<_, BabyBear, _>(&mut via_phase, roots);
 
-        assert_eq!(via_commitment.sample_bits(24), by_hand.sample_bits(24));
+        assert_eq!(via_commitment.sample_bits(24), via_phase.sample_bits(24));
 
         // The same obligation, for the duplex backend the Poseidon2 configurations use.
         let perm = TestPerm::new_from_rng_128(&mut SmallRng::seed_from_u64(1));
+        let duplex_roots = vec![BabyBear::ONE, BabyBear::TWO];
 
         let mut duplex_via_commitment = TestChallenger::new(perm.clone());
-        duplex_via_commitment.observe(StirCommitment(vec![BabyBear::ONE, BabyBear::TWO]));
+        duplex_via_commitment.observe(StirCommitment(duplex_roots.clone()));
 
-        let mut duplex_by_hand = TestChallenger::new(perm);
-        duplex_by_hand.observe(BabyBear::TWO);
-        duplex_by_hand.observe(BabyBear::ONE);
-        duplex_by_hand.observe(BabyBear::TWO);
+        let mut duplex_via_phase = TestChallenger::new(perm);
+        observe_commitment::<_, BabyBear, _>(&mut duplex_via_phase, duplex_roots);
 
         assert_eq!(
             duplex_via_commitment.sample_bits(24),
-            duplex_by_hand.sample_bits(24)
+            duplex_via_phase.sample_bits(24)
         );
     }
 
@@ -2528,6 +2647,52 @@ mod tests {
         )
     }
 
+    /// Add a random codeword of a bucket's own degree bound to its reduced opening.
+    ///
+    /// # Overview
+    ///
+    /// The sum is still a codeword of that degree bound.
+    ///
+    /// So every proximity-test round accepts it.
+    ///
+    /// Only the lane checks stand between such a prover and acceptance.
+    ///
+    /// # Arguments
+    ///
+    /// - `pcs`: the instance whose transform evaluates the perturbation.
+    /// - `reduced_openings`: the class map a prepared opening handed back.
+    /// - `log_native_h`: log of the bucket's only native height.
+    /// - `log_lde`: log of the shared domain the bucket runs on.
+    /// - `rng`: source of the perturbing polynomial's coefficients.
+    ///
+    /// # Panics
+    ///
+    /// When the map holds no class at that pair of heights.
+    fn add_low_degree_codeword(
+        pcs: &TestPcs,
+        reduced_openings: &mut alloc::collections::BTreeMap<(usize, usize), Vec<EF>>,
+        log_native_h: usize,
+        log_lde: usize,
+        rng: &mut SmallRng,
+    ) {
+        // A random polynomial of the bucket's degree bound, on the bucket's shared coset.
+        let mut coeffs: Vec<EF> = (0..1usize << log_native_h).map(|_| rng.random()).collect();
+        coeffs.resize(1 << log_lde, EF::ZERO);
+        let mut low_degree = codeword_from_coeffs(&pcs.dft, coeffs, TestVal::GENERATOR, log_lde);
+
+        // Reduced openings are stored bit-reversed, and un-reversed on the way in.
+        //
+        // So the perturbation is reversed here, to land in natural order there.
+        reverse_slice_index_bits(&mut low_degree);
+
+        let ro = reduced_openings
+            .get_mut(&(log_lde, log_native_h))
+            .expect("the bucket's only native-height class");
+        for (value, extra) in ro.iter_mut().zip(low_degree) {
+            *value += extra;
+        }
+    }
+
     /// A PCS over `TestVal`/`EF` at the given layout and soundness knobs.
     fn test_pcs_with(
         max_log_height_spread: usize,
@@ -2575,12 +2740,13 @@ mod tests {
                 }],
                 &mut prover,
             );
-            // Replay just the claims and batching site independently of `prepare_open`.
-            // Moving the prover's grind before a claim or after alpha breaks this check.
+            // Replay just the claim phase and the batching site.
+            //
+            // Neither reads anything the opening path settled.
+            //
+            // Moving the prover's grind before a claim, or after alpha, breaks this.
             let mut batch_replay = base.clone();
-            for claim in values.iter().flatten().flatten() {
-                batch_replay.observe_algebra_slice(claim);
-            }
+            observe_opened_values::<TestChallenger, TestVal, EF>(&mut batch_replay, &values);
             let _: EF = crate::batch_transcript::verify::<TestVal, EF, _, (), ()>(
                 &mut batch_replay,
                 8,
@@ -3721,16 +3887,21 @@ mod tests {
             }],
             &mut p_ch,
         );
-        assert_eq!(prepared.initial_codewords.len(), 1);
+        // Fixture state: one commitment at one height.
+        //
+        // That is one bucket holding one class.
+        assert_eq!(prepared.bucket_log_heights.len(), 1);
 
-        // A random polynomial of the same degree bound, evaluated on the same coset in the
-        // same natural order STIR reads `initial_codewords` in.
-        let mut coeffs: Vec<EF> = (0..1usize << log_h).map(|_| rng.random()).collect();
-        coeffs.resize(1 << log_lde, EF::ZERO);
-        let low_degree = codeword_from_coeffs(&pcs.dft, coeffs, TestVal::GENERATOR, log_lde);
-        for (value, extra) in prepared.initial_codewords[0].iter_mut().zip(low_degree) {
-            *value += extra;
-        }
+        // Mutation: the codeword the bucket will run on is no longer its reduced opening.
+        //
+        //     f_0 = reduced opening + a random codeword of the same degree bound
+        add_low_degree_codeword(
+            &pcs,
+            &mut prepared.reduced_openings,
+            log_h,
+            log_lde,
+            &mut rng,
+        );
 
         let (opened_values, proof) = pcs.prove_buckets(&[&data], prepared, &mut p_ch);
 
@@ -3791,12 +3962,14 @@ mod tests {
             "this test exists to cover the zero-intermediate-round schedule"
         );
 
-        let mut coeffs: Vec<EF> = (0..1usize << log_h).map(|_| rng.random()).collect();
-        coeffs.resize(1 << log_lde, EF::ZERO);
-        let low_degree = codeword_from_coeffs(&pcs.dft, coeffs, TestVal::GENERATOR, log_lde);
-        for (value, extra) in prepared.initial_codewords[0].iter_mut().zip(low_degree) {
-            *value += extra;
-        }
+        // Mutation: the same corruption, on a schedule with no intermediate round.
+        add_low_degree_codeword(
+            &pcs,
+            &mut prepared.reduced_openings,
+            log_h,
+            log_lde,
+            &mut rng,
+        );
 
         let (opened_values, proof) = pcs.prove_buckets(&[&data], prepared, &mut p_ch);
 
@@ -3818,15 +3991,8 @@ mod tests {
         );
     }
 
-    /// One lane per round-0 *draw*, in draw order — never one per distinct fiber.
-    ///
-    /// Sampling per unique fiber would leave a repeated fiber contributing no fresh
-    /// randomness, and the per-draw product the round's query count is priced on would no
-    /// longer hold. The two counts only differ when a fiber repeats, so this runs a
-    /// zero-intermediate-round bucket whose fold domain holds two indices and repeats are
-    /// forced; the transcript state after the draws is what tells the two apart.
     #[test]
-    fn lanes_are_sampled_once_per_round_zero_draw() {
+    fn lanes_are_drawn_once_per_round_zero_draw() {
         let pcs = test_pcs_with(
             DEFAULT_MAX_LOG_HEIGHT_SPREAD,
             SecurityAssumption::CapacityBound,
@@ -3845,6 +4011,20 @@ mod tests {
         base.observe(commit);
         let zeta: EF = base.sample_algebra_element();
 
+        // Invariant: one lane per first-round query draw, in draw order.
+        //
+        // Never one lane per distinct fiber.
+        //
+        // A repeated fiber would then contribute no fresh randomness.
+        //
+        // The per-draw product the round's query count is priced on would not hold.
+        //
+        // Fixture state: a zero-intermediate-round bucket, fold domain of two indices.
+        //
+        // A repeated fiber is forced there.
+        //
+        // The two counts actually differ.
+
         // The whole prover side, lanes included.
         let mut ch_full = base.clone();
         let prepared = pcs.prepare_open(
@@ -3858,54 +4038,90 @@ mod tests {
         let final_queries = prepared.stir_configs[0].final_queries;
         let _ = pcs.prove_buckets(&[&data], prepared, &mut ch_full);
 
-        // The same transcript, stopped right after STIR so the lane draws can be replayed by
-        // hand at both counts.
+        // The same run, replayed step by step.
+        //
+        // Both the draws and the lanes are visible that way.
         let mut ch_draws = base;
-        let prepared = pcs.prepare_open(
+        let PreparedOpen {
+            bucket_log_heights,
+            bucket_native_heights,
+            stir_configs,
+            mut reduced_openings,
+            ..
+        } = pcs.prepare_open(
             &[OpeningRequest {
                 prover_data: &data,
                 points: vec![vec![zeta]],
             }],
             &mut ch_draws,
         );
-        let PreparedOpen {
-            stir_configs,
-            initial_codewords,
-            ..
-        } = prepared;
+
+        // The bucket phase's description, built exactly as the prover builds it.
+        let shape = StirPcsOpeningShape::new(vec![StirPcsBucketShape::new(
+            bucket_log_heights[0],
+            bucket_native_heights[0].clone(),
+            &stir_configs[0],
+        )]);
+        let described_draws = shape.buckets[0].num_query_draws;
+        assert_eq!(
+            described_draws, final_queries,
+            "a zero-round bucket reads its initial oracle through the final round's queries"
+        );
+
         let configs: Vec<&TestConfig> = stir_configs.iter().map(AsRef::as_ref).collect();
-        let results =
-            prove_stir_multi_from_codewords(&configs, initial_codewords, &pcs.dft, &mut ch_draws);
+        let mut transcript = OpeningProverTranscript::<TestChallenger, TestVal, EF>::new(
+            &mut ch_draws,
+            shape.clone(),
+        );
+
+        // One native height.
+        //
+        // The bucket merges nothing and draws no challenge.
+        assert!(transcript.combination_challenge(0).is_none());
+        let codeword = combined_bucket_codeword::<TestVal, EF>(
+            &mut reduced_openings,
+            bucket_log_heights[0],
+            &bucket_native_heights[0],
+            None,
+        );
+        let results = transcript.delegate(|challenger| {
+            prove_stir_multi_from_codewords(&configs, vec![codeword], &pcs.dft, challenger)
+        });
+        let lanes = transcript.lanes(0);
+        transcript.finish();
 
         let draws = &results[0].1.draws;
         let unique = &results[0].1.unique_sorted;
-        assert_eq!(
-            draws.len(),
-            final_queries,
-            "a zero-round bucket draws its initial-oracle queries in the final round"
-        );
         assert!(
             unique.len() < draws.len(),
             "the fold domain must be small enough that a fiber repeats, or the two lane \
              counts are indistinguishable"
         );
 
-        let mut ch_per_unique = ch_draws.clone();
-        let lanes = sample_lanes::<TestVal, _>(&mut ch_draws, draws.len(), log_arity0);
+        // The described count is the draw count.
+        //
+        // One lane came out per draw.
+        assert_eq!(described_draws, draws.len());
         assert_eq!(lanes.len(), draws.len());
-        let _ = sample_lanes::<TestVal, _>(&mut ch_per_unique, unique.len(), log_arity0);
 
+        // The replay lands where the real prover landed.
         let after_full: EF = ch_full.sample_algebra_element();
-        let after_per_draw: EF = ch_draws.sample_algebra_element();
-        let after_per_unique: EF = ch_per_unique.sample_algebra_element();
-        assert_eq!(
-            after_full, after_per_draw,
-            "the implementation must draw one lane per draw"
-        );
+        let after_replay: EF = ch_draws.sample_algebra_element();
+        assert_eq!(after_full, after_replay);
+
+        // Mutation: describe one lane per unique fiber instead of one per draw.
+        //
+        //     draws  : 2 draws of fiber 1  ->  2 lanes described
+        //     unique : 1 distinct fiber    ->  1 lane described
+        //
+        // The count travels in the description.
+        //
+        // The two cannot share a seed.
+        let mut per_unique = shape.clone();
+        per_unique.buckets[0].num_query_draws = unique.len();
         assert_ne!(
-            after_full, after_per_unique,
-            "one lane per unique fiber would leave a different transcript, so this comparison \
-             is what makes the assertion above meaningful"
+            seed_digest(&shape.domain_separator::<TestVal, EF>()),
+            seed_digest(&per_unique.domain_separator::<TestVal, EF>()),
         );
 
         // Two draws of one fiber with different lanes are two distinct positions and both get

--- a/stir/src/pcs_transcript.rs
+++ b/stir/src/pcs_transcript.rs
@@ -1,0 +1,1522 @@
+//! Fiat-Shamir transcript of the STIR polynomial commitment scheme.
+//!
+//! # Overview
+//!
+//! Three descriptions, one per phase the commitment scheme owns for itself.
+//!
+//! - Absorbing one commitment: a list of Merkle roots.
+//! - Binding the claimed evaluations, before anything batches them.
+//! - Merging the height classes, delegating the proximity test, pinning the input rows.
+//!
+//! The batching grind and its challenge sit between the second phase and the third.
+//!
+//! That phase carries its own description.
+//!
+//! # Shape
+//!
+//! ```text
+//!     commitment phase
+//!       one opaque root per shared-domain group
+//!
+//!     claim phase
+//!       Begin commitment
+//!         Begin matrix
+//!           claimed values         one step per opening point, of that matrix's width
+//!         End   matrix
+//!       End   commitment
+//!
+//!     opening phase
+//!       Begin bucket combine
+//!         combination challenge    only when the bucket merges several heights
+//!       End   bucket combine
+//!       Begin proximity test       bracket around the delegated run
+//!       End   proximity test
+//!       Begin bucket lanes
+//!         lane indices             one uniform draw per first-round query
+//!       End   bucket lanes
+//! ```
+//!
+//! # Why the claim phase nests
+//!
+//! The claimed evaluations arrive grouped three levels deep.
+//!
+//! ```text
+//!     commitment  ->  matrix  ->  opening point  ->  one value per column
+//! ```
+//!
+//! Flattened to a bare run of steps, two groupings collapse onto one description.
+//!
+//! ```text
+//!     two matrices of width 3, one point each   ->  3, 3
+//!     one matrix of width 3, opened twice       ->  3, 3
+//! ```
+//!
+//! A container per level keeps them apart inside the fingerprint itself.
+//!
+//! ```text
+//!     Begin commitment  Begin matrix  3  End  Begin matrix  3  End  End
+//!     Begin commitment  Begin matrix  3  3  End  End
+//! ```
+//!
+//! Nothing about the grouping then has to travel in a separate label.
+//!
+//! # What is bound
+//!
+//! - Commitment phase: how many roots one commitment holds, through the step count.
+//! - Claim phase: every claimed width, and the grouping the widths sit in.
+//! - Opening phase: which buckets merge, every lane width, every lane count.
+//! - Opening phase label: each bucket's shared domain and the native heights it merges.
+//!
+//! # What is not bound
+//!
+//! The parameters of the proximity test itself are absent from the opening phase.
+//!
+//! That run seeds its own transcript inside the bracket, under its own description.
+//!
+//! The bracket records that the delegation happens, and where.
+//!
+//! # Where the lengths come from
+//!
+//! Every count in every description is read off an input the caller already holds.
+//!
+//! ```text
+//!     root count      the commitment being absorbed
+//!     claim widths    the matrices a prover holds, the claims a verifier was handed
+//!     bucket layout   the shared domains the claimed heights imply
+//!     lane geometry   the schedule solved for each bucket
+//! ```
+//!
+//! None of them is read out of an opening proof.
+
+use alloc::vec::Vec;
+use core::marker::PhantomData;
+
+use p3_challenger::fs::{
+    DomainSeparator, FieldToFieldCodec, FieldUnit, Hierarchy, Interaction, InteractionPattern,
+    Kind, Length, ProverState, TranscriptBound, VerifierState,
+};
+use p3_challenger::{
+    CanObserve, CanSample, CanSampleUniformBits, FieldChallenger, GrindingChallenger,
+};
+use p3_commit::{CommitmentOpening, MatrixOpening, Mmcs, OpenedValues, PointOpening};
+use p3_field::{ExtensionField, PrimeField64, TwoAdicField};
+
+use crate::config::StirConfig;
+
+/// Version byte bound into every seed this module builds.
+///
+/// Bumping it separates two revisions of the commitment scheme.
+///
+/// It does so even when their step sequences agree.
+const VERSION: u8 = 1;
+
+/// Protocol name bound into the commitment-phase seed.
+const COMMITMENT_NAME: &[u8] = b"p3-stir-pcs-commitment";
+
+/// Protocol name bound into the claim-phase seed.
+const CLAIM_NAME: &[u8] = b"p3-stir-pcs-claims";
+
+/// Protocol name bound into the opening-phase seed.
+const OPENING_NAME: &[u8] = b"p3-stir-pcs-opening";
+
+/// Step label of one shared-domain group's Merkle root.
+const GROUP_ROOT: &str = "group_root";
+
+/// Container label of one commitment's claims.
+const COMMITMENT_BLOCK: &str = "commitment";
+
+/// Container label of one matrix's claims.
+const MATRIX_BLOCK: &str = "matrix";
+
+/// Step label of one opening's claimed column evaluations.
+const CLAIMED_VALUES: &str = "claimed_values";
+
+/// Container label of one bucket's class-merging block.
+const COMBINE_BLOCK: &str = "bucket_combine";
+
+/// Step label of a bucket's class-merging challenge.
+const COMBINATION_CHALLENGE: &str = "combination_challenge";
+
+/// Container label of the delegated proximity test.
+const PROXIMITY_TEST: &str = "proximity_test";
+
+/// Container label of one bucket's lane block.
+const LANE_BLOCK: &str = "bucket_lanes";
+
+/// Step label of a bucket's fiber-lane indices.
+const FIBER_LANES: &str = "fiber_lanes";
+
+/// Sponge alphabet of a challenger that speaks the base field natively.
+type Alphabet<F> = FieldUnit<F>;
+
+/// Type naming every per-commitment, per-matrix and per-bucket container.
+///
+/// The name is compared locally when a closer meets its opener.
+///
+/// It never reaches the pattern fingerprint.
+type Block = ();
+
+/// Type-level name of the delegated proximity test.
+///
+/// Recorded on the bracket markers as a local diagnostic.
+struct ProximityTest;
+
+/// Append `value` as eight big-endian bytes.
+fn push_u64(out: &mut Vec<u8>, value: u64) {
+    // A fixed width keeps a run of packed numbers self-delimiting.
+    out.extend_from_slice(&value.to_be_bytes());
+}
+
+/// Append the opener of one block.
+fn open(steps: &mut Vec<Interaction>, label: &'static str) {
+    // A mixed container accepts nested steps of any kind, including further containers.
+    steps.push(Interaction::marker::<Block>(
+        Hierarchy::Begin,
+        Kind::Protocol,
+        label,
+    ));
+}
+
+/// Append the closer of one block.
+fn close(steps: &mut Vec<Interaction>, label: &'static str) {
+    // The closer repeats the opener's kind, label and type.
+    //
+    // The validator checks that it does.
+    steps.push(Interaction::marker::<Block>(
+        Hierarchy::End,
+        Kind::Protocol,
+        label,
+    ));
+}
+
+/// Number of first-round query draws one instance makes.
+///
+/// # Overview
+///
+/// The queries that read an instance's initial oracle belong to its first round.
+///
+/// A schedule with no intermediate round reads that oracle in the final round instead.
+///
+/// ```text
+///     rounds > 0   ->  round zero's query count
+///     rounds == 0  ->  the final round's query count
+/// ```
+///
+/// # Returns
+///
+/// The count, taken from the schedule and never from a proof.
+fn first_round_draw_count<F, EF, M, C>(config: &StirConfig<F, EF, M, C>) -> usize
+where
+    F: TwoAdicField + PrimeField64,
+    EF: ExtensionField<F>,
+    M: Mmcs<EF>,
+    C: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+{
+    // An instance that folds at least once reads its initial oracle in round zero.
+    config
+        .round_configs
+        .first()
+        .map_or(config.final_queries, |round| round.num_queries)
+}
+
+/// Numbers that fix the transcript of absorbing one commitment.
+///
+/// Both sides build this from the commitment in front of them.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StirPcsCommitmentShape {
+    /// Number of Merkle roots the commitment holds, one per shared-domain group.
+    pub num_roots: usize,
+}
+
+impl StirPcsCommitmentShape {
+    /// Collect the numbers that fix one commitment absorption.
+    ///
+    /// # Arguments
+    ///
+    /// - `num_roots`: number of Merkle roots the commitment holds.
+    #[must_use]
+    pub const fn new(num_roots: usize) -> Self {
+        Self { num_roots }
+    }
+
+    /// Describe the transcript this shape fixes.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice.
+    ///
+    /// A flat sequence of leaf steps always passes structural validation.
+    #[must_use]
+    pub fn pattern(&self) -> InteractionPattern {
+        // One step per root.
+        //
+        // The root count is the step count.
+        //
+        //     two roots   ->  a description of two steps
+        //     three roots ->  a description of three steps
+        //
+        // The count therefore reaches the seed.
+        //
+        // It needs no absorbed length of its own.
+        let steps = (0..self.num_roots)
+            .map(|_| {
+                Interaction::opaque(Hierarchy::Atomic, Kind::Message, GROUP_ROOT, Length::Scalar)
+            })
+            .collect();
+
+        InteractionPattern::new(steps).expect("a flat sequence of leaf steps is always well formed")
+    }
+
+    /// Bind the protocol identity and this shape into a seed.
+    #[must_use]
+    pub fn domain_separator<F: PrimeField64>(&self) -> DomainSeparator<Alphabet<F>> {
+        // The root count is the only number here.
+        //
+        // The fingerprint already covers it.
+        DomainSeparator::new(VERSION, COMMITMENT_NAME, self.pattern())
+    }
+}
+
+/// Absorb one commitment's Merkle roots.
+///
+/// # Overview
+///
+/// A commitment holds one root per shared-domain group of the matrices it covers.
+///
+/// The roots enter the sponge in order.
+///
+/// The seed already fixes how many there are.
+///
+/// ```text
+///     one commitment of two roots   ->  seed(2 steps), root_a, root_b
+///     two commitments of one root   ->  seed(1 step), root_a, then seed(1 step), root_b
+/// ```
+///
+/// Two commitments that split a given total of roots differently therefore stay apart.
+///
+/// So do two commitments over the same roots in the opposite order.
+///
+/// # Arguments
+///
+/// - `challenger`: sponge of the surrounding protocol, borrowed for the absorption.
+/// - `roots`: the commitment's Merkle roots, in group order.
+///
+/// # Panics
+///
+/// Never in practice.
+///
+/// Every described step is played before the driver is closed.
+pub(crate) fn observe_commitment<Ch, F, C>(challenger: &mut Ch, roots: Vec<C>)
+where
+    F: PrimeField64,
+    C: Clone,
+    Ch: CanObserve<F> + CanObserve<C>,
+{
+    // Seeding folds the root count into the sponge before any root is absorbed.
+    let shape = StirPcsCommitmentShape::new(roots.len());
+    let separator = shape.domain_separator::<F>();
+    let mut state: ProverState<&mut Ch, Alphabet<F>> = ProverState::new(challenger, &separator);
+
+    // Each root travels as an opaque value.
+    //
+    // The challenger owns its encoding, not this layer.
+    for root in roots {
+        state.observe_opaque(GROUP_ROOT, root);
+    }
+
+    // Nothing was written to the driver's own buffer.
+    //
+    // Closing is purely the shape check.
+    assert!(
+        state.finalize().is_empty(),
+        "a commitment absorption carries no wire bytes",
+    );
+}
+
+/// Numbers that fix the transcript of one batch of opening claims.
+///
+/// Both sides build this from their own inputs, never from a proof.
+///
+/// The prover's inputs are the matrices it holds.
+///
+/// The verifier's are the claims it was asked to check.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StirPcsClaimShape {
+    /// Claimed-value counts, nested by commitment, then matrix, then opening point.
+    ///
+    /// Each innermost entry is one matrix's column count.
+    ///
+    /// That is how many values one opening of it carries.
+    pub claim_widths: Vec<Vec<Vec<usize>>>,
+}
+
+impl StirPcsClaimShape {
+    /// Derive the shape from the values a prover is about to claim.
+    ///
+    /// # Arguments
+    ///
+    /// - `opened_values`: the claimed evaluations, nested three levels deep.
+    #[must_use]
+    pub fn from_opened_values<EF>(opened_values: &OpenedValues<EF>) -> Self {
+        // Walk the same three levels the absorption walks, keeping only the counts.
+        let claim_widths = opened_values
+            .iter()
+            .map(|commitment| {
+                commitment
+                    .iter()
+                    .map(|matrix| matrix.iter().map(Vec::len).collect())
+                    .collect()
+            })
+            .collect();
+
+        Self { claim_widths }
+    }
+
+    /// Derive the shape from the claims a verifier was asked to check.
+    ///
+    /// # Arguments
+    ///
+    /// - `claims`: one entry per commitment, holding each matrix's claims.
+    #[must_use]
+    pub fn from_claims<EF, Com, Domain>(claims: &[CommitmentOpening<EF, Com, Domain>]) -> Self {
+        // The claim tree has exactly the nesting the prover's value tree has.
+        let claim_widths = claims
+            .iter()
+            .map(|claim| {
+                claim
+                    .matrices
+                    .iter()
+                    .map(|matrix| {
+                        matrix
+                            .points
+                            .iter()
+                            .map(|PointOpening { values, .. }| values.len())
+                            .collect()
+                    })
+                    .collect()
+            })
+            .collect();
+
+        Self { claim_widths }
+    }
+
+    /// Describe the transcript this shape fixes.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice.
+    ///
+    /// Every container opened below is closed in the same call.
+    #[must_use]
+    pub fn pattern<F, EF>(&self) -> InteractionPattern
+    where
+        F: PrimeField64,
+        EF: ExtensionField<F>,
+    {
+        let mut steps = Vec::new();
+
+        for commitment in &self.claim_widths {
+            // One commitment is one block.
+            //
+            // Its matrix count cannot be reshuffled.
+            open(&mut steps, COMMITMENT_BLOCK);
+            for matrix in commitment {
+                // One matrix is one block too.
+                //
+                // Its opening count cannot be reshuffled either.
+                open(&mut steps, MATRIX_BLOCK);
+                for &width in matrix {
+                    // One opening is one step declaring that matrix's column count.
+                    //
+                    // The width belongs to the description.
+                    //
+                    // It does not come from the values as they arrive.
+                    steps.push(Interaction::algebra::<F, EF>(
+                        Hierarchy::Atomic,
+                        Kind::Message,
+                        CLAIMED_VALUES,
+                        Length::Fixed(width),
+                    ));
+                }
+                close(&mut steps, MATRIX_BLOCK);
+            }
+            close(&mut steps, COMMITMENT_BLOCK);
+        }
+
+        InteractionPattern::new(steps).expect("every container opened here is closed here")
+    }
+
+    /// Bind the protocol identity and this shape into a seed.
+    ///
+    /// Every number of this phase shapes the step sequence.
+    ///
+    /// The fingerprint of that sequence covers all of them.
+    #[must_use]
+    pub fn domain_separator<F, EF>(&self) -> DomainSeparator<Alphabet<F>>
+    where
+        F: PrimeField64,
+        EF: ExtensionField<F>,
+    {
+        DomainSeparator::new(VERSION, CLAIM_NAME, self.pattern::<F, EF>())
+    }
+}
+
+/// Bind one batch of claimed evaluations, prover side.
+///
+/// # Overview
+///
+/// The description is derived from the very values being bound.
+///
+/// So the widths and the grouping reach the seed.
+///
+/// No disagreement between the two is representable.
+///
+/// # Arguments
+///
+/// - `challenger`: sponge of the surrounding protocol, borrowed for the phase.
+/// - `opened_values`: the claimed evaluations, nested by commitment, matrix and point.
+///
+/// # Panics
+///
+/// Never in practice.
+///
+/// Every described step is played before the driver is closed.
+pub(crate) fn observe_opened_values<Ch, F, EF>(
+    challenger: &mut Ch,
+    opened_values: &OpenedValues<EF>,
+) where
+    F: PrimeField64,
+    EF: ExtensionField<F>,
+    Ch: CanObserve<F> + CanSample<F>,
+{
+    // Seeding folds the claim shape into the sponge before any value is absorbed.
+    let shape = StirPcsClaimShape::from_opened_values(opened_values);
+    let separator = shape.domain_separator::<F, EF>();
+    let mut state: ProverState<&mut Ch, Alphabet<F>> = ProverState::new(challenger, &separator);
+
+    for commitment in opened_values {
+        // Open the commitment's block before any of its matrices.
+        state.begin_protocol::<Block>(COMMITMENT_BLOCK);
+        for matrix in commitment {
+            // Open the matrix's block before any of its openings.
+            state.begin_protocol::<Block>(MATRIX_BLOCK);
+            for values in matrix {
+                // One opening is one step carrying that matrix's whole row of claims.
+                let _bound =
+                    state.observe_extensions::<F, EF, FieldToFieldCodec<F>>(CLAIMED_VALUES, values);
+            }
+            state.end_protocol::<Block>(MATRIX_BLOCK);
+        }
+        state.end_protocol::<Block>(COMMITMENT_BLOCK);
+    }
+
+    // The claims travel in the caller's own proof.
+    //
+    // The driver buffered nothing.
+    assert!(
+        state.finalize().is_empty(),
+        "the commitment scheme carries every claim in its own proof",
+    );
+}
+
+/// Bind one batch of opening claims, verifier side.
+///
+/// # Overview
+///
+/// Mirrors the prover side value for value, over the same description.
+///
+/// The claims are the statement this call was handed, not anything read out of a proof.
+///
+/// So the description derived from them agrees with them by construction.
+///
+/// # Arguments
+///
+/// - `challenger`: sponge of the surrounding protocol, borrowed for the phase.
+/// - `claims`: one entry per commitment, holding the points and values of each matrix.
+///
+/// # Panics
+///
+/// Never in practice.
+///
+/// Every described step is played before the driver is closed.
+pub(crate) fn observe_claims<Ch, F, EF, Com, Domain>(
+    challenger: &mut Ch,
+    claims: &[CommitmentOpening<EF, Com, Domain>],
+) where
+    F: PrimeField64,
+    EF: ExtensionField<F>,
+    Ch: CanObserve<F> + CanSample<F>,
+{
+    // Seeding folds the claim shape into the sponge before any value is absorbed.
+    let shape = StirPcsClaimShape::from_claims(claims);
+    let separator = shape.domain_separator::<F, EF>();
+    let mut state: VerifierState<'static, &mut Ch, Alphabet<F>> =
+        VerifierState::new(challenger, &separator, &[]);
+
+    for claim in claims {
+        // Open the commitment's block before any of its matrices.
+        state.begin_protocol::<Block>(COMMITMENT_BLOCK);
+        for MatrixOpening { points, .. } in &claim.matrices {
+            // Open the matrix's block before any of its openings.
+            state.begin_protocol::<Block>(MATRIX_BLOCK);
+            for PointOpening { values, .. } in points {
+                // The step's own width came from this slice.
+                //
+                // The count check cannot fire.
+                let _bound =
+                    state.observe_extensions::<F, EF, FieldToFieldCodec<F>>(CLAIMED_VALUES, values);
+            }
+            state.end_protocol::<Block>(MATRIX_BLOCK);
+        }
+        state.end_protocol::<Block>(COMMITMENT_BLOCK);
+    }
+
+    // The claims are held by the caller.
+    //
+    // No wire bytes can remain unread.
+    state
+        .finalize()
+        .expect("the commitment scheme reads an empty wire");
+}
+
+/// Numbers that fix the transcript of one shared-domain bucket.
+///
+/// Both sides build this from their own configuration, never from a proof.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StirPcsBucketShape {
+    /// Log of the shared evaluation domain this bucket's instance runs on.
+    ///
+    /// Reaches the seed through the instance label.
+    pub log_lde_height: usize,
+    /// Log of every native height merged into this bucket's codeword, descending.
+    ///
+    /// A single entry means nothing is merged.
+    ///
+    /// No merging challenge is then drawn.
+    ///
+    /// Reaches the seed through the instance label.
+    pub log_native_heights: Vec<usize>,
+    /// Log of the arity of the first fold.
+    ///
+    /// This is the bit width of one lane index.
+    pub log_first_fold_arity: usize,
+    /// Number of first-round query draws.
+    ///
+    /// One lane is drawn per query draw.
+    pub num_query_draws: usize,
+}
+
+impl StirPcsBucketShape {
+    /// Derive one bucket's shape from its configuration.
+    ///
+    /// # Arguments
+    ///
+    /// - `log_lde_height`: log of the shared evaluation domain the bucket runs on.
+    /// - `log_native_heights`: log of every native height the bucket merges, descending.
+    /// - `config`: the schedule the bucket's proximity test was solved for.
+    #[must_use]
+    pub fn new<F, EF, M, C>(
+        log_lde_height: usize,
+        log_native_heights: Vec<usize>,
+        config: &StirConfig<F, EF, M, C>,
+    ) -> Self
+    where
+        F: TwoAdicField + PrimeField64,
+        EF: ExtensionField<F>,
+        M: Mmcs<EF>,
+        C: FieldChallenger<F> + GrindingChallenger<Witness = F>,
+    {
+        Self {
+            log_lde_height,
+            log_native_heights,
+            // A fiber of the first fold domain holds one point per lane.
+            //
+            // So a lane index spans exactly the arity's worth of bits.
+            log_first_fold_arity: config.log_starting_folding_factor,
+            // One lane is drawn per first-round query draw, repeats included.
+            num_query_draws: first_round_draw_count(config),
+        }
+    }
+
+    /// Whether this bucket merges more than one native height.
+    ///
+    /// A bucket of a single height needs no merging challenge.
+    #[must_use]
+    pub const fn merges_classes(&self) -> bool {
+        self.log_native_heights.len() > 1
+    }
+
+    /// Every number of this bucket, packed for the instance label.
+    ///
+    /// Each value is eight big-endian bytes.
+    ///
+    /// The packing is therefore self-delimiting.
+    fn label_bytes(&self) -> Vec<u8> {
+        // Two bucket-wide values, then one per merged height.
+        let mut out = Vec::with_capacity(8 * (2 + self.log_native_heights.len()));
+        push_u64(&mut out, self.log_lde_height as u64);
+        push_u64(&mut out, self.log_native_heights.len() as u64);
+        for &log_native_height in &self.log_native_heights {
+            push_u64(&mut out, log_native_height as u64);
+        }
+        out
+    }
+}
+
+/// Numbers that fix the transcript of one opening argument's bucket phase.
+///
+/// Both sides build this from their own configuration, never from a proof.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StirPcsOpeningShape {
+    /// One entry per bucket, in the order the buckets are played.
+    pub buckets: Vec<StirPcsBucketShape>,
+}
+
+impl StirPcsOpeningShape {
+    /// Collect the buckets one opening argument plays.
+    ///
+    /// # Arguments
+    ///
+    /// - `buckets`: one entry per bucket, in play order.
+    #[must_use]
+    pub const fn new(buckets: Vec<StirPcsBucketShape>) -> Self {
+        Self { buckets }
+    }
+
+    /// Number of buckets this argument plays.
+    #[must_use]
+    pub const fn num_buckets(&self) -> usize {
+        self.buckets.len()
+    }
+
+    /// Describe the transcript this shape fixes.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice.
+    ///
+    /// Every container opened below is closed in the same call.
+    #[must_use]
+    pub fn pattern<F, EF>(&self) -> InteractionPattern
+    where
+        F: PrimeField64,
+        EF: ExtensionField<F>,
+    {
+        // Three steps per merging block, three per lane block, two for the bracket.
+        let mut steps = Vec::with_capacity(6 * self.buckets.len() + 2);
+
+        for bucket in &self.buckets {
+            // Every bucket opens a merging block, whether or not it draws inside it.
+            //
+            // The block says where one bucket's merging stops.
+            open(&mut steps, COMBINE_BLOCK);
+            if bucket.merges_classes() {
+                // One challenge merges the bucket's classes into one codeword.
+                steps.push(Interaction::algebra::<F, EF>(
+                    Hierarchy::Atomic,
+                    Kind::Challenge,
+                    COMBINATION_CHALLENGE,
+                    Length::Scalar,
+                ));
+            }
+            close(&mut steps, COMBINE_BLOCK);
+        }
+
+        // The bracket records that a sub-protocol runs here.
+        //
+        // Its steps live in the callee's own description.
+        //
+        // This description states only that the delegation happens, and where.
+        steps.push(Interaction::marker::<ProximityTest>(
+            Hierarchy::Begin,
+            Kind::Protocol,
+            PROXIMITY_TEST,
+        ));
+        steps.push(Interaction::marker::<ProximityTest>(
+            Hierarchy::End,
+            Kind::Protocol,
+            PROXIMITY_TEST,
+        ));
+
+        for bucket in &self.buckets {
+            // Lanes are drawn only once the whole proximity test is in the sponge.
+            open(&mut steps, LANE_BLOCK);
+            // Lane indices are drawn without modular bias.
+            //
+            // The tag records that.
+            steps.push(Interaction::uniform_bits(
+                Hierarchy::Atomic,
+                Kind::Challenge,
+                FIBER_LANES,
+                bucket.log_first_fold_arity,
+                Length::Fixed(bucket.num_query_draws),
+            ));
+            close(&mut steps, LANE_BLOCK);
+        }
+
+        InteractionPattern::new(steps).expect("every container opened here is closed here")
+    }
+
+    /// Bind the protocol identity, this shape, and the remaining parameters.
+    ///
+    /// A number that changes the step sequence is covered by the fingerprint.
+    ///
+    /// The rest go in the instance label.
+    #[must_use]
+    pub fn domain_separator<F, EF>(&self) -> DomainSeparator<Alphabet<F>>
+    where
+        F: PrimeField64,
+        EF: ExtensionField<F>,
+    {
+        let mut separator = DomainSeparator::new(VERSION, OPENING_NAME, self.pattern::<F, EF>());
+
+        // Header: how many buckets share the argument.
+        let mut header = Vec::with_capacity(8);
+        push_u64(&mut header, self.buckets.len() as u64);
+        separator.instance(&header);
+
+        // One delimited chunk per bucket.
+        //
+        // Two bucketings never collapse into one.
+        for bucket in &self.buckets {
+            separator.instance(&bucket.label_bytes());
+        }
+
+        separator
+    }
+}
+
+/// Prover-side transcript of one opening argument's bucket phase.
+///
+/// # Overview
+///
+/// Holds the only definition of what a prover draws around the proximity test.
+///
+/// Three things happen here, in this order.
+///
+/// - Each bucket merges its native-height classes into one codeword.
+/// - The proximity test runs on every bucket, inside a bracket.
+/// - Each bucket picks one fiber lane per first-round query draw.
+///
+/// # Why the lanes come last
+///
+/// A lane check reads the input rows at one position inside a queried fiber.
+///
+/// A prover who learns that position first can place its disagreement elsewhere.
+///
+/// No lane would then ever land on it.
+///
+/// So every lane is drawn once the whole proximity test is already in the sponge.
+///
+/// # Borrowing
+///
+/// The challenger is borrowed, not consumed.
+///
+/// The commitment scheme runs inside a larger protocol.
+///
+/// That protocol's own transcript continues where this one stops.
+pub struct OpeningProverTranscript<'a, C, F: PrimeField64, EF> {
+    /// Driver walking the description and holding the borrowed sponge.
+    state: ProverState<&'a mut C, Alphabet<F>>,
+    /// The numbers this run was described with.
+    shape: StirPcsOpeningShape,
+    /// Marker for the extension field the challenges live in.
+    _ef: PhantomData<EF>,
+}
+
+impl<'a, C, F, EF> OpeningProverTranscript<'a, C, F, EF>
+where
+    F: PrimeField64,
+    EF: ExtensionField<F>,
+    C: CanObserve<F> + CanSample<F> + CanSampleUniformBits<F>,
+{
+    /// Seed the transcript from the shape.
+    ///
+    /// # Arguments
+    ///
+    /// - `challenger`: sponge of the surrounding protocol, borrowed for the phase.
+    /// - `shape`: the numbers that fix this phase's transcript.
+    pub fn new(challenger: &'a mut C, shape: StirPcsOpeningShape) -> Self {
+        // Seeding folds the shape fingerprint into the sponge before any step.
+        let separator = shape.domain_separator::<F, EF>();
+        Self {
+            state: ProverState::new(challenger, &separator),
+            shape,
+            _ef: PhantomData,
+        }
+    }
+
+    /// Play one bucket's merging block.
+    ///
+    /// # Returns
+    ///
+    /// The merging challenge, or nothing when the bucket holds a single native height.
+    ///
+    /// # Panics
+    ///
+    /// When the bucket index lies outside the described run.
+    pub fn combination_challenge(&mut self, bucket: usize) -> Option<EF> {
+        let merges = self.shape.buckets[bucket].merges_classes();
+        // The block opens either way.
+        //
+        // It marks this bucket's slot in the sequence.
+        self.state.begin_protocol::<Block>(COMBINE_BLOCK);
+        let challenge = merges.then(|| {
+            self.state
+                .challenge_extension::<F, EF, FieldToFieldCodec<F>>(COMBINATION_CHALLENGE)
+                .into_inner()
+        });
+        self.state.end_protocol::<Block>(COMBINE_BLOCK);
+        challenge
+    }
+
+    /// Lend the sponge to the proximity test, bracketed as a sub-protocol.
+    ///
+    /// The callee seeds its own driver from the state this one has reached.
+    ///
+    /// # Returns
+    ///
+    /// Whatever the delegated run produced.
+    pub fn delegate<R>(&mut self, run: impl FnOnce(&mut C) -> R) -> R {
+        self.state.begin_protocol::<ProximityTest>(PROXIMITY_TEST);
+        let output = run(self.state.challenger_mut());
+        self.state.end_protocol::<ProximityTest>(PROXIMITY_TEST);
+        output
+    }
+
+    /// Draw one bucket's fiber lanes, one per first-round query draw.
+    ///
+    /// # Returns
+    ///
+    /// Every lane index, in draw order, repeats included.
+    ///
+    /// # Panics
+    ///
+    /// When the bucket index lies outside the described run.
+    pub fn lanes(&mut self, bucket: usize) -> Vec<usize> {
+        let shape = &self.shape.buckets[bucket];
+        let (width, count) = (shape.log_first_fold_arity, shape.num_query_draws);
+        self.state.begin_protocol::<Block>(LANE_BLOCK);
+        let lanes = self
+            .state
+            .challenge_uniform_bits::<F>(FIBER_LANES, width, count)
+            .into_iter()
+            .map(TranscriptBound::into_inner)
+            .collect();
+        self.state.end_protocol::<Block>(LANE_BLOCK);
+        lanes
+    }
+
+    /// Close the transcript once every described step has been played.
+    ///
+    /// # Panics
+    ///
+    /// When the run played fewer steps than it was described with.
+    pub fn finish(self) {
+        // Every value of this phase is a challenge.
+        //
+        // The driver buffered nothing.
+        assert!(
+            self.state.finalize().is_empty(),
+            "the bucket phase draws challenges and sends nothing",
+        );
+    }
+}
+
+/// Verifier-side transcript of one opening argument's bucket phase.
+///
+/// Mirrors the prover side call for call, over the same description.
+///
+/// Every value of this phase is drawn from the sponge.
+///
+/// No step of it can be rejected.
+pub struct OpeningVerifierTranscript<'a, C, F: PrimeField64, EF> {
+    /// Driver walking the description and holding the borrowed sponge.
+    ///
+    /// The phase sends nothing.
+    ///
+    /// The driver reads an empty wire.
+    state: VerifierState<'static, &'a mut C, Alphabet<F>>,
+    /// The numbers this run was described with.
+    shape: StirPcsOpeningShape,
+    /// Marker for the extension field the challenges live in.
+    _ef: PhantomData<EF>,
+}
+
+impl<'a, C, F, EF> OpeningVerifierTranscript<'a, C, F, EF>
+where
+    F: PrimeField64,
+    EF: ExtensionField<F>,
+    C: CanObserve<F> + CanSample<F> + CanSampleUniformBits<F>,
+{
+    /// Seed the transcript from the shape.
+    ///
+    /// The arguments match the prover's.
+    ///
+    /// Both sides seed identically.
+    pub fn new(challenger: &'a mut C, shape: StirPcsOpeningShape) -> Self {
+        // Seeding folds the shape fingerprint into the sponge before any step.
+        let separator = shape.domain_separator::<F, EF>();
+        Self {
+            state: VerifierState::new(challenger, &separator, &[]),
+            shape,
+            _ef: PhantomData,
+        }
+    }
+
+    /// Replay one bucket's merging block.
+    ///
+    /// # Returns
+    ///
+    /// The merging challenge, or nothing when the bucket holds a single native height.
+    ///
+    /// # Panics
+    ///
+    /// When the bucket index lies outside the described run.
+    pub fn combination_challenge(&mut self, bucket: usize) -> Option<EF> {
+        let merges = self.shape.buckets[bucket].merges_classes();
+        // The block opens either way.
+        //
+        // It marks this bucket's slot in the sequence.
+        self.state.begin_protocol::<Block>(COMBINE_BLOCK);
+        let challenge = merges.then(|| {
+            self.state
+                .challenge_extension::<F, EF, FieldToFieldCodec<F>>(COMBINATION_CHALLENGE)
+                .into_inner()
+        });
+        self.state.end_protocol::<Block>(COMBINE_BLOCK);
+        challenge
+    }
+
+    /// Lend the sponge to the proximity test, bracketed as a sub-protocol.
+    ///
+    /// The bracket closes whatever the delegated run returned.
+    ///
+    /// A rejection therefore leaves this transcript replayable to the end.
+    ///
+    /// # Returns
+    ///
+    /// Whatever the delegated run produced.
+    pub fn delegate<R>(&mut self, run: impl FnOnce(&mut C) -> R) -> R {
+        self.state.begin_protocol::<ProximityTest>(PROXIMITY_TEST);
+        let output = run(self.state.challenger_mut());
+        self.state.end_protocol::<ProximityTest>(PROXIMITY_TEST);
+        output
+    }
+
+    /// Redraw one bucket's fiber lanes, one per first-round query draw.
+    ///
+    /// # Returns
+    ///
+    /// Every lane index, in draw order, repeats included.
+    ///
+    /// # Panics
+    ///
+    /// When the bucket index lies outside the described run.
+    pub fn lanes(&mut self, bucket: usize) -> Vec<usize> {
+        let shape = &self.shape.buckets[bucket];
+        let (width, count) = (shape.log_first_fold_arity, shape.num_query_draws);
+        self.state.begin_protocol::<Block>(LANE_BLOCK);
+        let lanes = self
+            .state
+            .challenge_uniform_bits::<F>(FIBER_LANES, width, count)
+            .into_iter()
+            .map(TranscriptBound::into_inner)
+            .collect();
+        self.state.end_protocol::<Block>(LANE_BLOCK);
+        lanes
+    }
+
+    /// Release the completeness check because the proof is being rejected.
+    ///
+    /// Every path that leaves the transcript early goes through this.
+    ///
+    /// Dropping an unfinished driver otherwise panics.
+    ///
+    /// That panic would land on top of an error already travelling to the caller.
+    pub fn abort(&mut self) {
+        self.state.abort();
+    }
+
+    /// Close the transcript once every described step has been replayed.
+    ///
+    /// # Panics
+    ///
+    /// When the run replayed fewer steps than it was described with.
+    pub fn finish(self) {
+        self.state
+            .finalize()
+            .expect("the bucket phase reads an empty wire, so no bytes can remain");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
+    use p3_challenger::testing::{SeedDigest, assert_seeds_pairwise_distinct, seed_digest};
+    use p3_challenger::{CanSampleBits, DuplexChallenger};
+    use p3_field::PrimeCharacteristicRing;
+    use p3_field::extension::BinomialExtensionField;
+    use rand::SeedableRng;
+    use rand::rngs::SmallRng;
+
+    use super::*;
+
+    type F = BabyBear;
+    type EF = BinomialExtensionField<F, 4>;
+    type Perm = Poseidon2BabyBear<16>;
+    type Ch = DuplexChallenger<F, Perm, 16, 8>;
+
+    /// One commitment's claims, shaped the way a caller hands them over.
+    type Claim = CommitmentOpening<EF, (), ()>;
+
+    fn fresh_challenger() -> Ch {
+        // Fixed seed so two runs differ only where the transcript makes them differ.
+        let mut rng = SmallRng::seed_from_u64(0x5717_09C5);
+        Ch::new(Perm::new_from_rng_128(&mut rng))
+    }
+
+    /// A verifier-side claim tree matching `widths`, with every claimed value set to one.
+    fn claims_of(widths: &[Vec<Vec<usize>>]) -> Vec<Claim> {
+        widths
+            .iter()
+            .map(|commitment| CommitmentOpening {
+                commitment: (),
+                matrices: commitment
+                    .iter()
+                    .map(|matrix| MatrixOpening {
+                        domain: (),
+                        // Each opening point carries as many values as its width says.
+                        points: matrix
+                            .iter()
+                            .map(|&width| PointOpening {
+                                point: EF::ONE,
+                                values: vec![EF::ONE; width],
+                            })
+                            .collect(),
+                    })
+                    .collect(),
+            })
+            .collect()
+    }
+
+    /// A prover-side value tree matching `widths`, with every claimed value set to one.
+    fn opened_values_of(widths: &[Vec<Vec<usize>>]) -> OpenedValues<EF> {
+        widths
+            .iter()
+            .map(|commitment| {
+                commitment
+                    .iter()
+                    .map(|matrix| matrix.iter().map(|&w| vec![EF::ONE; w]).collect())
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// The digest of the byte stream a claim grouping seeds its sponge with.
+    fn claim_seed(widths: Vec<Vec<Vec<usize>>>) -> SeedDigest {
+        let shape = StirPcsClaimShape {
+            claim_widths: widths,
+        };
+        seed_digest(&shape.domain_separator::<F, EF>())
+    }
+
+    /// One bucket over the given merged heights, with fixed lane geometry.
+    fn bucket(log_native_heights: Vec<usize>) -> StirPcsBucketShape {
+        StirPcsBucketShape {
+            log_lde_height: 10,
+            log_native_heights,
+            log_first_fold_arity: 2,
+            num_query_draws: 3,
+        }
+    }
+
+    /// The digest of the byte stream a bucket-phase shape seeds its sponge with.
+    fn opening_seed(shape: &StirPcsOpeningShape) -> SeedDigest {
+        seed_digest(&shape.domain_separator::<F, EF>())
+    }
+
+    #[test]
+    fn the_root_count_of_a_commitment_reaches_its_seed() {
+        // Invariant: the root count is the step count.
+        //
+        // It cannot move without the seed moving too.
+        //
+        // Fixture state: three absorptions, of one, two and three roots.
+        //
+        //     1 root  -> a description of 1 step
+        //     2 roots -> a description of 2 steps
+        //     3 roots -> a description of 3 steps
+        let seeds: Vec<(usize, SeedDigest)> = (1..=3)
+            .map(|num_roots| {
+                let shape = StirPcsCommitmentShape::new(num_roots);
+                (num_roots, seed_digest(&shape.domain_separator::<F>()))
+            })
+            .collect();
+
+        assert_seeds_pairwise_distinct(&seeds);
+    }
+
+    #[test]
+    fn splitting_a_commitment_in_two_moves_the_sponge() {
+        // Invariant: two roots absorbed as one commitment differ from two absorbed apart.
+        //
+        // Fixture state: roots 7 and 9, absorbed once together and once separately.
+        //
+        // Mutation: split the two-root commitment into two one-root commitments.
+        //
+        //     merged: seed(2 steps), 7, 9
+        //     split : seed(1 step), 7, then seed(1 step), 9
+        let (root_a, root_b) = (F::from_u64(7), F::from_u64(9));
+
+        let mut merged = fresh_challenger();
+        observe_commitment::<_, F, _>(&mut merged, vec![root_a, root_b]);
+
+        let mut split = fresh_challenger();
+        observe_commitment::<_, F, _>(&mut split, vec![root_a]);
+        observe_commitment::<_, F, _>(&mut split, vec![root_b]);
+
+        assert_ne!(merged.sample_bits(24), split.sample_bits(24));
+    }
+
+    #[test]
+    fn the_root_order_of_a_commitment_reaches_the_sponge() {
+        // Invariant: roots are absorbed in sequence, never as an order-insensitive set.
+        //
+        // Fixture state: the same two roots, in the two possible orders.
+        //
+        // Mutation: swap the two roots.
+        //
+        //     forward : 7, 9
+        //     reversed: 9, 7
+        let (root_a, root_b) = (F::from_u64(7), F::from_u64(9));
+
+        let mut forward = fresh_challenger();
+        observe_commitment::<_, F, _>(&mut forward, vec![root_a, root_b]);
+
+        let mut reversed = fresh_challenger();
+        observe_commitment::<_, F, _>(&mut reversed, vec![root_b, root_a]);
+
+        assert_ne!(forward.sample_bits(24), reversed.sample_bits(24));
+    }
+
+    #[test]
+    fn a_root_that_moves_moves_the_sponge() {
+        // Invariant: every root is absorbed.
+        //
+        // Perturbing one parts the two sponges.
+        //
+        // Fixture state: a commitment of three roots, 7, 9 and 11.
+        //
+        // Mutation: bump the middle root by one.
+        //
+        //     bound:     7,  9, 11
+        //     perturbed: 7, 10, 11
+        let roots = vec![F::from_u64(7), F::from_u64(9), F::from_u64(11)];
+
+        let mut bound = fresh_challenger();
+        observe_commitment::<_, F, _>(&mut bound, roots.clone());
+
+        let mut perturbed_roots = roots;
+        perturbed_roots[1] += F::ONE;
+        let mut perturbed = fresh_challenger();
+        observe_commitment::<_, F, _>(&mut perturbed, perturbed_roots);
+
+        assert_ne!(bound.sample_bits(24), perturbed.sample_bits(24));
+    }
+
+    #[test]
+    fn no_two_claim_groupings_share_a_seed() {
+        // Invariant: every knob of the claim description is pairwise separated.
+        //
+        // Fixture state: one commitment, one matrix, two openings of widths 3 and 1.
+        //
+        // Mutation: one step away from that baseline, six different ways.
+        //
+        //     baseline         [[[3, 1]]]
+        //     wider            [[[4, 1]]]        one more value in the first opening
+        //     longer           [[[3, 1, 2]]]     one more opening, so one more step
+        //     reordered        [[[1, 3]]]        the same widths, absorbed the other way
+        //     two matrices     [[[3], [1]]]      the same widths, split across two blocks
+        //     two commitments  [[[3]], [[1]]]    the same widths, split across two blocks
+        let seeds = [
+            ("baseline", claim_seed(vec![vec![vec![3, 1]]])),
+            ("wider", claim_seed(vec![vec![vec![4, 1]]])),
+            ("longer", claim_seed(vec![vec![vec![3, 1, 2]]])),
+            ("reordered", claim_seed(vec![vec![vec![1, 3]]])),
+            ("two matrices", claim_seed(vec![vec![vec![3], vec![1]]])),
+            (
+                "two commitments",
+                claim_seed(vec![vec![vec![3]], vec![vec![1]]]),
+            ),
+        ];
+
+        assert_seeds_pairwise_distinct(&seeds);
+    }
+
+    #[test]
+    fn the_claim_grouping_reaches_the_pattern_itself() {
+        // Invariant: the containers separate two groupings.
+        //
+        // No separate label does that work.
+        //
+        // Fixture state: three groupings whose widths all flatten to `3, 3`.
+        //
+        //     one matrix, two points   Begin c  Begin m  3  3  End  End
+        //     two matrices, one point  Begin c  Begin m  3  End  Begin m  3  End  End
+        //     two commitments          Begin c  Begin m  3  End  End  Begin c  ...
+        //
+        // Fingerprints are compared here rather than seeds.
+        //
+        // A seed would also move if a label carried the grouping instead.
+        let two_points = StirPcsClaimShape {
+            claim_widths: vec![vec![vec![3, 3]]],
+        };
+        let two_matrices = StirPcsClaimShape {
+            claim_widths: vec![vec![vec![3], vec![3]]],
+        };
+        let two_commitments = StirPcsClaimShape {
+            claim_widths: vec![vec![vec![3]], vec![vec![3]]],
+        };
+
+        let hashes = [
+            two_points.pattern::<F, EF>().pattern_hash(),
+            two_matrices.pattern::<F, EF>().pattern_hash(),
+            two_commitments.pattern::<F, EF>().pattern_hash(),
+        ];
+
+        // Mutation: strip the containers.
+        //
+        // The three then collapse onto one description.
+        let flattened: Vec<[u8; 32]> = [&two_points, &two_matrices, &two_commitments]
+            .iter()
+            .map(|shape| {
+                let leaves: Vec<Interaction> = shape
+                    .pattern::<F, EF>()
+                    .interactions()
+                    .iter()
+                    .copied()
+                    .filter(|step| step.hierarchy() == Hierarchy::Atomic)
+                    .collect();
+                InteractionPattern::new(leaves)
+                    .expect("leaves alone are well formed")
+                    .pattern_hash()
+            })
+            .collect();
+
+        // Nested: all three descriptions differ.
+        assert_ne!(hashes[0], hashes[1]);
+        assert_ne!(hashes[0], hashes[2]);
+        assert_ne!(hashes[1], hashes[2]);
+        // Flat: all three descriptions coincide.
+        //
+        // That is what the containers rule out.
+        assert_eq!(flattened[0], flattened[1]);
+        assert_eq!(flattened[0], flattened[2]);
+    }
+
+    #[test]
+    fn a_claimed_value_that_moves_moves_the_sponge() {
+        // Invariant: every claimed value is absorbed.
+        //
+        // Perturbing one parts the two sponges.
+        //
+        // Fixture state: two commitments of widths [[3, 1], [2]] and [[4]].
+        //
+        // Mutation: bump one claimed value of the second commitment's only opening.
+        //
+        //     bound:     ..., [1, 1, 1, 1]
+        //     perturbed: ..., [1, 1, 2, 1]
+        let widths = vec![vec![vec![3, 1], vec![2]], vec![vec![4]]];
+        let values = opened_values_of(&widths);
+
+        let mut bound = fresh_challenger();
+        observe_opened_values::<_, F, EF>(&mut bound, &values);
+
+        let mut perturbed_values = values;
+        perturbed_values[1][0][0][2] += EF::ONE;
+        let mut perturbed = fresh_challenger();
+        observe_opened_values::<_, F, EF>(&mut perturbed, &perturbed_values);
+
+        assert_ne!(bound.sample_bits(24), perturbed.sample_bits(24));
+    }
+
+    #[test]
+    fn both_sides_absorb_one_batch_of_claims_identically() {
+        // Invariant: each side drives the claim phase from its own input shape.
+        //
+        // Both land on the same sponge state.
+        //
+        // Fixture state: two commitments of widths [[3, 1], [2]] and [[4]].
+        //
+        //     prover  : walks the value tree it computed
+        //     verifier: walks the claim tree it was handed
+        let widths = vec![vec![vec![3, 1], vec![2]], vec![vec![4]]];
+
+        let mut prover = fresh_challenger();
+        observe_opened_values::<_, F, EF>(&mut prover, &opened_values_of(&widths));
+
+        let mut verifier = fresh_challenger();
+        observe_claims::<_, F, EF, (), ()>(&mut verifier, &claims_of(&widths));
+
+        assert_eq!(prover.sample_bits(24), verifier.sample_bits(24));
+
+        // Both sides derive the same description from their own tree.
+        assert_eq!(
+            StirPcsClaimShape::from_opened_values(&opened_values_of(&widths)),
+            StirPcsClaimShape::from_claims(&claims_of(&widths)),
+        );
+    }
+
+    #[test]
+    fn no_two_configurations_of_the_bucket_shape_share_a_seed() {
+        // Invariant: every knob of the bucket-phase shape reaches the seed, pairwise.
+        //
+        // Fixture state: one bucket on the domain of size 2^10.
+        //
+        //     merged heights   2^8 and 2^6
+        //     lane draws       3 indices of 2 bits each
+        //
+        // Mutation: one field moved by one step, seven different ways.
+        let baseline = StirPcsOpeningShape::new(vec![bucket(vec![8, 6])]);
+
+        let mut wider_domain = baseline.clone();
+        wider_domain.buckets[0].log_lde_height += 1;
+
+        let mut one_class = baseline.clone();
+        one_class.buckets[0].log_native_heights = vec![8];
+
+        let mut other_classes = baseline.clone();
+        other_classes.buckets[0].log_native_heights = vec![8, 5];
+
+        let mut three_classes = baseline.clone();
+        three_classes.buckets[0].log_native_heights = vec![8, 6, 4];
+
+        let mut wider_lane = baseline.clone();
+        wider_lane.buckets[0].log_first_fold_arity += 1;
+
+        let mut more_draws = baseline.clone();
+        more_draws.buckets[0].num_query_draws += 1;
+
+        let mut two_buckets = baseline.clone();
+        two_buckets.buckets.push(bucket(vec![8, 6]));
+
+        let seeds = [
+            ("baseline", opening_seed(&baseline)),
+            ("log_lde_height", opening_seed(&wider_domain)),
+            ("one merged class", opening_seed(&one_class)),
+            ("other merged classes", opening_seed(&other_classes)),
+            ("three merged classes", opening_seed(&three_classes)),
+            ("log_first_fold_arity", opening_seed(&wider_lane)),
+            ("num_query_draws", opening_seed(&more_draws)),
+            ("bucket count", opening_seed(&two_buckets)),
+        ];
+
+        assert_seeds_pairwise_distinct(&seeds);
+    }
+
+    #[test]
+    fn a_single_class_bucket_draws_no_merging_challenge() {
+        // Invariant: the merging block is present either way.
+        //
+        // It is empty for a bucket of one class.
+        //
+        // Fixture state: two buckets, the first merging two heights and the second one.
+        //
+        //     bucket 0   Begin combine  challenge  End
+        //     bucket 1   Begin combine             End
+        let shape = StirPcsOpeningShape::new(vec![bucket(vec![8, 6]), bucket(vec![8])]);
+
+        let mut challenger = fresh_challenger();
+        let mut transcript =
+            OpeningProverTranscript::<Ch, F, EF>::new(&mut challenger, shape.clone());
+
+        // The merging bucket yields a challenge.
+        //
+        // The single-class one yields nothing.
+        assert!(transcript.combination_challenge(0).is_some());
+        assert!(transcript.combination_challenge(1).is_none());
+        transcript.delegate(|_| ());
+        let _lanes_0 = transcript.lanes(0);
+        let _lanes_1 = transcript.lanes(1);
+        transcript.finish();
+
+        // Mutation: let the second bucket merge too.
+        //
+        // That adds a step.
+        //
+        // The seed moves with it.
+        let both_merge = StirPcsOpeningShape::new(vec![bucket(vec![8, 6]), bucket(vec![8, 4])]);
+        assert_ne!(opening_seed(&shape), opening_seed(&both_merge));
+    }
+
+    #[test]
+    fn both_sides_draw_the_same_bucket_challenges() {
+        // Invariant: the two sides walk the bucket phase in lockstep, bracket included.
+        //
+        // They leave the sponge in one state.
+        //
+        // Fixture state: two buckets, the first merging two heights and the second one.
+        let shape = StirPcsOpeningShape::new(vec![bucket(vec![8, 6]), bucket(vec![7])]);
+
+        // Prover side: merge, delegate, then draw the lanes of both buckets.
+        let mut prover_challenger = fresh_challenger();
+        let mut prover =
+            OpeningProverTranscript::<Ch, F, EF>::new(&mut prover_challenger, shape.clone());
+        let prover_r_comb = prover.combination_challenge(0);
+        assert!(prover.combination_challenge(1).is_none());
+        prover.delegate(|_| ());
+        let prover_lanes: Vec<Vec<usize>> = (0..2).map(|b| prover.lanes(b)).collect();
+        prover.finish();
+
+        // Verifier side: the same calls, in the same order.
+        let mut verifier_challenger = fresh_challenger();
+        let mut verifier =
+            OpeningVerifierTranscript::<Ch, F, EF>::new(&mut verifier_challenger, shape);
+        let verifier_r_comb = verifier.combination_challenge(0);
+        assert!(verifier.combination_challenge(1).is_none());
+        verifier.delegate(|_| ());
+        let verifier_lanes: Vec<Vec<usize>> = (0..2).map(|b| verifier.lanes(b)).collect();
+        verifier.finish();
+
+        // Every drawn value agrees across the two sides.
+        assert_eq!(prover_r_comb, verifier_r_comb);
+        assert_eq!(prover_lanes, verifier_lanes);
+
+        // Lane widths follow the described arity.
+        //
+        // Each index stays inside its fiber.
+        assert!(prover_lanes.iter().flatten().all(|&lane| lane < 4));
+
+        // Both sponges land on the same state.
+        let prover_next: F = prover_challenger.sample();
+        let verifier_next: F = verifier_challenger.sample();
+        assert_eq!(prover_next, verifier_next);
+    }
+
+    #[test]
+    fn a_rejected_delegation_leaves_the_bucket_transcript_droppable() {
+        // Invariant: a sub-protocol that rejects must not turn into a drop-time panic.
+        //
+        // Fixture state: one bucket, whose delegation returns a rejection.
+        //
+        //     combine  ->  delegate (rejects)  ->  abort  ->  drop
+        //
+        // Without the release, dropping a half-played driver panics on top of the error.
+        let shape = StirPcsOpeningShape::new(vec![bucket(vec![8, 6])]);
+
+        let mut challenger = fresh_challenger();
+        let mut transcript = OpeningVerifierTranscript::<Ch, F, EF>::new(&mut challenger, shape);
+        let _r_comb = transcript.combination_challenge(0);
+
+        // Mutation: the delegated run reports a failure instead of an output.
+        let outcome: Result<(), ()> = transcript.delegate(|_| Err(()));
+        assert!(outcome.is_err());
+
+        // Releasing the completeness check is what keeps the rejection the only failure.
+        transcript.abort();
+        drop(transcript);
+    }
+}

--- a/stir/src/utils.rs
+++ b/stir/src/utils.rs
@@ -8,7 +8,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-use p3_challenger::FieldChallenger;
 use p3_field::{
     ExtensionField, Field, PrimeCharacteristicRing, TwoAdicField, batch_multiplicative_inverse,
 };
@@ -358,42 +357,6 @@ impl<F: Field> OodFilter<F> {
         // Deduplicate OOD points.
         outside_all_domains && kept.iter().all(|&existing| existing != z)
     }
-}
-
-/// Sample `num_ood_samples` distinct out-of-domain points for a STIR round from the
-/// transcript.
-///
-/// `excluded_domains` gives the `(shift, log_size)` of the current, next, and fold-query
-/// domains for the round: each candidate is drawn until it lies outside all three cosets,
-/// so that it cannot collide with the interpolation nodes used elsewhere in the round.
-/// Prover and verifier both call this to derive identical points from identical
-/// transcript state.
-pub fn sample_ood_points<F, EF, Challenger>(
-    challenger: &mut Challenger,
-    excluded_domains: [(F, usize); 3],
-    num_ood_samples: usize,
-) -> Vec<EF>
-where
-    F: Field,
-    EF: ExtensionField<F>,
-    Challenger: FieldChallenger<F>,
-{
-    // Nothing to sample, and nothing to precompute for it: keeps the contract identical to
-    // evaluating the predicate lazily, which did no inversions at all in this case.
-    if num_ood_samples == 0 {
-        return Vec::new();
-    }
-
-    let filter = OodFilter::new(excluded_domains);
-
-    let mut ood_points: Vec<EF> = Vec::with_capacity(num_ood_samples);
-    while ood_points.len() < num_ood_samples {
-        let z: EF = challenger.sample_algebra_element();
-        if filter.accepts(&z, &ood_points) {
-            ood_points.push(z);
-        }
-    }
-    ood_points
 }
 
 /// Interpolate a polynomial through the given `(points, values)` pairs.
@@ -790,8 +753,7 @@ pub fn lagrange_interpolate_at<F: Field, EF: ExtensionField<F>>(
 
 #[cfg(test)]
 mod tests {
-    use p3_baby_bear::{BabyBear, Poseidon2BabyBear};
-    use p3_challenger::DuplexChallenger;
+    use p3_baby_bear::BabyBear;
     use p3_field::PrimeCharacteristicRing;
     use p3_field::extension::BinomialExtensionField;
     use proptest::prelude::*;
@@ -802,8 +764,6 @@ mod tests {
 
     type F = BabyBear;
     type EF = BinomialExtensionField<F, 4>;
-    type Perm = Poseidon2BabyBear<16>;
-    type TestChallenger = DuplexChallenger<F, Perm, 16, 8>;
 
     #[test]
     fn test_eval_poly_zero() {
@@ -869,47 +829,51 @@ mod tests {
         }
     }
 
-    #[test]
-    fn sample_ood_points_returns_nothing_for_zero_samples() {
-        let mut rng = SmallRng::seed_from_u64(3);
-        let perm = Perm::new_from_rng_128(&mut rng);
-        let mut challenger = TestChallenger::new(perm);
-        let excluded = [(F::GENERATOR, 4), (F::GENERATOR, 3), (F::GENERATOR, 2)];
-        let points: Vec<EF> = sample_ood_points(&mut challenger, excluded, 0);
-        assert!(points.is_empty());
-    }
-
     proptest! {
         #![proptest_config(ProptestConfig::with_cases(32))]
 
-        /// The hoisted `shift^{-2^log_size}` and the shared squaring chain must compose back
-        /// into `(z / shift)^{2^log_size}`. The oracle is the original three-line predicate,
-        /// evaluated independently below; `log_sizes` are drawn freely so that equal sizes, a
-        /// zero size, and the maximum sitting at each of the three positions all occur.
         #[test]
-        fn sample_ood_points_avoids_every_excluded_domain(
+        fn the_out_of_domain_filter_matches_the_predicate_it_hoists(
             log_sizes in prop::collection::vec(0usize..=8, 3..=3),
             shift_seeds in prop::collection::vec(1u64..(1 << 20), 3..=3),
-            num_ood_samples in 1usize..=3,
-            seed: u64,
+            candidate_seeds in prop::collection::vec(1u64..(1 << 24), 1..=4),
         ) {
-            let mut rng = SmallRng::seed_from_u64(seed);
-            let perm = Perm::new_from_rng_128(&mut rng);
-            let mut challenger = TestChallenger::new(perm);
-
+            // Invariant: the filter agrees with the predicate it hoists.
+            //
+            //     hoisted:  z^(2^l) * shift^(-2^l)  ==  1
+            //     plain  :  (z / shift)^(2^l)       ==  1
+            //
+            // Fixture state: three excluded domains, drawn freely.
+            //
+            // So equal sizes, a zero size, and the maximum at each position all occur.
             let excluded: [(F, usize); 3] =
                 core::array::from_fn(|i| (F::from_u64(shift_seeds[i]), log_sizes[i]));
+            let filter = OodFilter::new(excluded);
 
-            let points: Vec<EF> = sample_ood_points(&mut challenger, excluded, num_ood_samples);
-            prop_assert_eq!(points.len(), num_ood_samples);
+            // Points already kept, grown one candidate at a time.
+            //
+            // So the dedup half meets a non-empty set as well as an empty one.
+            let mut kept: Vec<EF> = Vec::new();
 
-            for (i, &z) in points.iter().enumerate() {
-                for &(shift, log_size) in &excluded {
-                    let outside = (z * EF::from(shift).inverse()).exp_power_of_2(log_size)
-                        != EF::ONE;
-                    prop_assert!(log_size == 0 || outside);
+            for &seed in &candidate_seeds {
+                let candidate = EF::from(F::from_u64(seed));
+
+                // Reference: a candidate is admissible when it misses every coset.
+                //
+                // It must also repeat no point already kept.
+                let outside_all = excluded.iter().all(|&(shift, log_size)| {
+                    log_size == 0
+                        || (candidate * EF::from(shift).inverse()).exp_power_of_2(log_size)
+                            != EF::ONE
+                });
+                let expected = outside_all && !kept.contains(&candidate);
+
+                prop_assert_eq!(filter.accepts(&candidate, &kept), expected);
+
+                // Keeping the admissible ones mirrors what a rejection sampler does.
+                if expected {
+                    kept.push(candidate);
                 }
-                prop_assert!(!points[..i].contains(&z));
             }
         }
     }

--- a/stir/tests/stir.rs
+++ b/stir/tests/stir.rs
@@ -1655,6 +1655,49 @@ mod babybear_pcs {
         commit
     }
 
+    proptest::proptest! {
+        #![proptest_config(proptest::prelude::ProptestConfig::with_cases(8))]
+
+        #[test]
+        fn test_pcs_round_trips_over_random_layouts(
+            max_log_height_spread in 0usize..=4,
+            log_degrees in proptest::collection::vec(
+                LOG_STARTING_FOLDING_FACTOR..=6usize,
+                1..=4,
+            ),
+            widths in proptest::collection::vec(1usize..=4, 1..=4),
+        ) {
+            // Invariant: an honest opening verifies whatever layout the claims imply.
+            //
+            // That layout describes the transcript of the commitment scheme entirely.
+            //
+            // A failure here is the two sides disagreeing on the description itself.
+            //
+            // No proof-shape check could catch that.
+            //
+            // Fixture state: 1 to 4 matrices, log-height 2 to 6, width 1 to 4.
+            //
+            // The spread cap ranges over 0 to 4.
+            //
+            //     spread 0        -> one bucket per distinct height, nothing merged
+            //     spread >= range -> one bucket, every height merged into it
+            //
+            // Both ends and the mixed middle move the bucket count.
+            //
+            // They move the merged-class count and every claimed width too.
+            //
+            // So they move the description the two sides have to agree on.
+            let widths: Vec<usize> = log_degrees
+                .iter()
+                .enumerate()
+                .map(|(i, _)| widths[i % widths.len()])
+                .collect();
+
+            let (pcs, challenger_template) = get_pcs_with_spread(max_log_height_spread);
+            round_trip_under(&pcs, &challenger_template, &log_degrees, &widths);
+        }
+    }
+
     #[test]
     fn test_pcs_round_trips_at_every_spread() {
         // The same claim must verify whichever layout the spread cap produces: one STIR
@@ -3035,8 +3078,8 @@ mod babybear_pcs {
             ProofShapeError::InputOpenedRowCount {
                 log_height: log_d + 1,
                 commitment: 0,
-                expected: 18,
-                got: 17,
+                expected: 20,
+                got: 19,
             }
         );
     }
@@ -3137,14 +3180,41 @@ mod babybear_pcs {
         // there is only one and skips it entirely.
         let err = verify_with_claimed_degrees(&[8, 6], &[8, 8])
             .expect_err("an overstated native height must be rejected");
-        assert_eq!(
-            shape_of(err),
+        // One class rather than two gives a smaller first-round query count.
+        //
+        // So the point set an answer polynomial may interpolate is smaller too.
+        //
+        //     verifier accepts at most  2 OOD points + 21 queries = 23 coefficients
+        //     the proof carries         2 OOD points + 22 queries = 24 coefficients
+        //
+        // Two of STIR's shape checks can catch this, and both are correct.
+        //
+        //     query openings     one opening per distinct queried position
+        //     answer polynomial  one coefficient per interpolated point
+        //
+        // Which one trips first depends on how many of the drawn positions coincided.
+        //
+        // That is a property of the challenge stream, not of the mutation.
+        //
+        // So the assertion pins what the mutation controls, not which check won the race.
+        //
+        // In both readings the proof carries exactly one item too many, at round 0.
+        match shape_of(err) {
             ProofShapeError::QueryOpeningCount {
-                round: RoundLabel::Round(0),
-                expected: 21,
-                got: 22,
+                round,
+                expected,
+                got,
             }
-        );
+            | ProofShapeError::AnsPolynomialTooLong {
+                round,
+                maximum: expected,
+                got,
+            } => {
+                assert_eq!(round, RoundLabel::Round(0));
+                assert_eq!(got, expected + 1);
+            }
+            other => panic!("expected a round-0 shape rejection, got {other:?}"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
> Stacked on #2122, which is stacked on #2121. Review bottom-up; this PR's diff is against #2122.

## What was left behind

#2088 migrated STIR's core prover and verifier. The migration plan's entry for that work listed `stir/src/{prover,verifier,pcs}.rs`, and the PCS layer never followed. It still absorbed and drew straight off the sponge:

- the commitment absorb, which sent the root count through as a **field element value** rather than as a step count — a length travelling as data, which is the R1 smell
- an extension-slice absorb of interpolated values buried three iterator levels deep
- an extension-slice absorb of opened values inside nested per-point iteration
- two bare combination-challenge draws
- a lane sampler reached by handing the sponge to a helper

That last one was not in the inventory I first handed the agent. Grepping for `challenger.observe*`-style method calls misses every helper that takes the sponge as an argument, and the lane draw produces the query positions for a whole bucket. The inventory was rebuilt from scratch as a result.

## The design decision: containers, not a flat sequence

The claim absorbs sit inside nested per-commitment and per-matrix iteration whose order was previously kept in step by eye across the two sides. They are now expressed as pattern containers, one begin/end per level, with fixed-width leaf steps per opening point.

This is deliberately **not** what FRI does. FRI flattens the widths and binds the grouping through the separator's instance label. Containers put the grouping in the *pattern fingerprint* instead, which is the artefact both sides compute from configuration and compare.

The difference is proven rather than asserted. One test takes three groupings that all flatten to the same widths `3, 3`:

```text
    one matrix, two points    Begin c  Begin m  3  3  End  End
    two matrices, one point   Begin c  Begin m  3  End  Begin m  3  End  End
    two commitments           Begin c  Begin m  3  End  End  Begin c  ...
```

It shows the three nested fingerprints are pairwise distinct, then strips the container markers and shows the three flat fingerprints are **identical**. Comparing fingerprints rather than seeds is the point: a seed would also move if a label carried the grouping, so only the fingerprint comparison isolates what the containers contribute.

The same reasoning applies to the bucket phase. Every bucket opens a merging block whether or not it draws inside it, so the block sequence itself says where one bucket stops.

## Where every length comes from (R1)

- root count: from the commitment being absorbed, as the step count
- claim widths: from the prover's matrices, and from the verifier's own claims
- bucket layout: from the claimed heights
- lane geometry: from each bucket's own schedule — the round-0 query count, or the final query count for a zero-round schedule

No `.len()` on proof data feeds a pattern step.

## Restructuring this required

The opening preparation now hands back unmerged reduced openings plus the per-bucket native heights, and the bucket phase draws its own merging challenges, so the whole phase sits under one driver rather than one per bucket. The combined-codeword helper takes an optional challenge instead of a sponge. The verifier aborts its driver before returning a proximity-test rejection, so no drop-time panic lands on top of an error already in flight.

## A dead sampler removed, without losing its coverage

The public out-of-domain point sampler is superseded by the typed method using the layer's rejection-sampling primitive, and is deleted. Its proptest was actually exercising a live squaring-chain optimisation in the point filter, so that coverage was rewritten as a specialisation-versus-reference property on the filter rather than dropped with the function.

## Two integration expectations moved

Both are consequences of the changed challenge stream, and both are worth a reviewer's eye.

**Truncated openings**: the opened-row count went 19/18 → 20/19. The count is the number of **distinct** query positions; the query count itself is configuration and unchanged.

**Overstated native height**: this one flipped which shape check catches it, twice, across the two STIR PRs in this stack. Two checks can catch it and both are correct — the query-opening count and the answer-polynomial length — and which trips first depends on how many drawn positions coincided. That is a property of the challenge stream, not of the mutation.

Rather than pin one variant and re-pin it on every future transcript change, the assertion now matches either check and asserts what the mutation actually controls: a round-0 shape rejection carrying exactly one item too many. That is strictly more meaningful than a magic number, and it does not weaken the test — the round and the off-by-exactly-one are both still pinned.

## Verification

| Command | Result |
| --- | --- |
| `cargo test -p p3-stir` | 120 + 109 + 28 passed, 0 failed |
| `cargo check --workspace --all-targets` | clean |
| `cargo clippy -p p3-stir --all-targets -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

Re-run after rebasing onto #2122.

## Raw sponge sites remaining in this scope: 0

Every surviving mention hands the sponge to a typed component: one of the three new phases, the batching phase, or the STIR core inside its bracket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)